### PR TITLE
Comply with the specification

### DIFF
--- a/src/include/messages.h
+++ b/src/include/messages.h
@@ -9,16 +9,18 @@
 namespace mls {
 
 // struct {
-//     CipherSuite cipher_suites<0..255>; // OMITTED
-//     DHPublicKey init_keys<1..2^16-1>;  // ONLY ONE
+//     CipherSuite cipher_suites<0..255>; // ignored
+//     DHPublicKey init_keys<1..2^16-1>;  // only use first
 //     SignaturePublicKey identity_key;
-//     SignatureScheme algorithm;         // OMITTED
+//     SignatureScheme algorithm;         // always 0
 //     tls::opaque signature<0..2^16-1>;
 // } UserInitKey;
 struct UserInitKey
 {
-  DHPublicKey init_key;
+  tls::vector<uint16_t, 1> cipher_suites;
+  tls::vector<DHPublicKey, 2> init_keys;
   SignaturePublicKey identity_key;
+  uint16_t algorithm = 0;
   tls::opaque<2> signature;
 
   void sign(const SignaturePrivateKey& identity_priv);

--- a/src/include/messages.h
+++ b/src/include/messages.h
@@ -39,7 +39,7 @@ operator>>(tls::istream& in, UserInitKey& obj);
 //     uint64 epoch;
 //     uint32 group_size;
 //     tls::opaque group_id<0..2^16-1>;
-//     CipherSuite cipher_suite;                // OMITTED
+//     CipherSuite cipher_suite;                // ignored
 //     DHPublicKey add_key;
 //     MerkleNode identity_frontier<0..2^16-1>;
 //     DHPublicKey ratchet_frontier<0..2^16-1>;
@@ -49,6 +49,7 @@ struct GroupInitKey
   epoch_t epoch;
   uint32_t group_size;
   tls::opaque<2> group_id;
+  uint16_t cipher_suite;
   DHPublicKey add_key;
   tls::vector<MerkleNode, 2> identity_frontier;
   tls::vector<RatchetNode, 2> ratchet_frontier;

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -24,14 +24,15 @@ bytes
 UserInitKey::to_be_signed() const
 {
   tls::ostream out;
-  out << init_key << identity_key;
+  out << cipher_suites << init_keys << identity_key << algorithm;
   return out.bytes();
 }
 
 bool
 operator==(const UserInitKey& lhs, const UserInitKey& rhs)
 {
-  return (lhs.init_key == rhs.init_key) &&
+  return (lhs.cipher_suites == rhs.cipher_suites) &&
+         (lhs.init_keys == rhs.init_keys) &&
          (lhs.identity_key == rhs.identity_key) &&
          (lhs.signature == rhs.signature);
 }
@@ -39,13 +40,15 @@ operator==(const UserInitKey& lhs, const UserInitKey& rhs)
 tls::ostream&
 operator<<(tls::ostream& out, const UserInitKey& obj)
 {
-  return out << obj.init_key << obj.identity_key << obj.signature;
+  return out << obj.cipher_suites << obj.init_keys << obj.identity_key
+             << obj.algorithm << obj.signature;
 }
 
 tls::istream&
 operator>>(tls::istream& in, UserInitKey& obj)
 {
-  return in >> obj.init_key >> obj.identity_key >> obj.signature;
+  return in >> obj.cipher_suites >> obj.init_keys >> obj.identity_key >>
+         obj.algorithm >> obj.signature;
 }
 
 // GroupInitKey

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -64,6 +64,7 @@ bool
 operator==(const GroupInitKey& lhs, const GroupInitKey& rhs)
 {
   return (lhs.epoch == rhs.epoch) && (lhs.group_size == rhs.group_size) &&
+         (lhs.cipher_suite == rhs.cipher_suite) &&
          (lhs.group_id == rhs.group_id) && (lhs.add_key == rhs.add_key) &&
          (lhs.identity_frontier == rhs.identity_frontier) &&
          (lhs.ratchet_frontier == rhs.ratchet_frontier);
@@ -72,15 +73,16 @@ operator==(const GroupInitKey& lhs, const GroupInitKey& rhs)
 tls::ostream&
 operator<<(tls::ostream& out, const GroupInitKey& obj)
 {
-  return out << obj.epoch << obj.group_size << obj.group_id << obj.add_key
-             << obj.identity_frontier << obj.ratchet_frontier;
+  return out << obj.epoch << obj.group_size << obj.group_id << obj.cipher_suite
+             << obj.add_key << obj.identity_frontier << obj.ratchet_frontier;
 }
 
 tls::istream&
 operator>>(tls::istream& in, GroupInitKey& obj)
 {
-  return in >> obj.epoch >> obj.group_size >> obj.group_id >> obj.add_key >>
-         obj.identity_frontier >> obj.ratchet_frontier;
+  return in >> obj.epoch >> obj.group_size >> obj.group_id >>
+         obj.cipher_suite >> obj.add_key >> obj.identity_frontier >>
+         obj.ratchet_frontier;
 }
 
 // HandshakeType

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -153,7 +153,10 @@ Session::handle(const bytes& handshake)
 void
 Session::make_init_key()
 {
-  auto user_init_key = UserInitKey{ _init_priv.public_key() };
+  auto user_init_key = UserInitKey{
+    {},                         // No cipher suites
+    { _init_priv.public_key() } // One init key
+  };
   user_init_key.sign(_identity_priv);
   _user_init_key = tls::marshal(user_init_key);
 }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -39,8 +39,10 @@ State::State(const SignaturePrivateKey& identity_priv,
     throw InvalidParameterError("Group add is not from a member of the group");
   }
 
+  // XXX(rlb@ipv.sx): Assuming exactly one init key, of the same
+  // algorithm.  Should do algorithm negotiation.
+  auto init_key = group_add.message.user_init_key.init_keys[0];
   auto identity_key = group_add.message.user_init_key.identity_key;
-  auto init_key = group_add.message.user_init_key.init_key;
   if ((identity_key != identity_priv.public_key()) ||
       (init_key != init_priv.public_key())) {
     throw InvalidParameterError("Group add not targeted for this node");
@@ -172,7 +174,8 @@ State::handle(const Handshake<GroupAdd>& group_add) const
   auto next = spawn(group_add.epoch());
 
   // Add the new leaf to the ratchet tree
-  auto init_key = group_add.message.user_init_key.init_key;
+  // XXX(rlb@ipv.sx): Assumes only one initkey
+  auto init_key = group_add.message.user_init_key.init_keys[0];
   auto identity_key = group_add.message.user_init_key.identity_key;
 
   auto leaf_data = _add_priv.derive(init_key);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -449,6 +449,7 @@ State::group_init_key() const
   return GroupInitKey{ _epoch,
                        uint32_t(_identity_tree.size()),
                        _group_id,
+                       0x0000, // ciphersuite, ignored
                        _add_priv.public_key(),
                        _identity_tree.frontier(),
                        _ratchet_tree.frontier() };

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -32,6 +32,7 @@ TEST_CASE("Basic message serialization", "[messages]")
   GroupInitKey group_init_key{ epoch_val,
                                3,
                                { 0x03, 0x03, 0x03, 0x03 },
+                               0x0000,
                                dh_pub,
                                { merkle, merkle },
                                { ratchet, ratchet } };
@@ -86,6 +87,7 @@ TEST_CASE("Handshake serialization", "[messages]")
   GroupInitKey group_init_key{ epoch_val,
                                3,
                                { 0x03, 0x03, 0x03, 0x03 },
+                               0x0000,
                                dh_pub,
                                { merkle, merkle },
                                { ratchet, ratchet } };

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -23,7 +23,10 @@ TEST_CASE("Basic message serialization", "[messages]")
   auto dh_pub = DHPrivateKey::generate().public_key();
   RatchetNode ratchet(dh_pub);
 
-  UserInitKey user_init_key{ DHPrivateKey::generate().public_key() };
+  UserInitKey user_init_key{
+    {},                                       // No ciphersuites
+    { DHPrivateKey::generate().public_key() } // Only one init key
+  };
   user_init_key.sign(identity_priv);
 
   GroupInitKey group_init_key{ epoch_val,
@@ -77,7 +80,7 @@ TEST_CASE("Handshake serialization", "[messages]")
   std::vector<MerkleNode> copath = { merkle, merkle };
   auto root = ((merkle + merkle) + merkle).value();
 
-  UserInitKey user_init_key{ DHPrivateKey::generate().public_key() };
+  UserInitKey user_init_key{ {}, { DHPrivateKey::generate().public_key() } };
   user_init_key.sign(identity_priv);
 
   GroupInitKey group_init_key{ epoch_val,

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -26,7 +26,7 @@ TEST_CASE("Group creation", "[state]")
     identity_privs.emplace(idp + i, SignaturePrivateKey::generate());
     auto init_priv = DHPrivateKey::generate();
     user_init_keys.emplace(uik + i);
-    user_init_keys[i].init_key = init_priv.public_key();
+    user_init_keys[i].init_keys = { init_priv.public_key() };
     user_init_keys[i].sign(identity_privs[i]);
     init_privs.emplace(inp + i, init_priv);
   }


### PR DESCRIPTION
This PR adds fields to the `UserInitKey` and `GroupInitKey` structs that had been omitted / simplified because we're not doing ciphersuite negotiation right now.