### PR TITLE
Add high-security ciphersuites

### DIFF
--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -465,6 +465,12 @@ public:
 
   virtual OpenSSLKey* dup() const
   {
+    // XXX(rlb@ipv.sx): This shouldn't be necessary, but somehow the
+    // RatchetTree ctor tries to copy an empty key.
+    if (!_key.get()) {
+      return new ECKey(_curve_nid, static_cast<EVP_PKEY*>(nullptr));
+    }
+
     auto eckey_out = EC_KEY_dup(my_ec_key());
     return new ECKey(_curve_nid, eckey_out);
   }

--- a/src/include/crypto.h
+++ b/src/include/crypto.h
@@ -14,7 +14,9 @@ namespace mls {
 enum struct CipherSuite : uint16_t
 {
   P256_SHA256_AES128GCM = 0x0000,
-  X25519_SHA256_AES128GCM = 0x0001
+  P521_SHA512_AES256GCM = 0x0010,
+  X25519_SHA256_AES128GCM = 0x0001,
+  X448_SHA512_AES256GCM = 0x0011
 };
 
 // Utility class to avoid a bit of boilerplate
@@ -39,7 +41,9 @@ operator>>(tls::istream& in, CipherSuite& obj);
 enum struct SignatureScheme : uint16_t
 {
   P256_SHA256 = 0x0000,
-  Ed25519_SHA256 = 0x0001
+  P521_SHA512 = 0x0010,
+  Ed25519 = 0x0001,
+  Ed448 = 0x0011
 };
 
 tls::ostream&

--- a/src/include/crypto.h
+++ b/src/include/crypto.h
@@ -95,21 +95,26 @@ public:
 };
 
 // Digests
-class SHA256Digest
+enum struct DigestType
+{
+  SHA256,
+  SHA512
+};
+
+class Digest
 {
 public:
-  SHA256Digest();
-  SHA256Digest(uint8_t byte);
-  SHA256Digest(const bytes& data);
-
-  SHA256Digest& write(uint8_t byte);
-  SHA256Digest& write(const bytes& data);
+  Digest(DigestType type);
+  Digest(CipherSuite suite);
+  Digest& write(uint8_t byte);
+  Digest& write(const bytes& data);
   bytes digest();
 
-  static const size_t output_size = 32;
+  const size_t output_size() const;
 
 private:
-  SHA256_CTX _ctx;
+  size_t _size;
+  typed_unique_ptr<EVP_MD_CTX> _ctx;
 };
 
 bytes

--- a/src/include/crypto.h
+++ b/src/include/crypto.h
@@ -124,12 +124,13 @@ bytes
 random_bytes(size_t size);
 
 bytes
-hkdf_extract(const bytes& salt, const bytes& ikm);
+hkdf_extract(CipherSuite suite, const bytes& salt, const bytes& ikm);
 
 class State;
 
 bytes
-derive_secret(const bytes& secret,
+derive_secret(CipherSuite suite,
+              const bytes& secret,
               const std::string& label,
               const State& state,
               const size_t length);
@@ -226,6 +227,8 @@ public:
   ECIESCiphertext encrypt(const bytes& plaintext) const;
 
 private:
+  CipherSuite _suite;
+
   DHPublicKey(CipherSuite suite, OpenSSLKey* key);
   friend class DHPrivateKey;
 };
@@ -246,6 +249,7 @@ public:
   const DHPublicKey& public_key() const;
 
 private:
+  CipherSuite _suite;
   DHPrivateKey(CipherSuite suite, OpenSSLKey* key);
 };
 

--- a/src/include/crypto.h
+++ b/src/include/crypto.h
@@ -150,6 +150,8 @@ public:
   bytes encrypt(const bytes& plaintext) const;
   bytes decrypt(const bytes& ciphertext) const;
 
+  static size_t key_size(CipherSuite suite);
+
   static const size_t key_size_128 = 16;
   static const size_t key_size_192 = 24;
   static const size_t key_size_256 = 32;

--- a/src/include/crypto.h
+++ b/src/include/crypto.h
@@ -94,6 +94,7 @@ public:
   static OpenSSLError current();
 };
 
