### PR TITLE
UIK safety & more crypto negotiation

### DIFF
--- a/src/include/messages.h
+++ b/src/include/messages.h
@@ -48,21 +48,21 @@ operator>>(tls::istream& in, UserInitKey& obj);
 //   opaque group_id<0..255>;
 //   uint32 epoch;
 //   CipherSuite cipher_suite;
-//   Credential roster<1..2^24-1>;
-//   PublicKey tree<1..2^24-1>;
-//   GroupOperation transcript<0..2^24-1>;
+//   Credential roster<1..2^32-1>;
+//   PublicKey tree<1..2^32-1>;
+//   GroupOperation transcript<0..2^32-1>;
 //   opaque init_secret<0..255>;
 //   opaque leaf_secret<0..255>;
 // } Welcome;
 struct GroupOperation;
 struct Welcome
 {
-  tls::opaque<2> group_id;
+  tls::opaque<1> group_id;
   epoch_t epoch;
   CipherSuite cipher_suite;
   Roster roster;
   RatchetTree tree;
-  tls::vector<GroupOperation, 3> transcript;
+  tls::vector<GroupOperation, 4> transcript;
   tls::opaque<1> init_secret;
   tls::opaque<1> leaf_secret;
 

--- a/src/include/messages.h
+++ b/src/include/messages.h
@@ -11,16 +11,16 @@ namespace mls {
 // struct {
 //     CipherSuite cipher_suites<0..255>; // ignored
 //     DHPublicKey init_keys<1..2^16-1>;  // only use first
-//     SignaturePublicKey identity_key;
 //     SignatureScheme algorithm;
+//     SignaturePublicKey identity_key;
 //     tls::opaque signature<0..2^16-1>;
 // } UserInitKey;
 struct UserInitKey
 {
   tls::vector<CipherSuite, 1> cipher_suites;
-  tls::variant_vector<DHPublicKey, CipherSuite, 2> init_keys;
-  SignaturePublicKey identity_key;
+  tls::vector<tls::opaque<2>, 2> init_keys; // Postpone crypto parsing
   SignatureScheme algorithm;
+  SignaturePublicKey identity_key;
   tls::opaque<2> signature;
 
   // XXX(rlb@ipv.sx): This is kind of inelegant, but we need a dummy

--- a/src/include/ratchet_tree.h
+++ b/src/include/ratchet_tree.h
@@ -72,7 +72,7 @@ public:
   bytes root_secret() const;
 
 private:
-  tls::variant_vector<RatchetNode, CipherSuite, 3> _nodes;
+  tls::variant_vector<RatchetNode, CipherSuite, 4> _nodes;
 
   RatchetNode new_node(const bytes& data) const;
   uint32_t working_size(uint32_t from) const;

--- a/src/include/roster.h
+++ b/src/include/roster.h
@@ -43,6 +43,7 @@ public:
   void add(const RawKeyCredential& public_key);
   void copy(uint32_t dst, uint32_t src);
   RawKeyCredential get(uint32_t index) const;
+  size_t size() const;
 
 private:
   tls::vector<RawKeyCredential, 4> _credentials;

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -52,4 +52,7 @@ private:
   CipherSuite cipher_suite() const;
 };
 
+// TODO(rlb@ipv.sx): Enable a session to be initialized from the
+// counterparty's UIK
+
 } // namespace mls

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -10,25 +10,8 @@ namespace mls {
 class Session
 {
 public:
-  // Create a session joined to an empty group
-  Session(const bytes& group_id,
-          CipherSuite suite,
+  Session(const CipherList& supported_ciphersuites,
           const SignaturePrivateKey& identity_priv);
-
-  // Create an unjoined session
-  Session(const SignaturePrivateKey& identity_priv);
-
-  // Create an unjoined session (and auto-generate the identity key)
-  Session();
-
-  // Negotiate a session with a second peer based on their
-  // UserInitKey
-  typedef std::pair<Session, std::pair<bytes, bytes>> InitialInfo;
-  static InitialInfo negotiate(
-    const bytes& group_id,
-    const std::vector<CipherSuite> supported_ciphersuites,
-    const SignaturePrivateKey& identity_priv,
-    const bytes& user_init_key);
 
   // Two sessions are considered equal if:
   // (1) they agree on the states they have in common
@@ -36,6 +19,9 @@ public:
   friend bool operator==(const Session& lhs, const Session& rhs);
 
   bytes user_init_key() const;
+
+  std::pair<bytes, bytes> start(const bytes& group_id,
+                                const bytes& user_init_key);
 
   std::pair<bytes, bytes> add(const bytes& user_init_key) const;
   bytes update();
@@ -47,6 +33,7 @@ public:
   epoch_t current_epoch() const { return _current_epoch; }
 
 private:
+  CipherList _supported_ciphersuites;
   bytes _next_leaf_secret;
   bytes _init_secret;
   tls::opaque<2> _user_init_key;

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -21,6 +21,15 @@ public:
   // Create an unjoined session (and auto-generate the identity key)
   Session();
 
+  // Negotiate a session with a second peer based on their
+  // UserInitKey
+  typedef std::pair<Session, std::pair<bytes, bytes>> InitialInfo;
+  static InitialInfo negotiate(
+    const bytes& group_id,
+    const std::vector<CipherSuite> supported_ciphersuites,
+    const SignaturePrivateKey& identity_priv,
+    const bytes& user_init_key);
+
   // Two sessions are considered equal if:
   // (1) they agree on the states they have in common
   // (2) they agree on the current epoch
@@ -51,8 +60,5 @@ private:
   const State& current_state() const;
   CipherSuite cipher_suite() const;
 };
-
-// TODO(rlb@ipv.sx): Enable a session to be initialized from the
-// counterparty's UIK
 
 } // namespace mls

--- a/src/include/state.h
+++ b/src/include/state.h
@@ -26,6 +26,15 @@ public:
         const Welcome& welcome,
         const Handshake& handshake);
 
+  // Negotiate an initial state with another peer based on their
+  // UserInitKey
+  typedef std::pair<State, std::pair<Welcome, Handshake>> InitialInfo;
+  static InitialInfo negotiate(
+    const bytes& group_id,
+    const std::vector<CipherSuite> supported_ciphersuites,
+    const SignaturePrivateKey& identity_priv,
+    const UserInitKey& user_init_key);
+
   ///
   /// Message factories
   ///
@@ -105,12 +114,5 @@ private:
   // Verify this state with the indicated public key
   bool verify(uint32_t signer_index, const bytes& signature) const;
 };
