### PR TITLE
Run-time crypto agility

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -10,7 +10,6 @@
 #include "openssl/sha.h"
 #include "state.h"
 
-#include <iostream>
 #include <string>
 
 namespace mls {
@@ -81,7 +80,6 @@ ossl_key_type(CipherSuite suite)
       return OpenSSLKeyType::X25519;
   }
 
-  printf("unknown ciphersuite: %04x\n", static_cast<uint16_t>(suite));
   throw InvalidParameterError("Unknown ciphersuite");
 }
 
@@ -851,9 +849,6 @@ operator>>(tls::istream& in, PublicKey& obj)
 {
   tls::opaque<2> data;
   in >> data;
-
-  std::cout << ">>public: " << data.size() << " " << data << std::endl;
-
   obj.reset(data);
   return in;
 }

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -3,7 +3,6 @@
 #include <array>
 #include <experimental/optional>
 #include <iomanip>
-#include <iostream>
 #include <sstream>
 #include <stdexcept>
 #include <vector>

--- a/src/include/crypto.h
+++ b/src/include/crypto.h
@@ -17,6 +17,20 @@ enum struct CipherSuite : uint16_t
   X25519_SHA256_AES128GCM = 0x0001
 };
 
+// Utility class to avoid a bit of boilerplate
+class CipherAware
+{
+public:
+  CipherAware(CipherSuite suite)
+    : _suite(suite)
+  {}
+
+  CipherSuite cipher_suite() const { return _suite; }
+
+protected:
+  CipherSuite _suite;
+};
+
 // XXX
 #define DH_DEFAULT CipherSuite::P256_SHA256_AES128GCM
 
@@ -197,23 +211,24 @@ protected:
 // DH specialization
 struct ECIESCiphertext;
 
-class DHPublicKey : public PublicKey
+class DHPublicKey
+  : public PublicKey
+  , public CipherAware
 {
 public:
   DHPublicKey(CipherSuite suite);
   DHPublicKey(CipherSuite suite, const bytes& data);
 
   ECIESCiphertext encrypt(const bytes& plaintext) const;
-  CipherSuite cipher_suite() const;
 
 private:
-  CipherSuite _suite;
-
   DHPublicKey(CipherSuite suite, OpenSSLKey* key);
   friend class DHPrivateKey;
 };
 
-class DHPrivateKey : public PrivateKey
+class DHPrivateKey
+  : public PrivateKey
+  , public CipherAware
 {
 public:
   using PrivateKey::PrivateKey;
@@ -225,11 +240,8 @@ public:
   bytes decrypt(const ECIESCiphertext& ciphertext) const;
 
   const DHPublicKey& public_key() const;
-  CipherSuite cipher_suite() const;
 
 private:
-  CipherSuite _suite;
-
   DHPrivateKey(CipherSuite suite, OpenSSLKey* key);
 };
 

--- a/src/include/crypto.h
+++ b/src/include/crypto.h
@@ -31,9 +31,6 @@ protected:
   CipherSuite _suite;
 };
 
-// XXX
-#define DH_DEFAULT CipherSuite::P256_SHA256_AES128GCM
-
 tls::ostream&
 operator<<(tls::ostream& out, const CipherSuite& obj);
 tls::istream&
@@ -44,9 +41,6 @@ enum struct SignatureScheme : uint16_t
   P256_SHA256 = 0x0000,
   Ed25519_SHA256 = 0x0001
 };
-
-// XXX
-#define SIG_DEFAULT SignatureScheme::P256_SHA256
 
 tls::ostream&
 operator<<(tls::ostream& out, const SignatureScheme& obj);