+// Digests
 class SHA256Digest
 {
 public:

--- a/src/ratchet_tree.cpp
+++ b/src/ratchet_tree.cpp
@@ -215,7 +215,7 @@ RatchetTree::RatchetTree(CipherSuite suite, const std::vector<bytes>& secrets)
 
     auto right = tree_math::right(curr, size);
     auto child_secret = *(_nodes[right].secret());
-    auto secret = SHA256Digest(child_secret).digest();
+    auto secret = Digest(_suite).write(child_secret).digest();
     _nodes[curr] = new_node(secret);
   }
 }
@@ -250,7 +250,7 @@ RatchetTree::encrypt(uint32_t from, const bytes& leaf_secret) const
   auto sibling = tree_math::sibling(curr, size);
   auto secret = leaf_secret;
   while (curr != root) {
-    secret = SHA256Digest(secret).digest();
+    secret = Digest(_suite).write(secret).digest();
 
     auto temp = new_node(secret);
     path.nodes.push_back(temp);
@@ -285,7 +285,7 @@ RatchetTree::decrypt(uint32_t from, RatchetPath& path) const
       secret = priv->decrypt(path.node_secrets[i - 1]);
       have_secret = true;
     } else if (have_secret) {
-      secret = SHA256Digest(secret).digest();
+      secret = Digest(_suite).write(secret).digest();
     }
 
     if (have_secret) {
@@ -337,7 +337,7 @@ RatchetTree::set_leaf(uint32_t index, const bytes& leaf)
     }
 
     _nodes[curr] = new_node(secret);
-    secret = SHA256Digest(secret).digest();
+    secret = Digest(_suite).write(secret).digest();
 
     curr = tree_math::parent(curr, size);
   }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -252,11 +252,11 @@ State::update_leaf(uint32_t index,
 void
 State::derive_epoch_keys(const bytes& update_secret)
 {
-  auto epoch_secret = hkdf_extract(_init_secret, update_secret);
-  _message_master_secret =
-    derive_secret(epoch_secret, "msg", *this, Digest(_suite).output_size());
-  _init_secret =
-    derive_secret(epoch_secret, "init", *this, Digest(_suite).output_size());
+  auto epoch_secret = hkdf_extract(_suite, _init_secret, update_secret);
+  _message_master_secret = derive_secret(
+    _suite, epoch_secret, "msg", *this, Digest(_suite).output_size());
+  _init_secret = derive_secret(
+    _suite, epoch_secret, "init", *this, Digest(_suite).output_size());
 }
 
 Handshake

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -254,9 +254,9 @@ State::derive_epoch_keys(const bytes& update_secret)
 {
   auto epoch_secret = hkdf_extract(_init_secret, update_secret);
   _message_master_secret =
-    derive_secret(epoch_secret, "msg", *this, SHA256Digest::output_size);
+    derive_secret(epoch_secret, "msg", *this, Digest(_suite).output_size());
   _init_secret =
-    derive_secret(epoch_secret, "init", *this, SHA256Digest::output_size);
+    derive_secret(epoch_secret, "init", *this, Digest(_suite).output_size());
 }
 
 Handshake

--- a/test/crypto_test.cpp
+++ b/test/crypto_test.cpp
@@ -17,21 +17,24 @@ TEST_CASE("SHA-256 hash produces correct values", "[crypto]")
   {
     std::string answer =
       "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c";
-    REQUIRE(SHA256Digest(byte).digest() == from_hex(answer));
+    REQUIRE(Digest(DigestType::SHA256).write(byte).digest() ==
+            from_hex(answer));
   }
 
   SECTION("For a byte string")
   {
     std::string answer =
       "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a";
-    REQUIRE(SHA256Digest(data).digest() == from_hex(answer));
+    REQUIRE(Digest(DigestType::SHA256).write(data).digest() ==
+            from_hex(answer));
   }
 
   SECTION("For input in multiple chunks")
   {
     std::string answer =
       "76a952f18b6c638b028860087e7840a9cc43ed1af489d62a51c71984266789d6";
-    REQUIRE(SHA256Digest(byte).write(data).digest() == from_hex(answer));
+    REQUIRE(Digest(DigestType::SHA256).write(byte).write(data).digest() ==
+            from_hex(answer));
   }
 }
 