-
-typedef std::pair<State, std::pair<Welcome, Handshake>> InitialGroupInfo;
-InitialGroupInfo
-create_group(const bytes& group_id,
-             const std::vector<CipherSuite> supported_ciphersuites,
-             const SignaturePrivateKey& identity_priv,
-             const UserInitKey& user_init_key);
 
 } // namespace mls

--- a/src/include/state.h
+++ b/src/include/state.h
@@ -106,4 +106,11 @@ private:
   bool verify(uint32_t signer_index, const bytes& signature) const;
 };
 
+typedef std::pair<State, std::pair<Welcome, Handshake>> InitialGroupInfo;
+InitialGroupInfo
+create_group(const bytes& group_id,
+             const std::vector<CipherSuite> supported_ciphersuites,
+             const SignaturePrivateKey& identity_priv,
+             const UserInitKey& user_init_key);
+
 } // namespace mls

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -61,9 +61,10 @@ operator>>(tls::istream& in, UserInitKey& obj)
   in >> obj.cipher_suites >> obj.init_keys >> obj.algorithm;
 
   auto key = SignaturePublicKey(obj.algorithm);
+  in >> key;
   obj.identity_key = key;
 
-  in >> obj.identity_key >> obj.signature;
+  in >> obj.signature;
   return in;
 }
 
@@ -96,8 +97,11 @@ operator>>(tls::istream& in, Welcome& obj)
   // group
   obj.tree = RatchetTree(obj.cipher_suite);
 