--- a/src/include/messages.h
+++ b/src/include/messages.h
@@ -11,16 +11,16 @@ namespace mls {
 // struct {
 //     CipherSuite cipher_suites<0..255>; // ignored
 //     DHPublicKey init_keys<1..2^16-1>;  // only use first
-//     SignaturePublicKey identity_key;
 //     SignatureScheme algorithm;
+//     SignaturePublicKey identity_key;
 //     tls::opaque signature<0..2^16-1>;
 // } UserInitKey;
 struct UserInitKey
 {
-  tls::vector<uint16_t, 1> cipher_suites;
+  tls::vector<CipherSuite, 1> cipher_suites;
   tls::variant_vector<DHPublicKey, CipherSuite, 2> init_keys;
-  SignaturePublicKey identity_key;
   SignatureScheme algorithm;
+  SignaturePublicKey identity_key;
   tls::opaque<2> signature;
 
   // XXX(rlb@ipv.sx): This is kind of inelegant, but we need a dummy
@@ -31,6 +31,7 @@ struct UserInitKey
     : identity_key(SignatureScheme::P256_SHA256)
   {}
 
+  void add_init_key(const DHPublicKey& pub);
   void sign(const SignaturePrivateKey& identity_priv);
   bool verify() const;
   bytes to_be_signed() const;
@@ -116,11 +117,22 @@ operator>>(tls::istream& in, GroupOperationType& obj);
 //     DirectPath path<1..2^16-1>;
 //     UserInitKey init_key;
 // } Add;
-struct Add
+struct Add : public CipherAware
 {
 public:
   RatchetPath path;
   UserInitKey init_key;
+
+  Add(CipherSuite suite)
+    : CipherAware(suite)
+    , path(suite)
+  {}
+
+  Add(const RatchetPath& path, const UserInitKey& init_key)
+    : CipherAware(path)
+    , path(path)
+    , init_key(init_key)
+  {}
 
   static const GroupOperationType type;
 };
@@ -135,10 +147,20 @@ operator>>(tls::istream& in, Add& obj);
 // struct {
 //     DHPublicKey path<1..2^16-1>;
 // } Update;
-struct Update
+struct Update : public CipherAware
 {
 public:
   RatchetPath path;
+
+  Update(CipherSuite suite)
+    : CipherAware(suite)
+    , path(suite)
+  {}
+
+  Update(const RatchetPath& path)
+    : CipherAware(path)
+    , path(path)
+  {}
 
   static const GroupOperationType type;
 };
@@ -154,11 +176,22 @@ operator>>(tls::istream& in, Update& obj);
 //     uint32 removed;
 //     DHPublicKey path<1..2^16-1>;
 // } Remove;
-struct Remove
+struct Remove : public CipherAware
 {
 public:
   uint32_t removed;
   RatchetPath path;
+
+  Remove(CipherSuite suite)
+    : CipherAware(suite)
+    , path(suite)
+  {}
+
+  Remove(uint32_t removed, const RatchetPath& path)
+    : CipherAware(path)
+    , removed(removed)
+    , path(path)
+  {}
 
   static const GroupOperationType type;
 };
@@ -186,7 +219,7 @@ operator>>(tls::istream& in, Remove& obj);
 // members will be populated with a non-zero value.  This is a bit
 // wasteful of memory, but necessary to avoid the silliness of C++
 // union types over structs.
-struct GroupOperation
+struct GroupOperation : public CipherAware
 {
   GroupOperationType type;
 
@@ -194,43 +227,45 @@ struct GroupOperation
   Update update;
   Remove remove;
 
-  GroupOperation() {}
+  // XXX
+  GroupOperation()
+    : CipherAware(CipherSuite::P256_SHA256_AES128GCM)
+    , add(CipherSuite::P256_SHA256_AES128GCM)
+    , update(CipherSuite::P256_SHA256_AES128GCM)
+    , remove(CipherSuite::P256_SHA256_AES128GCM)
+  {}
+
+  GroupOperation(CipherSuite suite)
+    : CipherAware(suite)
+    , add(suite)
+    , update(suite)
+    , remove(suite)
+  {}
 
   GroupOperation(const Add& add)
-    : type(add.type)
+    : CipherAware(add)
+    , type(add.type)
     , add(add)
+    , update(add.cipher_suite())
+    , remove(add.cipher_suite())
   {}
 
   GroupOperation(const Update& update)
-    : type(update.type)
+    : CipherAware(update)
+    , type(update.type)
+    , add(update.cipher_suite())
     , update(update)
+    , remove(update.cipher_suite())
+
   {}
 
   GroupOperation(const Remove& remove)
-    : type(remove.type)
+    : CipherAware(remove)
+    , type(remove.type)
+    , add(remove.cipher_suite())
+    , update(remove.cipher_suite())
     , remove(remove)
   {}
-
-  // XXX(rlb@ipv.sx): It doesn't seem like this special copy ctor
-  // should be necessary, but there seems to be a problem with
-  // copying an empty Add structure.  It somehow creates an NPE.
-  // This should probably be cleaned up with some checks that all
-  // the crypto functions are null-safe.
-  GroupOperation(const GroupOperation& other)
-    : type(other.type)
-  {
-    switch (type) {
-      case GroupOperationType::add:
-        add = other.add;
-        break;
-      case GroupOperationType::update:
-        update = other.update;
-        break;
-      case GroupOperationType::remove:
-        remove = other.remove;
-        break;
-    }
-  }
 };
 
 bool
@@ -248,7 +283,7 @@ operator>>(tls::istream& in, GroupOperation& obj);
 //     SignatureScheme algorithm;
 //     opaque signature<1..2^16-1>;
 // } Handshake;
-struct Handshake
+struct Handshake : public CipherAware
 {
   epoch_t prior_epoch;
   GroupOperation operation;
@@ -258,13 +293,17 @@ struct Handshake
 
   epoch_t epoch() const { return prior_epoch + 1; }
 
-  Handshake() {}
+  Handshake(CipherSuite suite)
+    : CipherAware(suite)
+    , operation(suite)
+  {}
 
   Handshake(epoch_t prior_epoch,
             const GroupOperation& operation,
             uint32_t signer_index,
             bytes signature)
-    : prior_epoch(prior_epoch)
+    : CipherAware(operation)
+    , prior_epoch(prior_epoch)
     , operation(operation)
     , signer_index(signer_index)
     , signature(signature)

--- a/src/include/ratchet_tree.h
+++ b/src/include/ratchet_tree.h
@@ -10,7 +10,7 @@ namespace mls {
 class RatchetNode
 {
 public:
-  RatchetNode() = default;
+  RatchetNode(CipherSuite suite);
   RatchetNode(const RatchetNode& other);
   RatchetNode& operator=(const RatchetNode& other);
 
@@ -26,6 +26,7 @@ public:
   void merge(const RatchetNode& other);
 
 private:
+  CipherSuite _suite;
   optional<bytes> _secret;
   optional<DHPrivateKey> _priv;
   DHPublicKey _pub;
@@ -40,8 +41,8 @@ private:
 
 struct RatchetPath
 {
-  tls::vector<RatchetNode, 3> nodes;
-  tls::vector<ECIESCiphertext, 3> node_secrets;
+  tls::variant_vector<RatchetNode, CipherSuite, 3> nodes;
+  tls::variant_vector<ECIESCiphertext, CipherSuite, 3> node_secrets;
 
   friend bool operator==(const RatchetPath& lhs, const RatchetPath& rhs);
   friend std::ostream& operator<<(std::ostream& out, const RatchetPath& obj);
@@ -52,9 +53,9 @@ struct RatchetPath
 class RatchetTree
 {
 public:
-  RatchetTree();
-  RatchetTree(const bytes& secret);
-  RatchetTree(const std::vector<bytes>& secrets);
+  RatchetTree(CipherSuite suite);
+  RatchetTree(CipherSuite suite, const bytes& secret);
+  RatchetTree(CipherSuite suite, const std::vector<bytes>& secrets);
 
   RatchetPath encrypt(uint32_t from, const bytes& leaf) const;
   bytes decrypt(uint32_t from, RatchetPath& path) const;
@@ -66,7 +67,7 @@ public:
   bytes root_secret() const;
 
 private:
-  tls::vector<RatchetNode, 3> _nodes;
+  tls::variant_vector<RatchetNode, CipherSuite, 3> _nodes;
   CipherSuite _suite;
 
   RatchetNode new_node(const bytes& data) const;

--- a/src/include/ratchet_tree.h
+++ b/src/include/ratchet_tree.h
@@ -14,7 +14,7 @@ public:
   RatchetNode(const RatchetNode& other);
   RatchetNode& operator=(const RatchetNode& other);
 
-  RatchetNode(const bytes& secret);
+  RatchetNode(CipherSuite suite, const bytes& secret);
   RatchetNode(const DHPrivateKey& priv);
   RatchetNode(const DHPublicKey& pub);
 
@@ -66,9 +66,10 @@ public:
   bytes root_secret() const;
 
 private:
-  // TODO(rlb@ipv.sx) prefid with _
   tls::vector<RatchetNode, 3> _nodes;
+  CipherSuite _suite;
 
+  RatchetNode new_node(const bytes& data) const;
   uint32_t working_size(uint32_t from) const;
 
   friend bool operator==(const RatchetTree& lhs, const RatchetTree& rhs);

--- a/src/include/ratchet_tree.h
+++ b/src/include/ratchet_tree.h
@@ -7,7 +7,7 @@
 
 namespace mls {
 
-class RatchetNode
+class RatchetNode : public CipherAware
 {
 public:
   RatchetNode(CipherSuite suite);
@@ -26,7 +26,6 @@ public:
   void merge(const RatchetNode& other);
 
 private:
-  CipherSuite _suite;
   optional<bytes> _secret;
   optional<DHPrivateKey> _priv;
   DHPublicKey _pub;
@@ -39,10 +38,16 @@ private:
   friend tls::istream& operator>>(tls::istream& in, RatchetNode& obj);
 };
 
-struct RatchetPath
+struct RatchetPath : public CipherAware
 {
   tls::variant_vector<RatchetNode, CipherSuite, 3> nodes;
   tls::variant_vector<ECIESCiphertext, CipherSuite, 3> node_secrets;
+
+  RatchetPath(CipherSuite suite)
+    : CipherAware(suite)
+    , nodes(suite)
+    , node_secrets(suite)
+  {}
 
   friend bool operator==(const RatchetPath& lhs, const RatchetPath& rhs);
   friend std::ostream& operator<<(std::ostream& out, const RatchetPath& obj);
@@ -50,7 +55,7 @@ struct RatchetPath
   friend tls::istream& operator>>(tls::istream& in, RatchetPath& obj);
 };
 
-class RatchetTree
+class RatchetTree : public CipherAware
 {
 public:
   RatchetTree(CipherSuite suite);
@@ -68,7 +73,6 @@ public:
 
 private:
   tls::variant_vector<RatchetNode, CipherSuite, 3> _nodes;
-  CipherSuite _suite;
 
   RatchetNode new_node(const bytes& data) const;
   uint32_t working_size(uint32_t from) const;

--- a/src/include/roster.h
+++ b/src/include/roster.h
@@ -10,7 +10,9 @@ namespace mls {
 class RawKeyCredential
 {
 public:
-  RawKeyCredential() {}
+  RawKeyCredential()
+    : _key(SIG_DEFAULT) // XXX
+  {}
 
   RawKeyCredential(const SignaturePublicKey& key)
     : _key(key)

--- a/src/include/roster.h
+++ b/src/include/roster.h
@@ -7,11 +7,13 @@
 
 namespace mls {
 
+#define DUMMY_SIG_SCHEME SignatureScheme::P256_SHA256
+
 class RawKeyCredential
 {
 public:
   RawKeyCredential()
-    : _key(SIG_DEFAULT) // XXX
+    : _key(DUMMY_SIG_SCHEME)
   {}
 
   RawKeyCredential(const SignaturePublicKey& key)

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -49,6 +49,7 @@ private:
   void add_state(epoch_t prior_epoch, const State& state);
   State& current_state();
   const State& current_state() const;
+  CipherSuite cipher_suite() const;
 };
 
 } // namespace mls

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -11,7 +11,9 @@ class Session
 {
 public:
   // Create a session joined to an empty group
-  Session(const bytes& group_id, const SignaturePrivateKey& identity_priv);
+  Session(const bytes& group_id,
+          CipherSuite suite,
+          const SignaturePrivateKey& identity_priv);
 
   // Create an unjoined session
   Session(const SignaturePrivateKey& identity_priv);

--- a/src/include/state.h
+++ b/src/include/state.h
@@ -15,12 +15,10 @@ public:
   /// Constructors
   ///
 
-  // Default constructor does not have a useful semantic.  It should
-  // only be used for constructing blank states, e.g., for unmarshal
-  State() = default;
-
   // Initialize an empty group
-  State(const bytes& group_id, const SignaturePrivateKey& identity_priv);
+  State(const bytes& group_id,
+        CipherSuite suite,
+        const SignaturePrivateKey& identity_priv);
 
   // Initialize a group from a Add (for group-initiated join)
   State(const SignaturePrivateKey& identity_priv,
@@ -66,10 +64,12 @@ public:
 
   epoch_t epoch() const { return _epoch; }
   uint32_t index() const { return _index; }
+  CipherSuite cipher_suite() const { return _suite; }
 
 private:
   // Shared confirmed state:
   tls::opaque<2> _group_id;
+  CipherSuite _suite;
   epoch_t _epoch;
   Roster _roster;
   RatchetTree _tree;

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -46,8 +46,10 @@ operator<<(tls::ostream& out, const UserInitKey& obj)
 tls::istream&
 operator>>(tls::istream& in, UserInitKey& obj)
 {
-  return in >> obj.cipher_suites >> obj.init_keys >> obj.identity_key >>
-         obj.algorithm >> obj.signature;
+  // XXX TODO decode init_keys and identity key according to algorithms
+  // return in >> obj.cipher_suites >> obj.init_keys >> obj.identity_key >>
+  //       obj.algorithm >> obj.signature;
+  return in;
 }
 
 // Welcome

--- a/src/ratchet_tree.cpp
+++ b/src/ratchet_tree.cpp
@@ -10,14 +10,14 @@ namespace mls {
 ///
 
 RatchetNode::RatchetNode(CipherSuite suite)
-  : _suite(suite)
+  : CipherAware(suite)
   , _secret(std::experimental::nullopt)
   , _priv(std::experimental::nullopt)
   , _pub(suite)
 {}
 
 RatchetNode::RatchetNode(const RatchetNode& other)
-  : _suite(other._suite)
+  : CipherAware(other)
   , _secret(other._secret)
   , _priv(other._priv)
   , _pub(other._pub)
@@ -34,7 +34,7 @@ RatchetNode::operator=(const RatchetNode& other)
 }
 
 RatchetNode::RatchetNode(CipherSuite suite, const bytes& secret)
-  : _suite(suite)
+  : CipherAware(suite)
   , _secret(secret)
   , _priv(DHPrivateKey::derive(suite, secret))
   , _pub(suite)
@@ -43,14 +43,14 @@ RatchetNode::RatchetNode(CipherSuite suite, const bytes& secret)
 }
 
 RatchetNode::RatchetNode(const DHPrivateKey& priv)
-  : _suite(priv.cipher_suite())
+  : CipherAware(priv.cipher_suite())
   , _secret(std::experimental::nullopt)
   , _priv(priv)
   , _pub(priv.public_key())
 {}
 
 RatchetNode::RatchetNode(const DHPublicKey& pub)
-  : _suite(pub.cipher_suite())
+  : CipherAware(pub.cipher_suite())
   , _secret(std::experimental::nullopt)
   , _priv(std::experimental::nullopt)
   , _pub(pub)
@@ -175,19 +175,19 @@ operator>>(tls::istream& in, RatchetPath& obj)
 ///
 
 RatchetTree::RatchetTree(CipherSuite suite)
-  : _suite(suite)
+  : CipherAware(suite)
   , _nodes(suite)
 {}
 
 RatchetTree::RatchetTree(CipherSuite suite, const bytes& secret)
-  : _suite(suite)
+  : CipherAware(suite)
   , _nodes(suite)
 {
   _nodes.emplace_back(_suite, secret);
 }
 
 RatchetTree::RatchetTree(CipherSuite suite, const std::vector<bytes>& secrets)
-  : _suite(suite)
+  : CipherAware(suite)
   , _nodes(suite)
 {
   uint32_t size = secrets.size();
@@ -239,7 +239,7 @@ RatchetTree::working_size(uint32_t from) const
 RatchetPath
 RatchetTree::encrypt(uint32_t from, const bytes& leaf_secret) const
 {
-  RatchetPath path;
+  RatchetPath path(_suite);
 
   const auto size = working_size(from);
   const auto root = tree_math::root(size);

--- a/src/ratchet_tree.cpp
+++ b/src/ratchet_tree.cpp
@@ -9,8 +9,16 @@ namespace mls {
 /// RatchetNode
 ///
 
+RatchetNode::RatchetNode(CipherSuite suite)
+  : _suite(suite)
+  , _secret(std::experimental::nullopt)
+  , _priv(std::experimental::nullopt)
+  , _pub(suite)
+{}
+
 RatchetNode::RatchetNode(const RatchetNode& other)
-  : _secret(other._secret)
+  : _suite(other._suite)
+  , _secret(other._secret)
   , _priv(other._priv)
   , _pub(other._pub)
 {}
@@ -18,6 +26,7 @@ RatchetNode::RatchetNode(const RatchetNode& other)
 RatchetNode&
 RatchetNode::operator=(const RatchetNode& other)
 {
+  _suite = other._suite;
   _secret = other._secret;
   _priv = other._priv;
   _pub = other._pub;
@@ -25,21 +34,24 @@ RatchetNode::operator=(const RatchetNode& other)
 }
 
 RatchetNode::RatchetNode(CipherSuite suite, const bytes& secret)
-  : _secret(secret)
-  , _priv(DHPrivateKey::derive(DH_DEFAULT, secret))
+  : _suite(suite)
+  , _secret(secret)
+  , _priv(DHPrivateKey::derive(suite, secret))
   , _pub(suite)
 {
   _pub = _priv->public_key();
 }
 
 RatchetNode::RatchetNode(const DHPrivateKey& priv)
-  : _secret(std::experimental::nullopt)
+  : _suite(priv.cipher_suite())
+  , _secret(std::experimental::nullopt)
   , _priv(priv)
   , _pub(priv.public_key())
 {}
 
 RatchetNode::RatchetNode(const DHPublicKey& pub)
-  : _secret(std::experimental::nullopt)
+  : _suite(pub.cipher_suite())
+  , _secret(std::experimental::nullopt)
   , _priv(std::experimental::nullopt)
   , _pub(pub)
 {}
@@ -162,18 +174,21 @@ operator>>(tls::istream& in, RatchetPath& obj)
 /// RatchetTree
 ///
 
-RatchetTree::RatchetTree()
-  : _nodes()
+RatchetTree::RatchetTree(CipherSuite suite)
+  : _suite(suite)
+  , _nodes(suite)
 {}
 
-RatchetTree::RatchetTree(const bytes& secret)
-  : _nodes(1)
+RatchetTree::RatchetTree(CipherSuite suite, const bytes& secret)
+  : _suite(suite)
+  , _nodes(suite)
 {
-  _nodes[0] = new_node(secret);
+  _nodes.emplace_back(_suite, secret);
 }
 
-RatchetTree::RatchetTree(const std::vector<bytes>& secrets)
-  : _nodes(tree_math::node_width(secrets.size()))
+RatchetTree::RatchetTree(CipherSuite suite, const std::vector<bytes>& secrets)
+  : _suite(suite)
+  , _nodes(suite)
 {
   uint32_t size = secrets.size();
   std::queue<uint32_t> to_update;
@@ -184,7 +199,10 @@ RatchetTree::RatchetTree(const std::vector<bytes>& secrets)
       to_update.push(parent);
     }
 
-    _nodes[curr] = new_node(secrets[i]);
+    _nodes.emplace_back(_suite, secrets[i]);
+    if (i < secrets.size() - 1) {
+      _nodes.emplace_back(_suite);
+    }
   }
 
   while (to_update.size() > 0) {
@@ -296,8 +314,8 @@ RatchetTree::merge(uint32_t from, const RatchetPath& path)
 
   auto curr = 2 * from;
   for (auto& node : path.nodes) {
-    if (curr > _nodes.size() - 1) {
-      _nodes.resize(curr + 1);
+    while (curr > _nodes.size() - 1) {
+      _nodes.emplace_back(_suite);
     }
 
     _nodes[curr].merge(node);
@@ -314,8 +332,8 @@ RatchetTree::set_leaf(uint32_t index, const bytes& leaf)
   auto curr = 2 * index;
   auto secret = leaf;
   while (curr != root) {
-    if (curr > _nodes.size() - 1) {
-      _nodes.resize(curr + 1);
+    while (curr > _nodes.size() - 1) {
+      _nodes.emplace_back(_suite);
     }
 
     _nodes[curr] = new_node(secret);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -4,12 +4,13 @@
 namespace mls {
 
 Session::Session(const bytes& group_id,
+                 CipherSuite suite,
                  const SignaturePrivateKey& identity_priv)
   : _init_secret(random_bytes(32))
   , _next_leaf_secret(random_bytes(32))
   , _identity_priv(identity_priv)
 {
-  State root(group_id, identity_priv);
+  State root(group_id, suite, identity_priv);
   add_state(0, root);
   make_init_key();
 }
@@ -108,10 +109,8 @@ void
 Session::make_init_key()
 {
   auto init_priv = DHPrivateKey::derive(DH_DEFAULT, _init_secret);
-  auto user_init_key = UserInitKey{
-    {},                        // No cipher suites
-    { init_priv.public_key() } // One init key
-  };
+  auto user_init_key = UserInitKey{};
+  user_init_key.init_keys.push_back(init_priv.public_key());
   user_init_key.sign(_identity_priv);
   _user_init_key = tls::marshal(user_init_key);
 }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -85,10 +85,13 @@ Session::remove(uint32_t index) const
 void
 Session::join(const bytes& welcome_data, const bytes& add_data)
 {
+  std::cout << "welcome: " << welcome_data << std::endl;
+  std::cout << "add: " << welcome_data << std::endl;
+
   Welcome welcome;
   tls::unmarshal(welcome_data, welcome);
 
-  Handshake add{ cipher_suite() };
+  Handshake add{ welcome.cipher_suite };
   tls::unmarshal(add_data, add);
 
   State next(_identity_priv, _init_secret, welcome, add);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -25,7 +25,7 @@ Session::Session(const SignaturePrivateKey& identity_priv)
 Session::Session()
   : _init_secret(random_bytes(32))
   , _next_leaf_secret(random_bytes(32))
-  , _identity_priv(SignaturePrivateKey::generate())
+  , _identity_priv(SignaturePrivateKey::generate(SIG_DEFAULT))
 {
   make_init_key();
 }
@@ -107,7 +107,7 @@ Session::handle(const bytes& data)
 void
 Session::make_init_key()
 {
-  auto init_priv = DHPrivateKey::derive(_init_secret);
+  auto init_priv = DHPrivateKey::derive(DH_DEFAULT, _init_secret);
   auto user_init_key = UserInitKey{
     {},                        // No cipher suites
     { init_priv.public_key() } // One init key

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -45,7 +45,7 @@ State::State(const SignaturePrivateKey& identity_priv,
   // XXX(rlb@ipv.sx): Assuming exactly one init key, of the same
   // algorithm.  Should do algorithm negotiation.
   auto add = handshake.operation.add;
-  auto init_priv = DHPrivateKey::derive(DH_DEFAULT, init_secret);
+  auto init_priv = DHPrivateKey::derive(_suite, init_secret);
   auto init_key = add.init_key.init_keys[0];
   auto identity_key = add.init_key.identity_key;
   if ((identity_key != identity_priv.public_key()) ||
@@ -76,6 +76,8 @@ State::add(const UserInitKey& user_init_key) const
 
   auto leaf_secret = random_bytes(32);
   auto path = _tree.encrypt(_tree.size(), leaf_secret);
+
+  // TODO(rlb@ipv.sx): Do proper algorithm negotiation here
 
   Welcome welcome{ _group_id, _epoch,      _suite,       _roster,
                    _tree,     _transcript, _init_secret, leaf_secret };

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -15,6 +15,7 @@ State::State(const bytes& group_id,
   , _identity_priv(identity_priv)
   , _epoch(zero_epoch)
   , _group_id(group_id)
+  , _suite(suite)
   , _message_master_secret()
   , _init_secret(zero_bytes(32))
   , _tree(suite, random_bytes(32))

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -41,7 +41,7 @@ State::State(const SignaturePrivateKey& identity_priv,
   // XXX(rlb@ipv.sx): Assuming exactly one init key, of the same
   // algorithm.  Should do algorithm negotiation.
   auto add = handshake.operation.add;
-  auto init_priv = DHPrivateKey::derive(init_secret);
+  auto init_priv = DHPrivateKey::derive(DH_DEFAULT, init_secret);
   auto init_key = add.init_key.init_keys[0];
   auto identity_key = add.init_key.identity_key;
   if ((identity_key != identity_priv.public_key()) ||

--- a/test/crypto_test.cpp
+++ b/test/crypto_test.cpp
@@ -5,6 +5,9 @@
 
 using namespace mls;
 
+#define DH_TEST CipherSuite::P256_SHA256_AES128GCM
+#define SIG_TEST SignatureScheme::P256_SHA256
+
 TEST_CASE("SHA-256 hash produces correct values", "[crypto]")
 {
   uint8_t byte = 0x42;
@@ -85,8 +88,8 @@ TEST_CASE("AES-GCM encryption produces correct values", "[crypto]")
 
 TEST_CASE("Diffie-Hellman key pairs can be created and combined", "[crypto]")
 {
-  auto x = DHPrivateKey::generate();
-  auto y = DHPrivateKey::derive({ 0, 1, 2, 3 });
+  auto x = DHPrivateKey::generate(DH_TEST);
+  auto y = DHPrivateKey::derive(DH_TEST, { 0, 1, 2, 3 });
 
   REQUIRE(x == x);
   REQUIRE(y == y);
@@ -105,12 +108,12 @@ TEST_CASE("Diffie-Hellman key pairs can be created and combined", "[crypto]")
 
 TEST_CASE("Diffie-Hellman public keys serialize and deserialize", "[crypto]")
 {
-  auto x = DHPrivateKey::derive({ 0, 1, 2, 3 });
+  auto x = DHPrivateKey::derive(DH_TEST, { 0, 1, 2, 3 });
   auto gX = x.public_key();
 
   SECTION("Directly")
   {
-    DHPublicKey parsed(gX.to_bytes());
+    DHPublicKey parsed(DH_TEST, gX.to_bytes());
     REQUIRE(parsed == gX);
   }
 
@@ -124,7 +127,7 @@ TEST_CASE("Diffie-Hellman public keys serialize and deserialize", "[crypto]")
 
 TEST_CASE("Diffie-Hellman key pairs encrypt and decrypt ECIES", "[crypto]")
 {
-  auto x = DHPrivateKey::derive({ 0, 1, 2, 3 });
+  auto x = DHPrivateKey::derive(DH_TEST, { 0, 1, 2, 3 });
   auto gX = x.public_key();
 
   auto original = random_bytes(100);
@@ -136,8 +139,8 @@ TEST_CASE("Diffie-Hellman key pairs encrypt and decrypt ECIES", "[crypto]")
 
 TEST_CASE("Signature key pairs can sign and verify", "[crypto]")
 {
-  auto a = SignaturePrivateKey::generate();
-  auto b = SignaturePrivateKey::generate();
+  auto a = SignaturePrivateKey::generate(SIG_TEST);
+  auto b = SignaturePrivateKey::generate(SIG_TEST);
 
   REQUIRE(a == a);
   REQUIRE(b == b);
@@ -155,12 +158,12 @@ TEST_CASE("Signature key pairs can sign and verify", "[crypto]")
 
 TEST_CASE("Signature public keys serialize and deserialize", "[crypto]")
 {
-  auto x = SignaturePrivateKey::generate();
+  auto x = SignaturePrivateKey::generate(SIG_TEST);
   auto gX = x.public_key();
 
   SECTION("Directly")
   {
-    SignaturePublicKey parsed(gX.to_bytes());
+    SignaturePublicKey parsed(SIG_TEST, gX.to_bytes());
     REQUIRE(parsed == gX);
   }
 

--- a/test/crypto_test.cpp
+++ b/test/crypto_test.cpp
@@ -5,8 +5,8 @@
 
 using namespace mls;
 
-#define DH_TEST CipherSuite::P256_SHA256_AES128GCM
-#define SIG_TEST SignatureScheme::P256_SHA256
+#define CIPHERSUITE CipherSuite::P256_SHA256_AES128GCM
+#define SIG_SCHEME SignatureScheme::P256_SHA256
 
 TEST_CASE("SHA-256 hash produces correct values", "[crypto]")
 {
@@ -88,8 +88,8 @@ TEST_CASE("AES-GCM encryption produces correct values", "[crypto]")
 
 TEST_CASE("Diffie-Hellman key pairs can be created and combined", "[crypto]")
 {
-  auto x = DHPrivateKey::generate(DH_TEST);
-  auto y = DHPrivateKey::derive(DH_TEST, { 0, 1, 2, 3 });
+  auto x = DHPrivateKey::generate(CIPHERSUITE);
+  auto y = DHPrivateKey::derive(CIPHERSUITE, { 0, 1, 2, 3 });
 
   REQUIRE(x == x);
   REQUIRE(y == y);
@@ -108,18 +108,18 @@ TEST_CASE("Diffie-Hellman key pairs can be created and combined", "[crypto]")
 
 TEST_CASE("Diffie-Hellman public keys serialize and deserialize", "[crypto]")
 {
-  auto x = DHPrivateKey::derive(DH_TEST, { 0, 1, 2, 3 });
+  auto x = DHPrivateKey::derive(CIPHERSUITE, { 0, 1, 2, 3 });
   auto gX = x.public_key();
 
   SECTION("Directly")
   {
-    DHPublicKey parsed(DH_TEST, gX.to_bytes());
+    DHPublicKey parsed(CIPHERSUITE, gX.to_bytes());
     REQUIRE(parsed == gX);
   }
 
   SECTION("Via TLS syntax")
   {
-    DHPublicKey gX2;
+    DHPublicKey gX2(CIPHERSUITE);
     tls::unmarshal(tls::marshal(gX), gX2);
     REQUIRE(gX2 == gX);
   }
@@ -127,7 +127,7 @@ TEST_CASE("Diffie-Hellman public keys serialize and deserialize", "[crypto]")
 
 TEST_CASE("Diffie-Hellman key pairs encrypt and decrypt ECIES", "[crypto]")
 {
-  auto x = DHPrivateKey::derive(DH_TEST, { 0, 1, 2, 3 });
+  auto x = DHPrivateKey::derive(CIPHERSUITE, { 0, 1, 2, 3 });
   auto gX = x.public_key();
 
   auto original = random_bytes(100);
@@ -139,8 +139,8 @@ TEST_CASE("Diffie-Hellman key pairs encrypt and decrypt ECIES", "[crypto]")
 
 TEST_CASE("Signature key pairs can sign and verify", "[crypto]")
 {
-  auto a = SignaturePrivateKey::generate(SIG_TEST);
-  auto b = SignaturePrivateKey::generate(SIG_TEST);
+  auto a = SignaturePrivateKey::generate(SIG_SCHEME);
+  auto b = SignaturePrivateKey::generate(SIG_SCHEME);
 
   REQUIRE(a == a);
   REQUIRE(b == b);
@@ -158,18 +158,18 @@ TEST_CASE("Signature key pairs can sign and verify", "[crypto]")
 
 TEST_CASE("Signature public keys serialize and deserialize", "[crypto]")
 {
-  auto x = SignaturePrivateKey::generate(SIG_TEST);
+  auto x = SignaturePrivateKey::generate(SIG_SCHEME);
   auto gX = x.public_key();
 
   SECTION("Directly")
   {
-    SignaturePublicKey parsed(SIG_TEST, gX.to_bytes());
+    SignaturePublicKey parsed(SIG_SCHEME, gX.to_bytes());
     REQUIRE(parsed == gX);
   }
 
   SECTION("Via TLS syntax")
   {
-    SignaturePublicKey gX2;
+    SignaturePublicKey gX2(SIG_SCHEME);
     tls::unmarshal(tls::marshal(gX), gX2);
     REQUIRE(gX2 == gX);
   }

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -4,6 +4,9 @@
 
 using namespace mls;
 
+#define DH_TEST CipherSuite::P256_SHA256_AES128GCM
+#define SIG_TEST SignatureScheme::P256_SHA256
+
 template<typename T>
 T
 tls_round_trip(const T& before)
@@ -19,9 +22,9 @@ static const epoch_t epoch_val = 0x01020304;
 TEST_CASE("Basic message serialization", "[messages]")
 {
   auto random = random_bytes(32);
-  auto identity_priv = SignaturePrivateKey::generate();
+  auto identity_priv = SignaturePrivateKey::generate(SIG_TEST);
   auto identity_pub = identity_priv.public_key();
-  auto dh_pub = DHPrivateKey::generate().public_key();
+  auto dh_pub = DHPrivateKey::generate(DH_TEST).public_key();
 
   RatchetTree ratchet_tree{ { random, random } };
   auto ratchet_path = ratchet_tree.encrypt(0, random);
@@ -31,8 +34,8 @@ TEST_CASE("Basic message serialization", "[messages]")
   roster.add(cred);
 
   UserInitKey user_init_key{
-    {},                                       // No ciphersuites
-    { DHPrivateKey::generate().public_key() } // Only one init key
+    {},                                              // No ciphersuites
+    { DHPrivateKey::generate(DH_TEST).public_key() } // Only one init key
   };
   user_init_key.sign(identity_priv);
 

--- a/test/ratchet_tree_test.cpp
+++ b/test/ratchet_tree_test.cpp
@@ -4,6 +4,8 @@
 
 using namespace mls;
 
+#define CIPHERSUITE CipherSuite::P256_SHA256_AES128GCM
+
 TEST_CASE("Trees can be created and extended", "[ratchet-tree]")
 {
   bytes secretA = from_hex("00010203");
@@ -21,21 +23,21 @@ TEST_CASE("Trees can be created and extended", "[ratchet-tree]")
 
   SECTION("With one member")
   {
-    RatchetTree tree{ secretA };
+    RatchetTree tree{ CIPHERSUITE, secretA };
     REQUIRE(tree.size() == 1);
     REQUIRE(tree.root_secret() == secretA);
   }
 
   SECTION("With multiple members")
   {
-    RatchetTree tree{ { secretA, secretB, secretC, secretD } };
+    RatchetTree tree{ CIPHERSUITE, { secretA, secretB, secretC, secretD } };
     REQUIRE(tree.size() == 4);
     REQUIRE(tree.root_secret() == secretABCD);
   }
 
   SECTION("By extension")
   {
-    RatchetTree tree{ secretA };
+    RatchetTree tree{ CIPHERSUITE, secretA };
 
     auto ctB = tree.encrypt(1, secretB);
     auto rootAB = tree.decrypt(1, ctB);
@@ -61,14 +63,14 @@ TEST_CASE("Trees can be created and extended", "[ratchet-tree]")
     REQUIRE(tree.root_secret() == rootABCD);
     REQUIRE(tree.root_secret() == secretABCD);
 
-    RatchetTree direct{ { secretA, secretB, secretC, secretD } };
+    RatchetTree direct{ CIPHERSUITE, { secretA, secretB, secretC, secretD } };
     REQUIRE(tree == direct);
   }
 
   SECTION("Via serialization")
   {
-    RatchetTree before{ { secretA, secretB, secretC, secretD } };
-    RatchetTree after;
+    RatchetTree before{ CIPHERSUITE, { secretA, secretB, secretC, secretD } };
+    RatchetTree after{ CIPHERSUITE };
 
     tls::unmarshal(tls::marshal(before), after);
     REQUIRE(before == after);

--- a/test/roster_test.cpp
+++ b/test/roster_test.cpp
@@ -3,9 +3,11 @@
 
 using namespace mls;
 
+#define SIG_TEST SignatureScheme::P256_SHA256
+
 TEST_CASE("Rosters can be created and accessed", "[roster]")
 {
-  auto priv = SignaturePrivateKey::generate();
+  auto priv = SignaturePrivateKey::generate(SIG_TEST);
   auto pub = priv.public_key();
 
   RawKeyCredential cred{ pub };

--- a/test/session_test.cpp
+++ b/test/session_test.cpp
@@ -3,6 +3,8 @@
 
 using namespace mls;
 
+#define SIG_TEST SignatureScheme::P256_SHA256
+
 const size_t group_size = 5;
 const bytes group_id{ 0, 1, 2, 3 };
 
@@ -41,7 +43,7 @@ check(std::vector<Session> sessions, epoch_t initial_epoch)
 TEST_CASE("Session creation", "[session]")
 {
   std::vector<Session> sessions;
-  sessions.push_back({ group_id, SignaturePrivateKey::generate() });
+  sessions.push_back({ group_id, SignaturePrivateKey::generate(SIG_TEST) });
 
   SECTION("Two person")
   {
@@ -63,7 +65,7 @@ TEST_CASE("Session creation", "[session]")
 TEST_CASE("Session update and removal", "[session]")
 {
   std::vector<Session> sessions;
-  sessions.push_back({ group_id, SignaturePrivateKey::generate() });
+  sessions.push_back({ group_id, SignaturePrivateKey::generate(SIG_TEST) });
 
   for (int i = 0; i < group_size - 1; i += 1) {
     auto initial_epoch = sessions[0].current_epoch();
@@ -96,7 +98,7 @@ TEST_CASE("Session update and removal", "[session]")
 TEST_CASE("Full life-cycle", "[session]")
 {
   std::vector<Session> sessions;
-  sessions.push_back({ group_id, SignaturePrivateKey::generate() });
+  sessions.push_back({ group_id, SignaturePrivateKey::generate(SIG_TEST) });
 
   // Create the group
   for (int i = 0; i < group_size - 1; i += 1) {

--- a/test/session_test.cpp
+++ b/test/session_test.cpp
@@ -3,6 +3,7 @@
 
 using namespace mls;
 
+#define CIPHERSUITE CipherSuite::P256_SHA256_AES128GCM
 #define SIG_TEST SignatureScheme::P256_SHA256
 
 const size_t group_size = 5;
@@ -43,7 +44,8 @@ check(std::vector<Session> sessions, epoch_t initial_epoch)
 TEST_CASE("Session creation", "[session]")
 {
   std::vector<Session> sessions;
-  sessions.push_back({ group_id, SignaturePrivateKey::generate(SIG_TEST) });
+  sessions.push_back(
+    { group_id, CIPHERSUITE, SignaturePrivateKey::generate(SIG_TEST) });
 
   SECTION("Two person")
   {
@@ -65,7 +67,8 @@ TEST_CASE("Session creation", "[session]")
 TEST_CASE("Session update and removal", "[session]")
 {
   std::vector<Session> sessions;
-  sessions.push_back({ group_id, SignaturePrivateKey::generate(SIG_TEST) });
+  sessions.push_back(
+    { group_id, CIPHERSUITE, SignaturePrivateKey::generate(SIG_TEST) });
 
   for (int i = 0; i < group_size - 1; i += 1) {
     auto initial_epoch = sessions[0].current_epoch();
@@ -98,7 +101,8 @@ TEST_CASE("Session update and removal", "[session]")
 TEST_CASE("Full life-cycle", "[session]")
 {
   std::vector<Session> sessions;
-  sessions.push_back({ group_id, SignaturePrivateKey::generate(SIG_TEST) });
+  sessions.push_back(
+    { group_id, CIPHERSUITE, SignaturePrivateKey::generate(SIG_TEST) });
 
   // Create the group
   for (int i = 0; i < group_size - 1; i += 1) {

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -3,6 +3,9 @@
 
 using namespace mls;
 
+#define DH_TEST CipherSuite::P256_SHA256_AES128GCM
+#define SIG_TEST SignatureScheme::P256_SHA256
+
 const size_t group_size = 5;
 const bytes group_id{ 0, 1, 2, 3 };
 
@@ -23,9 +26,9 @@ TEST_CASE("Group creation", "[state]")
   auto inp = init_secrets.begin();
   auto stp = states.begin();
   for (size_t i = 0; i < group_size; i += 1) {
-    identity_privs.emplace(idp + i, SignaturePrivateKey::generate());
+    identity_privs.emplace(idp + i, SignaturePrivateKey::generate(SIG_TEST));
     auto init_secret = random_bytes(32);
-    auto init_priv = DHPrivateKey::derive(init_secret);
+    auto init_priv = DHPrivateKey::derive(DH_TEST, init_secret);
     user_init_keys.emplace(uik + i);
     user_init_keys[i].init_keys = { init_priv.public_key() };
     user_init_keys[i].sign(identity_privs[i]);
@@ -80,12 +83,12 @@ TEST_CASE("Operations on a running group", "[state]")
   states.reserve(group_size);
 
   auto stp = states.begin();
-  states.emplace(stp, group_id, SignaturePrivateKey::generate());
+  states.emplace(stp, group_id, SignaturePrivateKey::generate(SIG_TEST));
 
   for (size_t i = 1; i < group_size; i += 1) {
     auto init_secret = random_bytes(32);
-    auto init_priv = DHPrivateKey::derive(init_secret);
-    auto identity_priv = SignaturePrivateKey::generate();
+    auto init_priv = DHPrivateKey::derive(DH_TEST, init_secret);
+    auto identity_priv = SignaturePrivateKey::generate(SIG_TEST);
 
     UserInitKey uik;
     uik.init_keys = { init_priv.public_key() };

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -30,7 +30,7 @@ TEST_CASE("Group creation", "[state]")
     auto init_secret = random_bytes(32);
     auto init_priv = DHPrivateKey::derive(CIPHERSUITE, init_secret);
     user_init_keys.emplace(uik + i);
-    user_init_keys[i].init_keys = { init_priv.public_key() };
+    user_init_keys[i].add_init_key(init_priv.public_key());
     user_init_keys[i].sign(identity_privs[i]);
     init_secrets.emplace(inp + i, init_secret);
   }
@@ -92,7 +92,7 @@ TEST_CASE("Operations on a running group", "[state]")
     auto identity_priv = SignaturePrivateKey::generate(SIG_SCHEME);
 
     UserInitKey uik;
-    uik.init_keys = { init_priv.public_key() };
+    uik.add_init_key(init_priv.public_key());
     uik.sign(identity_priv);
 
     auto welcome_add = states[0].add(uik);

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -3,8 +3,8 @@
 
 using namespace mls;
 
-#define DH_TEST CipherSuite::P256_SHA256_AES128GCM
-#define SIG_TEST SignatureScheme::P256_SHA256
+#define CIPHERSUITE CipherSuite::P256_SHA256_AES128GCM
+#define SIG_SCHEME SignatureScheme::P256_SHA256
 
 const size_t group_size = 5;
 const bytes group_id{ 0, 1, 2, 3 };
@@ -26,9 +26,9 @@ TEST_CASE("Group creation", "[state]")
   auto inp = init_secrets.begin();
   auto stp = states.begin();
   for (size_t i = 0; i < group_size; i += 1) {
-    identity_privs.emplace(idp + i, SignaturePrivateKey::generate(SIG_TEST));
+    identity_privs.emplace(idp + i, SignaturePrivateKey::generate(SIG_SCHEME));
     auto init_secret = random_bytes(32);
-    auto init_priv = DHPrivateKey::derive(DH_TEST, init_secret);
+    auto init_priv = DHPrivateKey::derive(CIPHERSUITE, init_secret);
     user_init_keys.emplace(uik + i);
     user_init_keys[i].init_keys = { init_priv.public_key() };
     user_init_keys[i].sign(identity_privs[i]);
@@ -38,7 +38,7 @@ TEST_CASE("Group creation", "[state]")
   SECTION("Two person")
   {
     // Initialize the creator's state
-    states.emplace(stp, group_id, identity_privs[0]);
+    states.emplace(stp, group_id, CIPHERSUITE, identity_privs[0]);
 
     // Create a Add for the new participant
     auto welcome_add = states[0].add(user_init_keys[1]);
@@ -55,7 +55,7 @@ TEST_CASE("Group creation", "[state]")
   SECTION("Full size")
   {
     // Initialize the creator's state
-    states.emplace(stp, group_id, identity_privs[0]);
+    states.emplace(stp, group_id, CIPHERSUITE, identity_privs[0]);
 
     // Each participant invites the next
     for (size_t i = 1; i < group_size; i += 1) {
@@ -83,12 +83,13 @@ TEST_CASE("Operations on a running group", "[state]")
   states.reserve(group_size);
 
   auto stp = states.begin();
-  states.emplace(stp, group_id, SignaturePrivateKey::generate(SIG_TEST));
+  states.emplace(
+    stp, group_id, CIPHERSUITE, SignaturePrivateKey::generate(SIG_SCHEME));
 
   for (size_t i = 1; i < group_size; i += 1) {
     auto init_secret = random_bytes(32);
-    auto init_priv = DHPrivateKey::derive(DH_TEST, init_secret);
-    auto identity_priv = SignaturePrivateKey::generate(SIG_TEST);
+    auto init_priv = DHPrivateKey::derive(CIPHERSUITE, init_secret);
+    auto identity_priv = SignaturePrivateKey::generate(SIG_SCHEME);
 
     UserInitKey uik;
     uik.init_keys = { init_priv.public_key() };


### PR DESCRIPTION
Continuing work on #7.  This PR adds support for run-time crypto agility, which basically means making a bunch of structures aware of what ciphersuite is in use.  Still needs proper tests for all of the cipher suites implemented.