--- a/test/crypto_test.cpp
+++ b/test/crypto_test.cpp
@@ -8,172 +8,239 @@ using namespace mls;
 #define CIPHERSUITE CipherSuite::P256_SHA256_AES128GCM
 #define SIG_SCHEME SignatureScheme::P256_SHA256
 
+// TODO Known-answer tests of all individual primitives:
+// * Digest
+//    * SHA256      DONE
+//    * SHA512      DONE
+// * Encryption
+//    * AES-128-GCM DONE
+//    * AES-256-GCM DONE
+// * DH
+//    * ECDH P-256  TODO
+//    * ECDH P-521  TODO
+//    * X25519      TODO https://tools.ietf.org/html/rfc7748#section-6.1
+//    * X448        TODO https://tools.ietf.org/html/rfc7748#section-6.2
+// * Signature
+//    * ECDSA P-256 TODO
+//    * ECDSA P-521 TODO
+//    * Ed25519     TODO https://tools.ietf.org/html/rfc8032#section-7.1
+//    * Ed448       TODO https://tools.ietf.org/html/rfc8032#section-7.4
+
 TEST_CASE("SHA-256 hash produces correct values", "[crypto]")
 {
-  uint8_t byte = 0x42;
-  auto data = from_hex("01020304");
+  // https://www.di-mgt.com.au/sha_testvectors.html
+  auto input =
+    from_hex("6162636462636465636465666465666765666768666768696768696a68696a6b6"
+             "96a6b6c6a6b6c6d6b6c6d6e6c6d6e6f6d6e6f706e6f7071");
+  auto out256 = from_hex(
+    "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
+  auto out512 =
+    from_hex("204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a8279be331a703c3359"
+             "6fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445");
 
-  SECTION("For a single byte")
-  {
-    std::string answer =
-      "df7e70e5021544f4834bbee64a9e3789febc4be81470df629cad6ddb03320a5c";
-    REQUIRE(Digest(DigestType::SHA256).write(byte).digest() ==
-            from_hex(answer));
-  }
-
-  SECTION("For a byte string")
-  {
-    std::string answer =
-      "9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a";
-    REQUIRE(Digest(DigestType::SHA256).write(data).digest() ==
-            from_hex(answer));
-  }
-
-  SECTION("For input in multiple chunks")
-  {
-    std::string answer =
-      "76a952f18b6c638b028860087e7840a9cc43ed1af489d62a51c71984266789d6";
-    REQUIRE(Digest(DigestType::SHA256).write(byte).write(data).digest() ==
-            from_hex(answer));
-  }
+  REQUIRE(Digest(DigestType::SHA256).write(input).digest() == out256);
+  REQUIRE(Digest(DigestType::SHA512).write(input).digest() == out512);
 }
 
 TEST_CASE("AES-GCM encryption produces correct values", "[crypto]")
 {
   // https://tools.ietf.org/html/draft-mcgrew-gcm-test-01#section-4
-  auto key = from_hex("4c80cdefbb5d10da906ac73c3613a634");
-  auto nonce = from_hex("2e443b684956ed7e3b244cfe");
-  auto aad = from_hex("000043218765432100000000");
-  auto plaintext = from_hex("45000048699a000080114db7c0a80102"
-                            "c0a801010a9bf15638d3010000010000"
-                            "00000000045f736970045f7564700373"
-                            "69700963796265726369747902646b00"
-                            "0021000101020201");
-  auto ciphertext = from_hex("fecf537e729d5b07dc30df528dd22b76"
-                             "8d1b98736696a6fd348509fa13ceac34"
-                             "cfa2436f14a3f3cf65925bf1f4a13c5d"
-                             "15b21e1884f5ff6247aeabb786b93bce"
-                             "61bc17d768fd9732459018148f6cbe72"
-                             "2fd04796562dfdb4");
+  auto key128 = from_hex("4c80cdefbb5d10da906ac73c3613a634");
+  auto nonce128 = from_hex("2e443b684956ed7e3b244cfe");
+  auto aad128 = from_hex("000043218765432100000000");
+  auto plaintext128 = from_hex("45000048699a000080114db7c0a80102"
+                               "c0a801010a9bf15638d3010000010000"
+                               "00000000045f736970045f7564700373"
+                               "69700963796265726369747902646b00"
+                               "0021000101020201");
+  auto ciphertext128 = from_hex("fecf537e729d5b07dc30df528dd22b76"
+                                "8d1b98736696a6fd348509fa13ceac34"
+                                "cfa2436f14a3f3cf65925bf1f4a13c5d"
+                                "15b21e1884f5ff6247aeabb786b93bce"
+                                "61bc17d768fd9732459018148f6cbe72"
+                                "2fd04796562dfdb4");
+
+  auto key256 = from_hex("abbccddef00112233445566778899aab"
+                         "abbccddef00112233445566778899aab");
+  auto nonce256 = from_hex("112233440102030405060708");
+  auto aad256 = from_hex("4a2cbfe300000002");
+  auto plaintext256 = from_hex("4500003069a6400080062690c0a80102"
+                               "9389155e0a9e008b2dc57ee000000000"
+                               "7002400020bf0000020405b401010402"
+                               "01020201");
+  auto ciphertext256 = from_hex("ff425c9b724599df7a3bcd510194e00d"
+                                "6a78107f1b0b1cbf06efae9d65a5d763"
+                                "748a637985771d347f0545659f14e99d"
+                                "ef842d8eb335f4eecfdbf831824b4c49"
+                                "15956c96");
 
   SECTION("For encryption")
   {
-    AESGCM gcm(key, nonce);
-    gcm.set_aad(aad);
-    REQUIRE(gcm.encrypt(plaintext) == ciphertext);
+    AESGCM gcm128(key128, nonce128);
+    gcm128.set_aad(aad128);
+    REQUIRE(gcm128.encrypt(plaintext128) == ciphertext128);
+
+    AESGCM gcm256(key256, nonce256);
+    gcm256.set_aad(aad256);
+    REQUIRE(gcm256.encrypt(plaintext256) == ciphertext256);
   }
 
   SECTION("For decryption")
   {
-    AESGCM gcm(key, nonce);
-    gcm.set_aad(aad);
-    REQUIRE(gcm.decrypt(ciphertext) == plaintext);
+    AESGCM gcm128(key128, nonce128);
+    gcm128.set_aad(aad128);
+    REQUIRE(gcm128.decrypt(ciphertext128) == plaintext128);
+
+    AESGCM gcm256(key256, nonce256);
+    gcm256.set_aad(aad256);
+    REQUIRE(gcm256.decrypt(ciphertext256) == plaintext256);
   }
 
-  SECTION("For an encrypt/decrypt round-trip")
+  SECTION("For an encrypt/decrypt round-trip (128 bits)")
   {
-    auto key = random_bytes(AESGCM::key_size_256);
-    auto nonce = random_bytes(AESGCM::nonce_size);
-    auto aad = random_bytes(100);
-    auto original = random_bytes(100);
+    std::vector<size_t> key_sizes = { AESGCM::key_size_128,
+                                      AESGCM::key_size_256 };
+    for (auto key_size : key_sizes) {
+      auto key = random_bytes(AESGCM::key_size_128);
+      auto nonce = random_bytes(AESGCM::nonce_size);
+      auto aad = random_bytes(100);
+      auto original = random_bytes(100);
 
-    AESGCM gcm1(key, nonce);
-    gcm1.set_aad(aad);
-    auto encrypted = gcm1.encrypt(original);
+      AESGCM gcm1(key, nonce);
+      gcm1.set_aad(aad);
+      auto encrypted = gcm1.encrypt(original);
 
-    AESGCM gcm2(key, nonce);
-    gcm2.set_aad(aad);
-    auto decrypted = gcm2.decrypt(encrypted);
+      AESGCM gcm2(key, nonce);
+      gcm2.set_aad(aad);
+      auto decrypted = gcm2.decrypt(encrypted);
 
-    REQUIRE(decrypted == original);
+      REQUIRE(decrypted == original);
+    }
   }
 }
 
 TEST_CASE("Diffie-Hellman key pairs can be created and combined", "[crypto]")
 {
-  auto x = DHPrivateKey::generate(CIPHERSUITE);
-  auto y = DHPrivateKey::derive(CIPHERSUITE, { 0, 1, 2, 3 });
+  std::vector<CipherSuite> suites{ CipherSuite::P256_SHA256_AES128GCM,
+                                   CipherSuite::P521_SHA512_AES256GCM,
+                                   CipherSuite::X25519_SHA256_AES128GCM,
+                                   CipherSuite::X448_SHA512_AES256GCM };
 
-  REQUIRE(x == x);
-  REQUIRE(y == y);
-  REQUIRE(x != y);
+  for (auto suite : suites) {
+    auto x = DHPrivateKey::generate(suite);
+    auto y = DHPrivateKey::derive(suite, { 0, 1, 2, 3 });
 
-  auto gX = x.public_key();
-  auto gY = y.public_key();
-  REQUIRE(gX == gX);
-  REQUIRE(gY == gY);
-  REQUIRE(gX != gY);
+    REQUIRE(x == x);
+    REQUIRE(y == y);
+    REQUIRE(x != y);
 
-  auto gXY = x.derive(gY);
-  auto gYX = y.derive(gX);
-  REQUIRE(gXY == gYX);
+    auto gX = x.public_key();
+    auto gY = y.public_key();
+    REQUIRE(gX == gX);
+    REQUIRE(gY == gY);
+    REQUIRE(gX != gY);
+
+    auto gXY = x.derive(gY);
+    auto gYX = y.derive(gX);
+    REQUIRE(gXY == gYX);
+  }
 }
 
 TEST_CASE("Diffie-Hellman public keys serialize and deserialize", "[crypto]")
 {
-  auto x = DHPrivateKey::derive(CIPHERSUITE, { 0, 1, 2, 3 });
-  auto gX = x.public_key();
+  std::vector<CipherSuite> suites{ CipherSuite::P256_SHA256_AES128GCM,
+                                   CipherSuite::P521_SHA512_AES256GCM,
+                                   CipherSuite::X25519_SHA256_AES128GCM,
+                                   CipherSuite::X448_SHA512_AES256GCM };
 
-  SECTION("Directly")
-  {
-    DHPublicKey parsed(CIPHERSUITE, gX.to_bytes());
-    REQUIRE(parsed == gX);
-  }
+  for (auto suite : suites) {
+    auto x = DHPrivateKey::derive(suite, { 0, 1, 2, 3 });
+    auto gX = x.public_key();
 
-  SECTION("Via TLS syntax")
-  {
-    DHPublicKey gX2(CIPHERSUITE);
-    tls::unmarshal(tls::marshal(gX), gX2);
-    REQUIRE(gX2 == gX);
+    SECTION("Directly")
+    {
+      DHPublicKey parsed(suite, gX.to_bytes());
+      REQUIRE(parsed == gX);
+    }
+
+    SECTION("Via TLS syntax")
+    {
+      DHPublicKey gX2(suite);
+      tls::unmarshal(tls::marshal(gX), gX2);
+      REQUIRE(gX2 == gX);
+    }
   }
 }
 
 TEST_CASE("Diffie-Hellman key pairs encrypt and decrypt ECIES", "[crypto]")
 {
-  auto x = DHPrivateKey::derive(CIPHERSUITE, { 0, 1, 2, 3 });
-  auto gX = x.public_key();
+  std::vector<CipherSuite> suites{ CipherSuite::P256_SHA256_AES128GCM,
+                                   CipherSuite::P521_SHA512_AES256GCM,
+                                   CipherSuite::X25519_SHA256_AES128GCM,
+                                   CipherSuite::X448_SHA512_AES256GCM };
 
-  auto original = random_bytes(100);
-  auto encrypted = gX.encrypt(original);
-  auto decrypted = x.decrypt(encrypted);
+  for (auto suite : suites) {
+    auto x = DHPrivateKey::derive(CIPHERSUITE, { 0, 1, 2, 3 });
+    auto gX = x.public_key();
 
-  REQUIRE(original == decrypted);
+    auto original = random_bytes(100);
+    auto encrypted = gX.encrypt(original);
+    auto decrypted = x.decrypt(encrypted);
+
+    REQUIRE(original == decrypted);
+  }
 }
 
 TEST_CASE("Signature key pairs can sign and verify", "[crypto]")
 {
-  auto a = SignaturePrivateKey::generate(SIG_SCHEME);
-  auto b = SignaturePrivateKey::generate(SIG_SCHEME);
+  std::vector<SignatureScheme> schemes{ SignatureScheme::P256_SHA256,
+                                        SignatureScheme::P521_SHA512,
+                                        SignatureScheme::Ed25519,
+                                        SignatureScheme::Ed448 };
 
-  REQUIRE(a == a);
-  REQUIRE(b == b);
-  REQUIRE(a != b);
+  for (auto scheme : schemes) {
+    auto a = SignaturePrivateKey::generate(scheme);
+    auto b = SignaturePrivateKey::generate(scheme);
 
-  REQUIRE(a.public_key() == a.public_key());
-  REQUIRE(b.public_key() == b.public_key());
-  REQUIRE(a.public_key() != b.public_key());
+    REQUIRE(a == a);
+    REQUIRE(b == b);
+    REQUIRE(a != b);
 
-  auto message = from_hex("01020304");
-  auto signature = a.sign(message);
+    REQUIRE(a.public_key() == a.public_key());
+    REQUIRE(b.public_key() == b.public_key());
+    REQUIRE(a.public_key() != b.public_key());
 
-  REQUIRE(a.public_key().verify(message, signature));
+    auto message = from_hex("01020304");
+    auto signature = a.sign(message);
+
+    REQUIRE(a.public_key().verify(message, signature));
+  }
 }
 
 TEST_CASE("Signature public keys serialize and deserialize", "[crypto]")
 {
-  auto x = SignaturePrivateKey::generate(SIG_SCHEME);
-  auto gX = x.public_key();
+  std::vector<SignatureScheme> schemes{
+    SignatureScheme::P256_SHA256,
+    SignatureScheme::P521_SHA512,
+    SignatureScheme::Ed25519,
+    SignatureScheme::Ed448,
+  };
 
-  SECTION("Directly")
-  {
-    SignaturePublicKey parsed(SIG_SCHEME, gX.to_bytes());
-    REQUIRE(parsed == gX);
-  }
+  for (auto scheme : schemes) {
+    auto x = SignaturePrivateKey::generate(scheme);
+    auto gX = x.public_key();
 
-  SECTION("Via TLS syntax")
-  {
-    SignaturePublicKey gX2(SIG_SCHEME);
-    tls::unmarshal(tls::marshal(gX), gX2);
-    REQUIRE(gX2 == gX);
+    SECTION("Directly")
+    {
+      SignaturePublicKey parsed(scheme, gX.to_bytes());
+      REQUIRE(parsed == gX);
+    }
+
+    SECTION("Via TLS syntax")
+    {
+      SignaturePublicKey gX2(scheme);
+      tls::unmarshal(tls::marshal(gX), gX2);
+      REQUIRE(gX2 == gX);
+    }
   }
 }

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -2,8 +2,6 @@
 #include "tls_syntax.h"
 #include <catch.hpp>
 
-#include <iostream>
-
 using namespace mls;
 
 #define CIPHERSUITE CipherSuite::P256_SHA256_AES128GCM
@@ -37,9 +35,6 @@ TEST_CASE("Basic message serialization", "[messages]")
   UserInitKey user_init_key;
   user_init_key.add_init_key(dh_pub);
   user_init_key.sign(identity_priv);
-
-  auto uik = tls::marshal(user_init_key);
-  std::cout << uik << std::endl;
 
   SECTION("UserInitKey")
   {


### PR DESCRIPTION
Now that we have cipher agility, we can go a bit wild with the ciphersuites.  This PR adds some higher-security ciphersuites:

* ECDH with P-521, SHA-512, and AES-256-GCM
* ECDH with X448, SHA-512, and AES-256-GCM
* Signing with P-521 and SHA-512
* Signing with Ed448

Along the way, it completes the cipher agility story by making digests and ciphers agile, and expands crypto test coverage.