-  in >> obj.roster >> obj.tree >> obj.transcript >> obj.init_secret >>
-    obj.leaf_secret;
+  in >> obj.roster;
+  in >> obj.tree;
+  in >> obj.transcript;
+  in >> obj.init_secret;
+  in >> obj.leaf_secret;
   return in;
 }
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -8,7 +8,7 @@ void
 UserInitKey::add_init_key(const DHPublicKey& pub)
 {
   cipher_suites.push_back(pub.cipher_suite());
-  init_keys.push_back(pub);
+  init_keys.push_back(pub.to_bytes());
 }
 
 void
@@ -35,7 +35,7 @@ bytes
 UserInitKey::to_be_signed() const
 {
   tls::ostream out;
-  out << cipher_suites << init_keys << identity_key << algorithm;
+  out << cipher_suites << init_keys << algorithm << identity_key;
   return out.bytes();
 }
 
@@ -51,37 +51,19 @@ operator==(const UserInitKey& lhs, const UserInitKey& rhs)
 tls::ostream&
 operator<<(tls::ostream& out, const UserInitKey& obj)
 {
-  return out << obj.cipher_suites << obj.init_keys << obj.identity_key
-             << obj.algorithm << obj.signature;
+  return out << obj.cipher_suites << obj.init_keys << obj.algorithm
+             << obj.identity_key << obj.signature;
 }
 
 tls::istream&
 operator>>(tls::istream& in, UserInitKey& obj)
 {
-  in >> obj.cipher_suites;
+  in >> obj.cipher_suites >> obj.init_keys >> obj.algorithm;
 
-  // The need to adapt the public key type per ciphersuite means we
-  // need to do a bit of manual decoding
-  tls::opaque<2> init_key_buffer;
-  in >> init_key_buffer;
-  tls::istream init_key_stream(init_key_buffer);
+  auto key = SignaturePublicKey(obj.algorithm);
+  obj.identity_key = key;
 
-  obj.init_keys.clear();
-  for (auto suite : obj.cipher_suites) {
-    DHPublicKey key(suite);
-    init_key_stream >> key;
-    obj.init_keys.push_back(key);
-  }
-
-  // XXX(rlb@ipv.sx) Because the algorithm comes after the key, we
-  // have to read the key as opaque bytes, then populate it once we
-  // know the algorithm.  We could fix this by reversing the order
-  // of these fields in the struct.
-  auto key_data = tls::opaque<2>();
-  in >> key_data >> obj.algorithm;
-  obj.identity_key = SignaturePublicKey(obj.algorithm, key_data);
-
-  in >> obj.signature;
+  in >> obj.identity_key >> obj.signature;
   return in;
 }
 

--- a/src/roster.cpp
+++ b/src/roster.cpp
@@ -11,13 +11,20 @@ operator==(const RawKeyCredential& lhs, const RawKeyCredential& rhs)
 tls::ostream&
 operator<<(tls::ostream& out, const RawKeyCredential& obj)
 {
-  return out << obj._key;
+  return out << obj._key.signature_scheme() << obj._key;
 }
 
 tls::istream&
 operator>>(tls::istream& in, RawKeyCredential& obj)
 {
-  return in >> obj._key;
+  SignatureScheme scheme;
+  in >> scheme;
+
+  SignaturePublicKey key(scheme);
+  in >> key;
+
+  obj._key = key;
+  return in;
 }
 
 void
@@ -50,6 +57,12 @@ RawKeyCredential
 Roster::get(uint32_t index) const
 {
   return _credentials[index];
+}
+
+size_t
+Roster::size() const
+{
+  return _credentials.size();
 }
 
 bool

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1,5 +1,7 @@
 #include "state.h"
 
+#include <iostream>
+
 namespace mls {
 
 ///
@@ -108,7 +110,7 @@ State::negotiate(const bytes& group_id,
 
   auto state = State{ group_id, suite, identity_priv };
   auto welcome_add = state.add(user_init_key);
-  state.handle(welcome_add.second);
+  state = state.handle(welcome_add.second);
 
   return InitialInfo(state, welcome_add);
 }
@@ -274,11 +276,14 @@ operator==(const State& lhs, const State& rhs)
             << std::endl
             << "_epoch " << epoch << " " << lhs._epoch << " " << rhs._epoch
             << std::endl
-            << "_group_id " << group_id << std::endl
-            << "_roster " << roster << std::endl
-            << "_tree " << ratchet_tree << std::endl
+            << "_group_id " << group_id << " " << lhs._group_id << " "
+            << rhs._group_id << std::endl
+            << "_roster " << roster << " " << lhs._roster.size() << " "
+            << rhs._roster.size() << std::endl
+            << "_tree " << ratchet_tree << " " << lhs._tree.size() << " "
+            << rhs._tree.size() << std::endl
             << "_message_master_secret " << message_master_secret << std::endl
-            << "_init_secret " << init_secret << std::endl
+            << "_init_secret " << init_secret << std::endl;
   */
 
   return epoch && group_id && roster && ratchet_tree && message_master_secret &&

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -41,8 +41,6 @@ TEST_CASE("Basic message serialization", "[messages]")
 
   SECTION("UserInitKey")
   {
-    std::cout << "uik: " << tls::marshal(user_init_key) << std::endl;
-
     REQUIRE(user_init_key.verify());
     UserInitKey after;
     tls_round_trip(user_init_key, after);

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -162,7 +162,7 @@ TEST_CASE("Operations on a running group", "[state]")
     auto group_id = from_hex("0001020304");
 
     // They should negotiate P-256
-    auto initial = create_group(group_id, supported_ciphers, idkB, uikA);
+    auto initial = State::negotiate(group_id, supported_ciphers, idkB, uikA);
     REQUIRE(initial.first.cipher_suite() == CipherSuite::P256_SHA256_AES128GCM);
   }
 }

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -144,10 +144,12 @@ TEST_CASE("Operations on a running group", "[state]")
 
   SECTION("Ciphersuite negotiation works")
   {
-    // Alice supports P-256 and X25516
+    // Alice supports P-256 and X25519
     auto idkA = SignaturePrivateKey::generate(SignatureScheme::Ed25519);
-    auto inkA1 = DHPrivateKey::generate(CipherSuite::P256_SHA256_AES128GCM);
-    auto inkA2 = DHPrivateKey::generate(CipherSuite::X25519_SHA256_AES128GCM);
+    auto insA = bytes{ 0, 1, 2, 3 };
+    auto inkA1 = DHPrivateKey::derive(CipherSuite::P256_SHA256_AES128GCM, insA);
+    auto inkA2 =
+      DHPrivateKey::derive(CipherSuite::X25519_SHA256_AES128GCM, insA);
 
     auto uikA = UserInitKey{};
     uikA.add_init_key(inkA1.public_key());
@@ -161,8 +163,15 @@ TEST_CASE("Operations on a running group", "[state]")
     auto idkB = SignaturePrivateKey::generate(SignatureScheme::Ed25519);
     auto group_id = from_hex("0001020304");
 
-    // They should negotiate P-256
-    auto initial = State::negotiate(group_id, supported_ciphers, idkB, uikA);
-    REQUIRE(initial.first.cipher_suite() == CipherSuite::P256_SHA256_AES128GCM);
+    // Bob should choose P-256
+    auto initialB = State::negotiate(group_id, supported_ciphers, idkB, uikA);
+    auto stateB = initialB.first;
+    REQUIRE(stateB.cipher_suite() == CipherSuite::P256_SHA256_AES128GCM);
+
+    // Alice should also arrive at P-256 when initialized
+    auto welcome = initialB.second.first;
+    auto add = initialB.second.second;
+    auto stateA = State(idkA, insA, welcome, add);
+    REQUIRE(stateA == stateB);
   }
 }


### PR DESCRIPTION
This PR includes a few loosely-related changes

* Fixes a bug where a UIK with an unknown ciphersuite would cause an exception
* Enables the creation of a `State` from capabilities + a UIK
* Refactors the session API to make negotiation a core part of session initiation
* Refactors the `PublicKey` / `PrivateKey` API to hold all permanent state (so the `DH` and `Signature` variants are really just there to add some methods)