### PR TITLE
Gtest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "third_party/openssl"]
 	path = third_party/openssl
 	url = http://github.com/openssl/openssl
+[submodule "third_party/googletest"]
+	path = third_party/googletest
+	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,22 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_subdirectory(third_party EXCLUDE_FROM_ALL)
 
+# Find OpenSSL
 set(OPENSSL_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/third_party/openssl/include")
 set(OPENSSL_LIBRARIES "${PROJECT_SOURCE_DIR}/third_party/openssl/libcrypto.a")
 
 MESSAGE( STATUS "OPENSSL_INCLUDE_DIR: " ${OPENSSL_INCLUDE_DIR} )
 MESSAGE( STATUS "OPENSSL_LIBRARIES: " ${OPENSSL_LIBRARIES} )
+
+# Find GTest
+set(GTEST_DIR "${PROJECT_SOURCE_DIR}/third_party/googletest/googletest")
+set(GTEST_INCLUDE_DIR "${GTEST_DIR}/include")
+set(GTEST_LIBRARY "${GTEST_DIR}/make/libgtest.a")
+set(GTEST_MAIN_LIBRARY "${GTEST_DIR}/make/libgtest_main.a")
+
+MESSAGE( STATUS "GTEST_INCLUDE_DIR: " ${GTEST_INCLUDE_DIR} )
+MESSAGE( STATUS "GTEST_LIBRARY: " ${GTEST_LIBRARY} )
+MESSAGE( STATUS "GTEST_MAIN_LIBRARY: " ${GTEST_MAIN_LIBRARY} )
 
 ###
 ### Library Config
@@ -44,4 +55,4 @@ target_link_libraries(mls ${OPENSSL_LIBRARIES})
 ###
 
 enable_testing()
-add_subdirectory(test)
+add_subdirectory(gtest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,4 +55,4 @@ target_link_libraries(mls ${OPENSSL_LIBRARIES})
 ###
 
 enable_testing()
-add_subdirectory(gtest)
+add_subdirectory(test)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ${BUILD_DIR}: CMakeLists.txt test/CMakeLists.txt third_party/CMakeLists.txt
 	cmake -H. -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug
 
 test: all
-	cd ${BUILD_DIR} && ctest -V
+	cd ${BUILD_DIR} && ctest
 
 clean:
 	rm -rf ${BUILD_DIR}

--- a/src/include/roster.h
+++ b/src/include/roster.h
@@ -53,7 +53,7 @@ public:
 class Roster
 {
 public:
-  void add(const RawKeyCredential& public_key);
+  void add(const RawKeyCredential& cred);
   void remove(uint32_t index);
   RawKeyCredential get(uint32_t index) const;
   size_t size() const;

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -31,6 +31,7 @@ public:
   void handle(const bytes& handshake);
 
   epoch_t current_epoch() const { return _current_epoch; }
+  CipherSuite cipher_suite() const;
 
 private:
   CipherList _supported_ciphersuites;
@@ -45,7 +46,6 @@ private:
   void add_state(epoch_t prior_epoch, const State& state);
   State& current_state();
   const State& current_state() const;
-  CipherSuite cipher_suite() const;
 };
 
 } // namespace mls

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,22 +1,21 @@
-# Depends on the following variables from the parent:
-#   PROJECT_SOURCE_DIR
-#   LIB_NAME
-#   LIBRARY_INCLUDE_PATH
-#   LIBRARY_PRIVATE_INCLUDE_PATH
+include(GoogleTest)
 
-set(TEST_APP_NAME "${LIB_NAME}_test")
-set(TEST_SRC_PATH "${PROJECT_SOURCE_DIR}/test")
+set(GTEST_APP_NAME "${LIB_NAME}_gtest")
+set(GTEST_SRC_PATH "${PROJECT_SOURCE_DIR}/gtest")
+set(GTEST_RUN_PATH "${PROJECT_SOURCE_DIR}/third_party/mls-implementations")
 
 include_directories(${LIBRARY_INCLUDE_PATH})
 include_directories(${LIBRARY_PRIVATE_INCLUDE_PATH})
-include_directories(${TEST_THIRD_PARTY_INCLUDE_PATH})
+include_directories(${GTEST_INCLUDE_DIR})
 
-file(GLOB TEST_SOURCE_FILES "${TEST_SRC_PATH}/*.cpp")
-set(TEST_SOURCE_FILES ${TEST_SOURCE_FILES} PARENT_SCOPE)
+file(GLOB GTEST_SOURCE_FILES "${GTEST_SRC_PATH}/*.cpp")
+set(GTEST_SOURCE_FILES ${GTEST_SOURCE_FILES} PARENT_SCOPE)
 
-add_executable(${TEST_APP_NAME} ${TEST_SOURCE_FILES})
-target_link_libraries(${TEST_APP_NAME} ${OPENSSL_LIBRARIES})
-target_link_libraries(${TEST_APP_NAME} ${LIB_NAME})
+add_executable(${GTEST_APP_NAME} ${GTEST_SOURCE_FILES})
+target_link_libraries(${GTEST_APP_NAME} ${OPENSSL_LIBRARIES})
+target_link_libraries(${GTEST_APP_NAME} ${LIB_NAME})
+target_link_libraries(${GTEST_APP_NAME} ${GTEST_LIBRARY})
+target_link_libraries(${GTEST_APP_NAME} ${GTEST_MAIN_LIBRARY})
 
-enable_testing()
-ParseAndAddCatchTests(${TEST_APP_NAME})
+gtest_discover_tests(${GTEST_APP_NAME}
+                     WORKING_DIRECTORY ${GTEST_RUN_PATH})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(GoogleTest)
 
 set(GTEST_APP_NAME "${LIB_NAME}_gtest")
-set(GTEST_SRC_PATH "${PROJECT_SOURCE_DIR}/gtest")
+set(GTEST_SRC_PATH "${PROJECT_SOURCE_DIR}/test")
 set(GTEST_RUN_PATH "${PROJECT_SOURCE_DIR}/third_party/mls-implementations")
 
 include_directories(${LIBRARY_INCLUDE_PATH})

--- a/test/crypto_test.cpp
+++ b/test/crypto_test.cpp
@@ -26,14 +26,18 @@ using namespace mls;
 //    * Ed25519     TODO https://tools.ietf.org/html/rfc8032#section-7.1
 //    * Ed448       TODO https://tools.ietf.org/html/rfc8032#section-7.4
 
-class CryptoTest : public ::testing::Test {
+class CryptoTest : public ::testing::Test
+{
 protected:
   // SHA-256 and SHA-512
-  const bytes sha2_in = from_hex("6162636462636465636465666465666765666768666768696768696a68696a6b6"
-                                "96a6b6c6a6b6c6d6b6c6d6e6c6d6e6f6d6e6f706e6f7071");
-  const bytes sha256_out = from_hex("248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
-  const bytes sha512_out = from_hex("204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a8279be331a703c3359"
-                                    "6fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445");
+  const bytes sha2_in =
+    from_hex("6162636462636465636465666465666765666768666768696768696a68696a6b6"
+             "96a6b6c6a6b6c6d6b6c6d6e6c6d6e6f6d6e6f706e6f7071");
+  const bytes sha256_out = from_hex(
+    "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
+  const bytes sha512_out =
+    from_hex("204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a8279be331a703c3359"
+             "6fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445");
 
   // AES-GCM
   // https://tools.ietf.org/html/draft-mcgrew-gcm-test-01#section-4
@@ -65,7 +69,6 @@ protected:
                                       "ef842d8eb335f4eecfdbf831824b4c49"
                                       "15956c96");
 };
-
 
 TEST_F(CryptoTest, SHA2)
 {

--- a/test/crypto_test.cpp
+++ b/test/crypto_test.cpp
@@ -1,5 +1,6 @@
 #include "crypto.h"
-#include <catch.hpp>
+#include <gtest/gtest.h>
+#include <iostream>
 #include <string>
 
 using namespace mls;
@@ -25,100 +26,98 @@ using namespace mls;
 //    * Ed25519     TODO https://tools.ietf.org/html/rfc8032#section-7.1
 //    * Ed448       TODO https://tools.ietf.org/html/rfc8032#section-7.4
 
-TEST_CASE("SHA-256 hash produces correct values", "[crypto]")
-{
-  // https://www.di-mgt.com.au/sha_testvectors.html
-  auto input =
-    from_hex("6162636462636465636465666465666765666768666768696768696a68696a6b6"
-             "96a6b6c6a6b6c6d6b6c6d6e6c6d6e6f6d6e6f706e6f7071");
-  auto out256 = from_hex(
-    "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
-  auto out512 =
-    from_hex("204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a8279be331a703c3359"
-             "6fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445");
+class CryptoTest : public ::testing::Test {
+protected:
+  // SHA-256 and SHA-512
+  const bytes sha2_in = from_hex("6162636462636465636465666465666765666768666768696768696a68696a6b6"
+                                "96a6b6c6a6b6c6d6b6c6d6e6c6d6e6f6d6e6f706e6f7071");
+  const bytes sha256_out = from_hex("248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
+  const bytes sha512_out = from_hex("204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a8279be331a703c3359"
+                                    "6fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445");
 
-  REQUIRE(Digest(DigestType::SHA256).write(input).digest() == out256);
-  REQUIRE(Digest(DigestType::SHA512).write(input).digest() == out512);
-}
-
-TEST_CASE("AES-GCM encryption produces correct values", "[crypto]")
-{
+  // AES-GCM
   // https://tools.ietf.org/html/draft-mcgrew-gcm-test-01#section-4
-  auto key128 = from_hex("4c80cdefbb5d10da906ac73c3613a634");
-  auto nonce128 = from_hex("2e443b684956ed7e3b244cfe");
-  auto aad128 = from_hex("000043218765432100000000");
-  auto plaintext128 = from_hex("45000048699a000080114db7c0a80102"
-                               "c0a801010a9bf15638d3010000010000"
-                               "00000000045f736970045f7564700373"
-                               "69700963796265726369747902646b00"
-                               "0021000101020201");
-  auto ciphertext128 = from_hex("fecf537e729d5b07dc30df528dd22b76"
-                                "8d1b98736696a6fd348509fa13ceac34"
-                                "cfa2436f14a3f3cf65925bf1f4a13c5d"
-                                "15b21e1884f5ff6247aeabb786b93bce"
-                                "61bc17d768fd9732459018148f6cbe72"
-                                "2fd04796562dfdb4");
+  const bytes aes128gcm_key = from_hex("4c80cdefbb5d10da906ac73c3613a634");
+  const bytes aes128gcm_nonce = from_hex("2e443b684956ed7e3b244cfe");
+  const bytes aes128gcm_aad = from_hex("000043218765432100000000");
+  const bytes aes128gcm_pt = from_hex("45000048699a000080114db7c0a80102"
+                                      "c0a801010a9bf15638d3010000010000"
+                                      "00000000045f736970045f7564700373"
+                                      "69700963796265726369747902646b00"
+                                      "0021000101020201");
+  const bytes aes128gcm_ct = from_hex("fecf537e729d5b07dc30df528dd22b76"
+                                      "8d1b98736696a6fd348509fa13ceac34"
+                                      "cfa2436f14a3f3cf65925bf1f4a13c5d"
+                                      "15b21e1884f5ff6247aeabb786b93bce"
+                                      "61bc17d768fd9732459018148f6cbe72"
+                                      "2fd04796562dfdb4");
+  const bytes aes256gcm_key = from_hex("abbccddef00112233445566778899aab"
+                                       "abbccddef00112233445566778899aab");
+  const bytes aes256gcm_nonce = from_hex("112233440102030405060708");
+  const bytes aes256gcm_aad = from_hex("4a2cbfe300000002");
+  const bytes aes256gcm_pt = from_hex("4500003069a6400080062690c0a80102"
+                                      "9389155e0a9e008b2dc57ee000000000"
+                                      "7002400020bf0000020405b401010402"
+                                      "01020201");
+  const bytes aes256gcm_ct = from_hex("ff425c9b724599df7a3bcd510194e00d"
+                                      "6a78107f1b0b1cbf06efae9d65a5d763"
+                                      "748a637985771d347f0545659f14e99d"
+                                      "ef842d8eb335f4eecfdbf831824b4c49"
+                                      "15956c96");
+};
 
-  auto key256 = from_hex("abbccddef00112233445566778899aab"
-                         "abbccddef00112233445566778899aab");
-  auto nonce256 = from_hex("112233440102030405060708");
-  auto aad256 = from_hex("4a2cbfe300000002");
-  auto plaintext256 = from_hex("4500003069a6400080062690c0a80102"
-                               "9389155e0a9e008b2dc57ee000000000"
-                               "7002400020bf0000020405b401010402"
-                               "01020201");
-  auto ciphertext256 = from_hex("ff425c9b724599df7a3bcd510194e00d"
-                                "6a78107f1b0b1cbf06efae9d65a5d763"
-                                "748a637985771d347f0545659f14e99d"
-                                "ef842d8eb335f4eecfdbf831824b4c49"
-                                "15956c96");
 
-  SECTION("For encryption")
-  {
-    AESGCM gcm128(key128, nonce128);
-    gcm128.set_aad(aad128);
-    REQUIRE(gcm128.encrypt(plaintext128) == ciphertext128);
-
-    AESGCM gcm256(key256, nonce256);
-    gcm256.set_aad(aad256);
-    REQUIRE(gcm256.encrypt(plaintext256) == ciphertext256);
-  }
-
-  SECTION("For decryption")
-  {
-    AESGCM gcm128(key128, nonce128);
-    gcm128.set_aad(aad128);
-    REQUIRE(gcm128.decrypt(ciphertext128) == plaintext128);
-
-    AESGCM gcm256(key256, nonce256);
-    gcm256.set_aad(aad256);
-    REQUIRE(gcm256.decrypt(ciphertext256) == plaintext256);
-  }
-
-  SECTION("For an encrypt/decrypt round-trip (128 bits)")
-  {
-    std::vector<size_t> key_sizes = { AESGCM::key_size_128,
-                                      AESGCM::key_size_256 };
-    for (auto key_size : key_sizes) {
-      auto key = random_bytes(AESGCM::key_size_128);
-      auto nonce = random_bytes(AESGCM::nonce_size);
-      auto aad = random_bytes(100);
-      auto original = random_bytes(100);
-
-      AESGCM gcm1(key, nonce);
-      gcm1.set_aad(aad);
-      auto encrypted = gcm1.encrypt(original);
-
-      AESGCM gcm2(key, nonce);
-      gcm2.set_aad(aad);
-      auto decrypted = gcm2.decrypt(encrypted);
-
-      REQUIRE(decrypted == original);
-    }
-  }
+TEST_F(CryptoTest, SHA2)
+{
+  ASSERT_EQ(Digest(DigestType::SHA256).write(sha2_in).digest(), sha256_out);
+  ASSERT_EQ(Digest(DigestType::SHA512).write(sha2_in).digest(), sha512_out);
 }
 
-TEST_CASE("Diffie-Hellman key pairs can be created and combined", "[crypto]")
+TEST_F(CryptoTest, AES128GCM)
+{
+  AESGCM enc(aes128gcm_key, aes128gcm_nonce);
+  enc.set_aad(aes128gcm_aad);
+  ASSERT_EQ(enc.encrypt(aes128gcm_pt), aes128gcm_ct);
+
+  AESGCM dec(aes128gcm_key, aes128gcm_nonce);
+  dec.set_aad(aes128gcm_aad);
+  ASSERT_EQ(dec.decrypt(aes128gcm_ct), aes128gcm_pt);
+
+  auto rtt_key = random_bytes(AESGCM::key_size_128);
+  auto rtt_nonce = random_bytes(AESGCM::nonce_size);
+  auto rtt_aad = random_bytes(100);
+  auto rtt_pt = random_bytes(100);
+
+  AESGCM rtt_enc(rtt_key, rtt_nonce);
+  AESGCM rtt_dec(rtt_key, rtt_nonce);
+  rtt_enc.set_aad(rtt_aad);
+  rtt_dec.set_aad(rtt_aad);
+  ASSERT_EQ(rtt_dec.decrypt(rtt_dec.encrypt(rtt_pt)), rtt_pt);
+}
+
+TEST_F(CryptoTest, AES256GCM)
+{
+  AESGCM enc(aes256gcm_key, aes256gcm_nonce);
+  enc.set_aad(aes256gcm_aad);
+  ASSERT_EQ(enc.encrypt(aes256gcm_pt), aes256gcm_ct);
+
+  AESGCM dec(aes256gcm_key, aes256gcm_nonce);
+  dec.set_aad(aes256gcm_aad);
+  ASSERT_EQ(dec.decrypt(aes256gcm_ct), aes256gcm_pt);
+
+  auto rtt_key = random_bytes(AESGCM::key_size_256);
+  auto rtt_nonce = random_bytes(AESGCM::nonce_size);
+  auto rtt_aad = random_bytes(100);
+  auto rtt_pt = random_bytes(100);
+
+  AESGCM rtt_enc(rtt_key, rtt_nonce);
+  AESGCM rtt_dec(rtt_key, rtt_nonce);
+  rtt_enc.set_aad(rtt_aad);
+  rtt_dec.set_aad(rtt_aad);
+  ASSERT_EQ(rtt_dec.decrypt(rtt_dec.encrypt(rtt_pt)), rtt_pt);
+}
+
+TEST_F(CryptoTest, BasicDH)
 {
   std::vector<CipherSuite> suites{ CipherSuite::P256_SHA256_AES128GCM,
                                    CipherSuite::P521_SHA512_AES256GCM,
@@ -129,23 +128,23 @@ TEST_CASE("Diffie-Hellman key pairs can be created and combined", "[crypto]")
     auto x = DHPrivateKey::generate(suite);
     auto y = DHPrivateKey::derive(suite, { 0, 1, 2, 3 });
 
-    REQUIRE(x == x);
-    REQUIRE(y == y);
-    REQUIRE(x != y);
+    ASSERT_EQ(x, x);
+    ASSERT_EQ(y, y);
+    ASSERT_NE(x, y);
 
     auto gX = x.public_key();
     auto gY = y.public_key();
-    REQUIRE(gX == gX);
-    REQUIRE(gY == gY);
-    REQUIRE(gX != gY);
+    ASSERT_EQ(gX, gX);
+    ASSERT_EQ(gY, gY);
+    ASSERT_NE(gX, gY);
 
     auto gXY = x.derive(gY);
     auto gYX = y.derive(gX);
-    REQUIRE(gXY == gYX);
+    ASSERT_EQ(gXY, gYX);
   }
 }
 
-TEST_CASE("Diffie-Hellman public keys serialize and deserialize", "[crypto]")
+TEST_F(CryptoTest, DHSerialize)
 {
   std::vector<CipherSuite> suites{ CipherSuite::P256_SHA256_AES128GCM,
                                    CipherSuite::P521_SHA512_AES256GCM,
@@ -156,22 +155,16 @@ TEST_CASE("Diffie-Hellman public keys serialize and deserialize", "[crypto]")
     auto x = DHPrivateKey::derive(suite, { 0, 1, 2, 3 });
     auto gX = x.public_key();
 
-    SECTION("Directly")
-    {
-      DHPublicKey parsed(suite, gX.to_bytes());
-      REQUIRE(parsed == gX);
-    }
+    DHPublicKey parsed(suite, gX.to_bytes());
+    ASSERT_EQ(parsed, gX);
 
-    SECTION("Via TLS syntax")
-    {
-      DHPublicKey gX2(suite);
-      tls::unmarshal(tls::marshal(gX), gX2);
-      REQUIRE(gX2 == gX);
-    }
+    DHPublicKey gX2(suite);
+    tls::unmarshal(tls::marshal(gX), gX2);
+    ASSERT_EQ(gX2, gX);
   }
 }
 
-TEST_CASE("Diffie-Hellman key pairs encrypt and decrypt ECIES", "[crypto]")
+TEST_F(CryptoTest, ECIES)
 {
   std::vector<CipherSuite> suites{ CipherSuite::P256_SHA256_AES128GCM,
                                    CipherSuite::P521_SHA512_AES256GCM,
@@ -186,11 +179,11 @@ TEST_CASE("Diffie-Hellman key pairs encrypt and decrypt ECIES", "[crypto]")
     auto encrypted = gX.encrypt(original);
     auto decrypted = x.decrypt(encrypted);
 
-    REQUIRE(original == decrypted);
+    ASSERT_EQ(original, decrypted);
   }
 }
 
-TEST_CASE("Signature key pairs can sign and verify", "[crypto]")
+TEST_F(CryptoTest, BasicSignature)
 {
   std::vector<SignatureScheme> schemes{ SignatureScheme::P256_SHA256,
                                         SignatureScheme::P521_SHA512,
@@ -201,22 +194,22 @@ TEST_CASE("Signature key pairs can sign and verify", "[crypto]")
     auto a = SignaturePrivateKey::generate(scheme);
     auto b = SignaturePrivateKey::generate(scheme);
 
-    REQUIRE(a == a);
-    REQUIRE(b == b);
-    REQUIRE(a != b);
+    ASSERT_EQ(a, a);
+    ASSERT_EQ(b, b);
+    ASSERT_NE(a, b);
 
-    REQUIRE(a.public_key() == a.public_key());
-    REQUIRE(b.public_key() == b.public_key());
-    REQUIRE(a.public_key() != b.public_key());
+    ASSERT_EQ(a.public_key(), a.public_key());
+    ASSERT_EQ(b.public_key(), b.public_key());
+    ASSERT_NE(a.public_key(), b.public_key());
 
     auto message = from_hex("01020304");
     auto signature = a.sign(message);
 
-    REQUIRE(a.public_key().verify(message, signature));
+    ASSERT_TRUE(a.public_key().verify(message, signature));
   }
 }
 
-TEST_CASE("Signature public keys serialize and deserialize", "[crypto]")
+TEST_F(CryptoTest, SignatureSerialize)
 {
   std::vector<SignatureScheme> schemes{
     SignatureScheme::P256_SHA256,
@@ -229,17 +222,11 @@ TEST_CASE("Signature public keys serialize and deserialize", "[crypto]")
     auto x = SignaturePrivateKey::generate(scheme);
     auto gX = x.public_key();
 
-    SECTION("Directly")
-    {
-      SignaturePublicKey parsed(scheme, gX.to_bytes());
-      REQUIRE(parsed == gX);
-    }
+    SignaturePublicKey parsed(scheme, gX.to_bytes());
+    ASSERT_EQ(parsed, gX);
 
-    SECTION("Via TLS syntax")
-    {
-      SignaturePublicKey gX2(scheme);
-      tls::unmarshal(tls::marshal(gX), gX2);
-      REQUIRE(gX2 == gX);
-    }
+    SignaturePublicKey gX2(scheme);
+    tls::unmarshal(tls::marshal(gX), gX2);
+    ASSERT_EQ(gX2, gX);
   }
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,2 +1,0 @@
-#define CATCH_CONFIG_MAIN
-#include <catch.hpp>

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -1,92 +1,103 @@
 #include "messages.h"
 #include "tls_syntax.h"
-#include <catch.hpp>
+#include <gtest/gtest.h>
 
 using namespace mls;
-
-#define P256_SUITE CipherSuite::P256_SHA256_AES128GCM
-#define X25519_SUITE CipherSuite::X25519_SHA256_AES128GCM
-#define SIG_TEST SignatureScheme::P256_SHA256
 
 template<typename T>
 void
 tls_round_trip(const T& before, T& after)
 {
   tls::unmarshal(tls::marshal(before), after);
-  REQUIRE(before == after);
+  ASSERT_EQ(before, after);
 }
 
 static const epoch_t epoch_val = 0x01020304;
 
-TEST_CASE("Basic message serialization", "[messages]")
-{
-  auto suite = P256_SUITE;
-  auto random = random_bytes(32);
-  auto identity_priv = SignaturePrivateKey::generate(SIG_TEST);
-  auto identity_pub = identity_priv.public_key();
-  auto dh_pub_p256 = DHPrivateKey::generate(P256_SUITE).public_key();
-  auto dh_pub_x25519 = DHPrivateKey::generate(X25519_SUITE).public_key();
+class MessagesTest : public ::testing::Test {
+protected:
+  const CipherSuite suite = CipherSuite::P256_SHA256_AES128GCM;
+  const SignatureScheme scheme = SignatureScheme::P256_SHA256;
 
-  RatchetTree ratchet_tree{ P256_SUITE, { random, random } };
-  auto ratchet_path = ratchet_tree.encrypt(0, random);
-
-  RawKeyCredential cred{ identity_pub };
-  Roster roster;
-  roster.add(cred);
-
+  bytes random;
   UserInitKey user_init_key;
-  user_init_key.add_init_key(dh_pub_p256);
-  user_init_key.add_init_key(dh_pub_x25519);
-  user_init_key.sign(identity_priv);
+  Roster roster;
+  RatchetTree ratchet_tree;
+  DirectPath direct_path;
 
-  SECTION("UserInitKey")
+  MessagesTest()
+    : random(random_bytes(32))
+    , ratchet_tree(suite)
+    , direct_path(suite)
   {
-    REQUIRE(user_init_key.verify());
-    UserInitKey after;
-    tls_round_trip(user_init_key, after);
-    REQUIRE(after.verify());
-  }
+    auto identity_priv = SignaturePrivateKey::generate(scheme);
+    auto identity_pub = identity_priv.public_key();
 
-  SECTION("Welcome")
-  {
-    Welcome before{ random, 0x42, suite, roster, ratchet_tree, {}, random };
-    Welcome after;
-    tls_round_trip(before, after);
-  }
+    auto p256 = CipherSuite::P256_SHA256_AES128GCM;
+    auto x25519 = CipherSuite::X25519_SHA256_AES128GCM;
+    auto dh_pub_p256 = DHPrivateKey::generate(p256).public_key();
+    auto dh_pub_x25519 = DHPrivateKey::generate(x25519).public_key();
 
-  SECTION("GroupOperationType")
-  {
-    GroupOperationType before = GroupOperationType::update;
-    GroupOperationType after;
-    tls_round_trip(before, after);
-  }
+    ratchet_tree = RatchetTree{ suite, { random, random } };
+    direct_path = ratchet_tree.encrypt(0, random);
 
-  SECTION("Add")
-  {
-    auto before = Add{ user_init_key };
-    auto after = Add{};
-    tls_round_trip(before, after);
-  }
+    RawKeyCredential cred{ identity_pub };
+    roster.add(cred);
 
-  SECTION("Update")
-  {
-    auto before = Update{ ratchet_path };
-    auto after = Update{ P256_SUITE };
-    tls_round_trip(before, after);
+    user_init_key.add_init_key(dh_pub_p256);
+    user_init_key.add_init_key(dh_pub_x25519);
+    user_init_key.sign(identity_priv);
   }
+};
 
-  SECTION("Remove")
-  {
-    auto before = Remove{ 0x42, ratchet_path };
-    auto after = Remove{ P256_SUITE };
-    tls_round_trip(before, after);
-  }
+TEST_F(MessagesTest, UserInitKey)
+{
+  ASSERT_TRUE(user_init_key.verify());
+  UserInitKey after;
+  tls_round_trip(user_init_key, after);
+  ASSERT_TRUE(after.verify());
+}
 
-  SECTION("Handshake")
-  {
-    auto add = Add{ user_init_key };
-    auto before = Handshake{ 0x42, add, 0x43, random };
-    auto after = Handshake{ P256_SUITE };
-    tls_round_trip(before, after);
-  }
+TEST_F(MessagesTest, Welcome)
+{
+  Welcome before{ random,       0x42, suite,  roster,
+                  ratchet_tree, {},   random };
+  Welcome after;
+  tls_round_trip(before, after);
+}
+
+TEST_F(MessagesTest, GroupOperationType)
+{
+  GroupOperationType before = GroupOperationType::update;
+  GroupOperationType after;
+  tls_round_trip(before, after);
+}
+
+TEST_F(MessagesTest, Add)
+{
+  auto before = Add{ user_init_key };
+  auto after = Add{};
+  tls_round_trip(before, after);
+}
+
+TEST_F(MessagesTest, Update)
+{
+  auto before = Update{ direct_path };
+  auto after = Update{ suite };
+  tls_round_trip(before, after);
+}
+
+TEST_F(MessagesTest, Remove)
+{
+  auto before = Remove{ 0x42, direct_path };
+  auto after = Remove{ suite };
+  tls_round_trip(before, after);
+}
+
+TEST_F(MessagesTest, Handshake)
+{
+  auto add = Add{ user_init_key };
+  auto before = Handshake{ 0x42, add, 0x43, random };
+  auto after = Handshake{ suite };
+  tls_round_trip(before, after);
 }

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -14,7 +14,8 @@ tls_round_trip(const T& before, T& after)
 
 static const epoch_t epoch_val = 0x01020304;
 
-class MessagesTest : public ::testing::Test {
+class MessagesTest : public ::testing::Test
+{
 protected:
   const CipherSuite suite = CipherSuite::P256_SHA256_AES128GCM;
   const SignatureScheme scheme = SignatureScheme::P256_SHA256;
@@ -60,8 +61,7 @@ TEST_F(MessagesTest, UserInitKey)
 
 TEST_F(MessagesTest, Welcome)
 {
-  Welcome before{ random,       0x42, suite,  roster,
-                  ratchet_tree, {},   random };
+  Welcome before{ random, 0x42, suite, roster, ratchet_tree, {}, random };
   Welcome after;
   tls_round_trip(before, after);
 }

--- a/test/ratchet_tree_test.cpp
+++ b/test/ratchet_tree_test.cpp
@@ -1,11 +1,12 @@
-#include "ratchet_tree.h"
 #include "messages.h"
+#include "ratchet_tree.h"
 #include "tls_syntax.h"
 #include <gtest/gtest.h>
 
 using namespace mls;
 
-class RatchetTreeTest : public ::testing::Test {
+class RatchetTreeTest : public ::testing::Test
+{
 protected:
   const CipherSuite ciphersuite = CipherSuite::P256_SHA256_AES128GCM;
 
@@ -41,26 +42,26 @@ TEST_F(RatchetTreeTest, ByExtension)
 {
   RatchetTree tree{ ciphersuite, secretA };
 
-    tree.add_leaf(secretB);
-    tree.set_path(1, secretB);
+  tree.add_leaf(secretB);
+  tree.set_path(1, secretB);
 
-    ASSERT_EQ(tree.size(), 2);
-    ASSERT_EQ(tree.root_secret(), secretAB);
+  ASSERT_EQ(tree.size(), 2);
+  ASSERT_EQ(tree.root_secret(), secretAB);
 
-    tree.add_leaf(secretC);
-    tree.set_path(2, secretC);
+  tree.add_leaf(secretC);
+  tree.set_path(2, secretC);
 
-    ASSERT_EQ(tree.size(), 3);
-    ASSERT_EQ(tree.root_secret(), secretABC);
+  ASSERT_EQ(tree.size(), 3);
+  ASSERT_EQ(tree.root_secret(), secretABC);
 
-    tree.add_leaf(secretD);
-    tree.set_path(3, secretD);
+  tree.add_leaf(secretD);
+  tree.set_path(3, secretD);
 
-    ASSERT_EQ(tree.size(), 4);
-    ASSERT_EQ(tree.root_secret(), secretABCD);
+  ASSERT_EQ(tree.size(), 4);
+  ASSERT_EQ(tree.root_secret(), secretABCD);
 
-    RatchetTree direct{ ciphersuite, { secretA, secretB, secretC, secretD } };
-    ASSERT_EQ(tree, direct);
+  RatchetTree direct{ ciphersuite, { secretA, secretB, secretC, secretD } };
+  ASSERT_EQ(tree, direct);
 }
 
 TEST_F(RatchetTreeTest, BySerialization)

--- a/test/roster_test.cpp
+++ b/test/roster_test.cpp
@@ -1,19 +1,19 @@
 #include "roster.h"
-#include <catch.hpp>
+#include <gtest/gtest.h>
 
 using namespace mls;
 
-#define SIG_TEST SignatureScheme::P256_SHA256
-
-TEST_CASE("Rosters can be created and accessed", "[roster]")
+TEST(RosterTest, Basic)
 {
-  auto priv = SignaturePrivateKey::generate(SIG_TEST);
+  auto scheme = SignatureScheme::P256_SHA256;
+  auto priv = SignaturePrivateKey::generate(scheme);
   auto pub = priv.public_key();
 
   RawKeyCredential cred{ pub };
-  REQUIRE(cred.public_key() == pub);
+  ASSERT_EQ(cred.public_key(), pub);
 
   Roster roster;
+  // TODO(rlb@ipv.sx): Continue
   // roster.put(0, cred);
   // REQUIRE(roster.get(0).public_key() == pub);
 }

--- a/test/roster_test.cpp
+++ b/test/roster_test.cpp
@@ -13,7 +13,14 @@ TEST(RosterTest, Basic)
   ASSERT_EQ(cred.public_key(), pub);
 
   Roster roster;
-  // TODO(rlb@ipv.sx): Continue
-  // roster.put(0, cred);
-  // REQUIRE(roster.get(0).public_key() == pub);
+  roster.add(cred);
+  roster.add(cred);
+  ASSERT_EQ(roster.size(), 2);
+  ASSERT_EQ(roster.get(0), cred);
+  ASSERT_EQ(roster.get(1), cred);
+
+  roster.remove(1);
+  ASSERT_EQ(roster.size(), 2);
+  ASSERT_EQ(roster.get(0), cred);
+  ASSERT_THROW(roster.get(1), InvalidParameterError);
 }

--- a/test/session_test.cpp
+++ b/test/session_test.cpp
@@ -1,159 +1,147 @@
 #include "session.h"
-#include <catch.hpp>
+#include <gtest/gtest.h>
 
 using namespace mls;
 
-const CipherList ciphersuites{ CipherSuite::P256_SHA256_AES128GCM,
-                               CipherSuite::X25519_SHA256_AES128GCM };
+class SessionTest : public ::testing::Test {
+protected:
+  const CipherList suites{ CipherSuite::P256_SHA256_AES128GCM,
+                           CipherSuite::X25519_SHA256_AES128GCM };
+  const SignatureScheme scheme = SignatureScheme::Ed25519;
+  const size_t group_size = 5;
+  const bytes group_id = {0, 1, 2, 3};
 
-SignaturePrivateKey
-new_identity_key()
-{
-  return SignaturePrivateKey::generate(SignatureScheme::Ed25519);
-}
-
-const size_t group_size = 5;
-const bytes group_id{ 0, 1, 2, 3 };
-
-void
-broadcast(std::vector<Session>& sessions, const bytes& message)
-{
-  for (auto& session : sessions) {
-    session.handle(message);
-  }
-}
-
-void
-broadcast_add(std::vector<Session>& sessions)
-{
-  Session next{ ciphersuites, new_identity_key() };
-  auto last = sessions.size() - 1;
-  std::pair<bytes, bytes> welcome_add;
-
-  // Initial add is different
-  if (sessions.size() == 1) {
-    welcome_add = sessions[last].start(group_id, next.user_init_key());
-    next.join(welcome_add.first, welcome_add.second);
-    sessions.push_back(next);
-    return;
-  }
-
-  welcome_add = sessions[last].add(next.user_init_key());
-  next.join(welcome_add.first, welcome_add.second);
-  broadcast(sessions, welcome_add.second);
-  sessions.push_back(next);
-}
-
-void
-check(std::vector<Session> sessions, epoch_t initial_epoch)
-{
-  // Verify that everyone ended up in consistent states
-  for (const auto& session : sessions) {
-    REQUIRE(session == sessions[0]);
-  }
-
-  // Verify that the epoch got updated
-  REQUIRE(sessions[0].current_epoch() != initial_epoch);
-}
-
-TEST_CASE("Session creation", "[session]")
-{
   std::vector<Session> sessions;
-  sessions.push_back({ ciphersuites, new_identity_key() });
 
-  SECTION("Two person")
-  {
+  SessionTest() {
+    sessions.push_back({ suites, new_identity_key() });
+  }
+
+  SignaturePrivateKey new_identity_key() {
+    return SignaturePrivateKey::generate(scheme);
+  }
+
+  void broadcast(const bytes& message) {
     auto initial_epoch = sessions[0].current_epoch();
-    broadcast_add(sessions);
-    check(sessions, initial_epoch);
-  }
-
-  SECTION("Full-size")
-  {
-    for (int i = 0; i < group_size - 1; i += 1) {
-      auto initial_epoch = sessions[0].current_epoch();
-      broadcast_add(sessions);
-      check(sessions, initial_epoch);
+    for (auto& session : sessions) {
+      session.handle(message);
     }
+    check(initial_epoch);
   }
 
-  SECTION("With Ciphersuite Negotiation")
-  {
-    // Alice supports P-256 and X25519
-    Session alice{ { CipherSuite::P256_SHA256_AES128GCM,
-                     CipherSuite::X25519_SHA256_AES128GCM },
-                   new_identity_key() };
+  void broadcast_add() {
+    auto initial_epoch = sessions[0].current_epoch();
+    Session next{ suites, new_identity_key() };
+    auto last = sessions.size() - 1;
+    std::pair<bytes, bytes> welcome_add;
 
-    // Bob supports P-256 and P-521
-    Session bob{ { CipherSuite::P256_SHA256_AES128GCM,
+    // Initial add is different
+    if (sessions.size() == 1) {
+      welcome_add = sessions[last].start(group_id, next.user_init_key());
+      next.join(welcome_add.first, welcome_add.second);
+      sessions.push_back(next);
+      // NB: Don't check epoch change, because it doesn't
+      return;
+    }
+
+    welcome_add = sessions[last].add(next.user_init_key());
+    next.join(welcome_add.first, welcome_add.second);
+    broadcast(welcome_add.second);
+    sessions.push_back(next);
+    check(initial_epoch);
+  }
+
+  void check(epoch_t initial_epoch) const {
+    // Verify that everyone ended up in consistent states
+    for (const auto& session : sessions) {
+      ASSERT_EQ(session, sessions[0]);
+    }
+
+    // Verify that the epoch got updated
+    ASSERT_NE(sessions[0].current_epoch(), initial_epoch);
+  }
+};
+
+TEST_F(SessionTest, CreateTwoPerson)
+{
+  broadcast_add();
+}
+
+TEST_F(SessionTest, CreateFullSize)
+{
+  for (int i = 0; i < group_size - 1; i += 1) {
+    broadcast_add();
+  }
+}
+
+TEST_F(SessionTest, CiphersuiteNegotiation)
+{
+  // Alice supports P-256 and X25519
+  Session alice{ { CipherSuite::P256_SHA256_AES128GCM,
                    CipherSuite::X25519_SHA256_AES128GCM },
                  new_identity_key() };
 
-    auto welcome_add = alice.start({ 0, 1, 2, 3 }, bob.user_init_key());
-    bob.join(welcome_add.first, welcome_add.second);
-    REQUIRE(alice == bob);
-  }
+  // Bob supports P-256 and P-521
+  Session bob{ { CipherSuite::P256_SHA256_AES128GCM,
+                 CipherSuite::X25519_SHA256_AES128GCM },
+               new_identity_key() };
+
+  auto welcome_add = alice.start({ 0, 1, 2, 3 }, bob.user_init_key());
+  bob.join(welcome_add.first, welcome_add.second);
+  ASSERT_EQ(alice, bob);
+  ASSERT_EQ(alice.cipher_suite(), CipherSuite::P256_SHA256_AES128GCM);
 }
 
-TEST_CASE("Session update and removal", "[session]")
-{
-  std::vector<Session> sessions;
-  sessions.push_back({ ciphersuites, new_identity_key() });
-
-  for (int i = 0; i < group_size - 1; i += 1) {
-    auto initial_epoch = sessions[0].current_epoch();
-    broadcast_add(sessions);
-    check(sessions, initial_epoch);
-  }
-
-  SECTION("Update")
+class RunningSessionTest : public SessionTest {
+protected:
+  RunningSessionTest()
+    : SessionTest()
   {
-    for (int i = 0; i < group_size; i += 1) {
-      auto initial_epoch = sessions[0].current_epoch();
-      auto update = sessions[i].update();
-      broadcast(sessions, update);
-      check(sessions, initial_epoch);
+    for (int i = 0; i < group_size - 1; i += 1) {
+      broadcast_add();
     }
   }
+};
 
-  SECTION("Removal")
-  {
-    for (int i = group_size - 1; i > 0; i -= 1) {
-      auto initial_epoch = sessions[0].current_epoch();
-      auto remove = sessions[i - 1].remove(i);
-      sessions.pop_back();
-      broadcast(sessions, remove);
-      check(sessions, initial_epoch);
-    }
-  }
-}
-
-TEST_CASE("Full life-cycle", "[session]")
+TEST_F(RunningSessionTest, Update)
 {
-  std::vector<Session> sessions;
-  sessions.push_back({ ciphersuites, new_identity_key() });
-
-  // Create the group
-  for (int i = 0; i < group_size - 1; i += 1) {
-    auto initial_epoch = sessions[0].current_epoch();
-    broadcast_add(sessions);
-    check(sessions, initial_epoch);
-  }
-
-  // Have everyone update
-  for (int i = 0; i < group_size - 1; i += 1) {
+  for (int i = 0; i < group_size; i += 1) {
     auto initial_epoch = sessions[0].current_epoch();
     auto update = sessions[i].update();
-    broadcast(sessions, update);
-    check(sessions, initial_epoch);
+    broadcast(update);
+    check(initial_epoch);
   }
+}
 
-  // Remove everyone but the creator
+TEST_F(RunningSessionTest, Remove)
+{
   for (int i = group_size - 1; i > 0; i -= 1) {
     auto initial_epoch = sessions[0].current_epoch();
     auto remove = sessions[i - 1].remove(i);
     sessions.pop_back();
-    broadcast(sessions, remove);
-    check(sessions, initial_epoch);
+    broadcast(remove);
+    check(initial_epoch);
+  }
+}
+
+TEST_F(RunningSessionTest, FullLifeCycle)
+{
+  // 1. Group is created in the ctor
+
+  // 2. Have everyone update
+  for (int i = 0; i < group_size - 1; i += 1) {
+    auto initial_epoch = sessions[0].current_epoch();
+    auto update = sessions[i].update();
+    broadcast(update);
+    check(initial_epoch);
+  }
+
+  // 3. Remove everyone but the creator
+  for (int i = group_size - 1; i > 0; i -= 1) {
+    auto initial_epoch = sessions[0].current_epoch();
+    auto remove = sessions[i - 1].remove(i);
+    sessions.pop_back();
+    broadcast(remove);
+    check(initial_epoch);
   }
 }

--- a/test/session_test.cpp
+++ b/test/session_test.cpp
@@ -3,25 +3,26 @@
 
 using namespace mls;
 
-class SessionTest : public ::testing::Test {
+class SessionTest : public ::testing::Test
+{
 protected:
   const CipherList suites{ CipherSuite::P256_SHA256_AES128GCM,
                            CipherSuite::X25519_SHA256_AES128GCM };
   const SignatureScheme scheme = SignatureScheme::Ed25519;
   const size_t group_size = 5;
-  const bytes group_id = {0, 1, 2, 3};
+  const bytes group_id = { 0, 1, 2, 3 };
 
   std::vector<Session> sessions;
 
-  SessionTest() {
-    sessions.push_back({ suites, new_identity_key() });
-  }
+  SessionTest() { sessions.push_back({ suites, new_identity_key() }); }
 
-  SignaturePrivateKey new_identity_key() {
+  SignaturePrivateKey new_identity_key()
+  {
     return SignaturePrivateKey::generate(scheme);
   }
 
-  void broadcast(const bytes& message) {
+  void broadcast(const bytes& message)
+  {
     auto initial_epoch = sessions[0].current_epoch();
     for (auto& session : sessions) {
       session.handle(message);
@@ -29,7 +30,8 @@ protected:
     check(initial_epoch);
   }
 
-  void broadcast_add() {
+  void broadcast_add()
+  {
     auto initial_epoch = sessions[0].current_epoch();
     Session next{ suites, new_identity_key() };
     auto last = sessions.size() - 1;
@@ -51,7 +53,8 @@ protected:
     check(initial_epoch);
   }
 
-  void check(epoch_t initial_epoch) const {
+  void check(epoch_t initial_epoch) const
+  {
     // Verify that everyone ended up in consistent states
     for (const auto& session : sessions) {
       ASSERT_EQ(session, sessions[0]);
@@ -92,7 +95,8 @@ TEST_F(SessionTest, CiphersuiteNegotiation)
   ASSERT_EQ(alice.cipher_suite(), CipherSuite::P256_SHA256_AES128GCM);
 }
 
-class RunningSessionTest : public SessionTest {
+class RunningSessionTest : public SessionTest
+{
 protected:
   RunningSessionTest()
     : SessionTest()

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -3,23 +3,26 @@
 
 using namespace mls;
 
-class StateTest : public ::testing::Test {
+class StateTest : public ::testing::Test
+{
 protected:
   const CipherSuite suite = CipherSuite::P256_SHA256_AES128GCM;
   const SignatureScheme scheme = SignatureScheme::P256_SHA256;
 
   const size_t group_size = 5;
-  const bytes group_id = {0, 1, 2, 3};
+  const bytes group_id = { 0, 1, 2, 3 };
 };
 
-class GroupCreationTest : public StateTest {
+class GroupCreationTest : public StateTest
+{
 protected:
   std::vector<SignaturePrivateKey> identity_privs;
   std::vector<UserInitKey> user_init_keys;
   std::vector<bytes> init_secrets;
   std::vector<State> states;
 
-  GroupCreationTest() {
+  GroupCreationTest()
+  {
     identity_privs.reserve(group_size);
     user_init_keys.reserve(group_size);
     init_secrets.reserve(group_size);
@@ -40,7 +43,8 @@ protected:
   }
 };
 
-TEST_F(GroupCreationTest, TwoPerson) {
+TEST_F(GroupCreationTest, TwoPerson)
+{
   // Initialize the creator's state
   auto stp = states.begin();
   states.emplace(stp, group_id, suite, identity_privs[0]);
@@ -82,16 +86,17 @@ TEST_F(GroupCreationTest, FullSize)
   }
 }
 
-class RunningGroupTest : public StateTest {
+class RunningGroupTest : public StateTest
+{
 protected:
   std::vector<State> states;
 
-  RunningGroupTest() {
+  RunningGroupTest()
+  {
     states.reserve(group_size);
 
     auto stp = states.begin();
-    states.emplace(
-      stp, group_id, suite, SignaturePrivateKey::generate(scheme));
+    states.emplace(stp, group_id, suite, SignaturePrivateKey::generate(scheme));
 
     for (size_t i = 1; i < group_size; i += 1) {
       auto init_secret = random_bytes(32);
@@ -115,11 +120,10 @@ protected:
     }
   }
 
-  void SetUp() override {
-    check_consistency();
-  }
+  void SetUp() override { check_consistency(); }
 
-  void check_consistency() {
+  void check_consistency()
+  {
     for (const auto& state : states) {
       ASSERT_EQ(state, states[0]);
     }
@@ -160,8 +164,7 @@ TEST(OtherStateTest, CipherNegotiation)
   auto idkA = SignaturePrivateKey::generate(SignatureScheme::Ed25519);
   auto insA = bytes{ 0, 1, 2, 3 };
   auto inkA1 = DHPrivateKey::derive(CipherSuite::P256_SHA256_AES128GCM, insA);
-  auto inkA2 =
-    DHPrivateKey::derive(CipherSuite::X25519_SHA256_AES128GCM, insA);
+  auto inkA2 = DHPrivateKey::derive(CipherSuite::X25519_SHA256_AES128GCM, insA);
 
   auto uikA = UserInitKey{};
   uikA.add_init_key(inkA1.public_key());

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -1,177 +1,188 @@
 #include "state.h"
-#include <catch.hpp>
+#include <gtest/gtest.h>
 
 using namespace mls;
 
-#define CIPHERSUITE CipherSuite::P256_SHA256_AES128GCM
-#define SIG_SCHEME SignatureScheme::P256_SHA256
+class StateTest : public ::testing::Test {
+protected:
+  const CipherSuite suite = CipherSuite::P256_SHA256_AES128GCM;
+  const SignatureScheme scheme = SignatureScheme::P256_SHA256;
 
-const size_t group_size = 5;
-const bytes group_id{ 0, 1, 2, 3 };
+  const size_t group_size = 5;
+  const bytes group_id = {0, 1, 2, 3};
+};
 
-TEST_CASE("Group creation", "[state]")
-{
+class GroupCreationTest : public StateTest {
+protected:
   std::vector<SignaturePrivateKey> identity_privs;
   std::vector<UserInitKey> user_init_keys;
   std::vector<bytes> init_secrets;
   std::vector<State> states;
 
-  identity_privs.reserve(group_size);
-  user_init_keys.reserve(group_size);
-  init_secrets.reserve(group_size);
-  states.reserve(group_size);
+  GroupCreationTest() {
+    identity_privs.reserve(group_size);
+    user_init_keys.reserve(group_size);
+    init_secrets.reserve(group_size);
+    states.reserve(group_size);
 
-  auto idp = identity_privs.begin();
-  auto uik = user_init_keys.begin();
-  auto inp = init_secrets.begin();
-  auto stp = states.begin();
-  for (size_t i = 0; i < group_size; i += 1) {
-    identity_privs.emplace(idp + i, SignaturePrivateKey::generate(SIG_SCHEME));
-    auto init_secret = random_bytes(32);
-    auto init_priv = DHPrivateKey::derive(CIPHERSUITE, init_secret);
-    user_init_keys.emplace(uik + i);
-    user_init_keys[i].add_init_key(init_priv.public_key());
-    user_init_keys[i].sign(identity_privs[i]);
-    init_secrets.emplace(inp + i, init_secret);
+    auto idp = identity_privs.begin();
+    auto uik = user_init_keys.begin();
+    auto inp = init_secrets.begin();
+    for (size_t i = 0; i < group_size; i += 1) {
+      identity_privs.emplace(idp + i, SignaturePrivateKey::generate(scheme));
+      auto init_secret = random_bytes(32);
+      auto init_priv = DHPrivateKey::derive(suite, init_secret);
+      user_init_keys.emplace(uik + i);
+      user_init_keys[i].add_init_key(init_priv.public_key());
+      user_init_keys[i].sign(identity_privs[i]);
+      init_secrets.emplace(inp + i, init_secret);
+    }
   }
+};
 
-  SECTION("Two person")
-  {
-    // Initialize the creator's state
-    states.emplace(stp, group_id, CIPHERSUITE, identity_privs[0]);
+TEST_F(GroupCreationTest, TwoPerson) {
+  // Initialize the creator's state
+  auto stp = states.begin();
+  states.emplace(stp, group_id, suite, identity_privs[0]);
 
-    // Create a Add for the new participant
-    auto welcome_add = states[0].add(user_init_keys[1]);
+  // Create a Add for the new participant
+  auto welcome_add = states[0].add(user_init_keys[1]);
+  auto welcome = welcome_add.first;
+  auto add = welcome_add.second;
+
+  // Process the Add
+  states[0] = states[0].handle(add);
+  states.emplace(stp + 1, identity_privs[1], init_secrets[1], welcome, add);
+
+  ASSERT_EQ(states[0], states[1]);
+}
+
+TEST_F(GroupCreationTest, FullSize)
+{
+  // Initialize the creator's state
+  auto stp = states.begin();
+  states.emplace(stp, group_id, suite, identity_privs[0]);
+
+  // Each participant invites the next
+  for (size_t i = 1; i < group_size; i += 1) {
+    auto welcome_add = states[i - 1].add(user_init_keys[i]);
     auto welcome = welcome_add.first;
     auto add = welcome_add.second;
 
-    // Process the Add
-    states[0] = states[0].handle(add);
-    states.emplace(stp + 1, identity_privs[1], init_secrets[1], welcome, add);
+    for (auto& state : states) {
+      state = state.handle(add);
+    }
 
-    REQUIRE(states[0] == states[1]);
-  }
+    states.emplace(stp + i, identity_privs[i], init_secrets[i], welcome, add);
 
-  SECTION("Full size")
-  {
-    // Initialize the creator's state
-    states.emplace(stp, group_id, CIPHERSUITE, identity_privs[0]);
-
-    // Each participant invites the next
-    for (size_t i = 1; i < group_size; i += 1) {
-      auto welcome_add = states[i - 1].add(user_init_keys[i]);
-      auto welcome = welcome_add.first;
-      auto add = welcome_add.second;
-
-      for (auto& state : states) {
-        state = state.handle(add);
-      }
-
-      states.emplace(stp + i, identity_privs[i], init_secrets[i], welcome, add);
-
-      // Check that everyone ended up in the same place
-      for (const auto& state : states) {
-        REQUIRE(state == states[0]);
-      }
+    // Check that everyone ended up in the same place
+    for (const auto& state : states) {
+      ASSERT_EQ(state, states[0]);
     }
   }
 }
 
-TEST_CASE("Operations on a running group", "[state]")
-{
+class RunningGroupTest : public StateTest {
+protected:
   std::vector<State> states;
-  states.reserve(group_size);
 
-  auto stp = states.begin();
-  states.emplace(
-    stp, group_id, CIPHERSUITE, SignaturePrivateKey::generate(SIG_SCHEME));
+  RunningGroupTest() {
+    states.reserve(group_size);
 
-  for (size_t i = 1; i < group_size; i += 1) {
-    auto init_secret = random_bytes(32);
-    auto init_priv = DHPrivateKey::derive(CIPHERSUITE, init_secret);
-    auto identity_priv = SignaturePrivateKey::generate(SIG_SCHEME);
+    auto stp = states.begin();
+    states.emplace(
+      stp, group_id, suite, SignaturePrivateKey::generate(scheme));
 
-    UserInitKey uik;
-    uik.add_init_key(init_priv.public_key());
-    uik.sign(identity_priv);
+    for (size_t i = 1; i < group_size; i += 1) {
+      auto init_secret = random_bytes(32);
+      auto init_priv = DHPrivateKey::derive(suite, init_secret);
+      auto identity_priv = SignaturePrivateKey::generate(scheme);
 
-    auto welcome_add = states[0].add(uik);
+      UserInitKey uik;
+      uik.add_init_key(init_priv.public_key());
+      uik.sign(identity_priv);
+
+      auto welcome_add = states[0].add(uik);
+      for (auto& state : states) {
+        state = state.handle(welcome_add.second);
+      }
+
+      states.emplace(stp + i,
+                     identity_priv,
+                     init_secret,
+                     welcome_add.first,
+                     welcome_add.second);
+    }
+  }
+
+  void SetUp() override {
+    check_consistency();
+  }
+
+  void check_consistency() {
+    for (const auto& state : states) {
+      ASSERT_EQ(state, states[0]);
+    }
+  }
+};
+
+TEST_F(RunningGroupTest, Update)
+{
+  for (size_t i = 0; i < group_size; i += 1) {
+    auto new_leaf = random_bytes(32);
+    auto update = states[i].update(new_leaf);
+
+    for (size_t j = 0; j < group_size; j += 1) {
+      states[j] = states[j].handle(update);
+    }
+
+    check_consistency();
+  }
+}
+
+TEST_F(RunningGroupTest, Remove)
+{
+  for (int i = group_size - 2; i > 0; i -= 1) {
+    auto remove = states[i].remove(i + 1);
+    states.pop_back();
+
     for (auto& state : states) {
-      state = state.handle(welcome_add.second);
+      state = state.handle(remove);
     }
 
-    states.emplace(stp + i,
-                   identity_priv,
-                   init_secret,
-                   welcome_add.first,
-                   welcome_add.second);
+    check_consistency();
   }
+}
 
-  for (const auto& state : states) {
-    REQUIRE(state == states[0]);
-  }
+TEST(OtherStateTest, CipherNegotiation)
+{
+  // Alice supports P-256 and X25519
+  auto idkA = SignaturePrivateKey::generate(SignatureScheme::Ed25519);
+  auto insA = bytes{ 0, 1, 2, 3 };
+  auto inkA1 = DHPrivateKey::derive(CipherSuite::P256_SHA256_AES128GCM, insA);
+  auto inkA2 =
+    DHPrivateKey::derive(CipherSuite::X25519_SHA256_AES128GCM, insA);
 
-  SECTION("Each node can update its leaf key")
-  {
-    for (size_t i = 0; i < group_size; i += 1) {
-      auto new_leaf = random_bytes(32);
-      auto update = states[i].update(new_leaf);
+  auto uikA = UserInitKey{};
+  uikA.add_init_key(inkA1.public_key());
+  uikA.add_init_key(inkA2.public_key());
+  uikA.sign(idkA);
 
-      for (size_t j = 0; j < group_size; j += 1) {
-        states[j] = states[j].handle(update);
-      }
+  // Bob spuports P-256 and P-521
+  auto supported_ciphers =
+    std::vector<CipherSuite>{ CipherSuite::P256_SHA256_AES128GCM,
+                              CipherSuite::P521_SHA512_AES256GCM };
+  auto idkB = SignaturePrivateKey::generate(SignatureScheme::Ed25519);
+  auto group_id = from_hex("0001020304");
 
-      for (const auto& state : states) {
-        REQUIRE(state == states[0]);
-      }
-    }
-  }
+  // Bob should choose P-256
+  auto initialB = State::negotiate(group_id, supported_ciphers, idkB, uikA);
+  auto stateB = initialB.first;
+  ASSERT_EQ(stateB.cipher_suite(), CipherSuite::P256_SHA256_AES128GCM);
 
-  SECTION("Each node can remove its successor")
-  {
-    for (int i = group_size - 2; i > 0; i -= 1) {
-      auto remove = states[i].remove(i + 1);
-
-      for (size_t j = 0; j < i; j += 1) {
-        states[j] = states[j].handle(remove);
-      }
-
-      for (size_t j = 0; j < i; j += 1) {
-        REQUIRE(states[j] == states[0]);
-      }
-    }
-  }
-
-  SECTION("Ciphersuite negotiation works")
-  {
-    // Alice supports P-256 and X25519
-    auto idkA = SignaturePrivateKey::generate(SignatureScheme::Ed25519);
-    auto insA = bytes{ 0, 1, 2, 3 };
-    auto inkA1 = DHPrivateKey::derive(CipherSuite::P256_SHA256_AES128GCM, insA);
-    auto inkA2 =
-      DHPrivateKey::derive(CipherSuite::X25519_SHA256_AES128GCM, insA);
-
-    auto uikA = UserInitKey{};
-    uikA.add_init_key(inkA1.public_key());
-    uikA.add_init_key(inkA2.public_key());
-    uikA.sign(idkA);
-
-    // Bob spuports P-256 and P-521
-    auto supported_ciphers =
-      std::vector<CipherSuite>{ CipherSuite::P256_SHA256_AES128GCM,
-                                CipherSuite::P521_SHA512_AES256GCM };
-    auto idkB = SignaturePrivateKey::generate(SignatureScheme::Ed25519);
-    auto group_id = from_hex("0001020304");
-
-    // Bob should choose P-256
-    auto initialB = State::negotiate(group_id, supported_ciphers, idkB, uikA);
-    auto stateB = initialB.first;
-    REQUIRE(stateB.cipher_suite() == CipherSuite::P256_SHA256_AES128GCM);
-
-    // Alice should also arrive at P-256 when initialized
-    auto welcome = initialB.second.first;
-    auto add = initialB.second.second;
-    auto stateA = State(idkA, insA, welcome, add);
-    REQUIRE(stateA == stateB);
-  }
+  // Alice should also arrive at P-256 when initialized
+  auto welcome = initialB.second.first;
+  auto add = initialB.second.second;
+  auto stateA = State(idkA, insA, welcome, add);
+  ASSERT_EQ(stateA, stateB);
 }

--- a/test/tls_syntax_test.cpp
+++ b/test/tls_syntax_test.cpp
@@ -1,5 +1,5 @@
-#include "tls_syntax.h"
 #include "common.h"
+#include "tls_syntax.h"
 #include <gtest/gtest.h>
 
 using namespace mls;
@@ -31,7 +31,8 @@ operator>>(tls::istream& in, ExampleStruct& data)
 }
 
 // Known-answer tests
-class TLSSyntaxTest : public ::testing::Test {
+class TLSSyntaxTest : public ::testing::Test
+{
 protected:
   const uint8_t val_uint8{ 0x11 };
   const bytes enc_uint8 = from_hex("11");
@@ -51,10 +52,13 @@ protected:
   const tls::vector<uint32_t, 3> val_vector{ 5, 6 };
   const bytes enc_vector = from_hex("0000080000000500000006");
 
-  const ExampleStruct val_struct{ 0x1111,
-                                { 0x22, 0x22 },
-                                { 0x33333333, 0x44444444, 0x55555555, 0x66666666 } };
-  const bytes enc_struct = from_hex("11110002222233333333444444445555555566666666");
+  const ExampleStruct val_struct{
+    0x1111,
+    { 0x22, 0x22 },
+    { 0x33333333, 0x44444444, 0x55555555, 0x66666666 }
+  };
+  const bytes enc_struct =
+    from_hex("11110002222233333333444444445555555566666666");
 };
 
 template<typename T>

--- a/test/tls_syntax_test.cpp
+++ b/test/tls_syntax_test.cpp
@@ -1,26 +1,10 @@
-#include "common.h"
 #include "tls_syntax.h"
-#include <catch.hpp>
+#include "common.h"
+#include <gtest/gtest.h>
 
-// Known-answer tests
-uint8_t val_uint8{ 0x11 };
-std::vector<uint8_t> enc_uint8 = mls::from_hex("11");
+using namespace mls;
 
-uint16_t val_uint16{ 0x2222 };
-std::vector<uint8_t> enc_uint16 = mls::from_hex("2222");
-
-uint32_t val_uint32{ 0x44444444 };
-std::vector<uint8_t> enc_uint32 = mls::from_hex("44444444");
-
-uint64_t val_uint64{ 0x8888888888888888 };
-std::vector<uint8_t> enc_uint64 = mls::from_hex("8888888888888888");
-
-std::array<uint16_t, 4> val_array{ 1, 2, 3, 4 };
-std::vector<uint8_t> enc_array = mls::from_hex("0001000200030004");
-
-tls::vector<uint32_t, 3> val_vector{ 5, 6 };
-std::vector<uint8_t> enc_vector = mls::from_hex("0000080000000500000006");
-
+// A struct to test struct encoding, and its operators
 struct ExampleStruct
 {
   uint16_t a;
@@ -46,11 +30,32 @@ operator>>(tls::istream& in, ExampleStruct& data)
   return in >> data.a >> data.b >> data.c;
 }
 
-ExampleStruct val_struct{ 0x1111,
-                          { 0x22, 0x22 },
-                          { 0x33333333, 0x44444444, 0x55555555, 0x66666666 } };
-std::vector<uint8_t> enc_struct =
-  mls::from_hex("11110002222233333333444444445555555566666666");
+// Known-answer tests
+class TLSSyntaxTest : public ::testing::Test {
+protected:
+  const uint8_t val_uint8{ 0x11 };
+  const bytes enc_uint8 = from_hex("11");
+
+  const uint16_t val_uint16{ 0x2222 };
+  const bytes enc_uint16 = from_hex("2222");
+
+  const uint32_t val_uint32{ 0x44444444 };
+  const bytes enc_uint32 = from_hex("44444444");
+
+  const uint64_t val_uint64{ 0x8888888888888888 };
+  const bytes enc_uint64 = from_hex("8888888888888888");
+
+  const std::array<uint16_t, 4> val_array{ 1, 2, 3, 4 };
+  const bytes enc_array = from_hex("0001000200030004");
+
+  const tls::vector<uint32_t, 3> val_vector{ 5, 6 };
+  const bytes enc_vector = from_hex("0000080000000500000006");
+
+  const ExampleStruct val_struct{ 0x1111,
+                                { 0x22, 0x22 },
+                                { 0x33333333, 0x44444444, 0x55555555, 0x66666666 } };
+  const bytes enc_struct = from_hex("11110002222233333333444444445555555566666666");
+};
 
 template<typename T>
 void
@@ -58,32 +63,23 @@ ostream_test(T val, const std::vector<uint8_t>& enc)
 {
   tls::ostream w;
   w << val;
-  REQUIRE(w.bytes() == enc);
+  ASSERT_EQ(w.bytes(), enc);
 }
 
-TEST_CASE("TLS ostream correctly marshals", "[tls_syntax]")
+TEST_F(TLSSyntaxTest, OStream)
 {
-  SECTION("raw")
-  {
-    std::vector<uint8_t> answer{ 1, 2, 3, 4 };
-    tls::ostream w;
-    w.write_raw(answer);
-    REQUIRE(w.bytes() == answer);
-  }
+  bytes answer{ 1, 2, 3, 4 };
+  tls::ostream w;
+  w.write_raw(answer);
+  ASSERT_EQ(w.bytes(), answer);
 
-  SECTION("uint8_t") { ostream_test(val_uint8, enc_uint8); }
-
-  SECTION("uint16_t") { ostream_test(val_uint16, enc_uint16); }
-
-  SECTION("uint32_t") { ostream_test(val_uint32, enc_uint32); }
-
-  SECTION("uint64_t") { ostream_test(val_uint64, enc_uint64); }
-
-  SECTION("array") { ostream_test(val_array, enc_array); }
-
-  SECTION("vector") { ostream_test(val_vector, enc_vector); }
-
-  SECTION("struct") { ostream_test(val_struct, enc_struct); }
+  ostream_test(val_uint8, enc_uint8);
+  ostream_test(val_uint16, enc_uint16);
+  ostream_test(val_uint32, enc_uint32);
+  ostream_test(val_uint64, enc_uint64);
+  ostream_test(val_array, enc_array);
+  ostream_test(val_vector, enc_vector);
+  ostream_test(val_struct, enc_struct);
 }
 
 template<typename T>
@@ -93,24 +89,18 @@ istream_test(T val, const std::vector<uint8_t>& enc)
   T data;
   tls::istream r(enc);
   r >> data;
-  REQUIRE(data == val);
+  ASSERT_EQ(data, val);
 }
 
-TEST_CASE("TLS istream correctly unmarshals", "[tls_syntax]")
+TEST_F(TLSSyntaxTest, IStream)
 {
-  SECTION("uint8_t") { istream_test(val_uint8, enc_uint8); }
-
-  SECTION("uint16_t") { istream_test(val_uint16, enc_uint16); }
-
-  SECTION("uint32_t") { istream_test(val_uint32, enc_uint32); }
-
-  SECTION("uint64_t") { istream_test(val_uint64, enc_uint64); }
-
-  SECTION("array") { istream_test(val_array, enc_array); }
-
-  SECTION("vector") { istream_test(val_vector, enc_vector); }
-
-  SECTION("struct") { istream_test(val_struct, enc_struct); }
+  istream_test(val_uint8, enc_uint8);
+  istream_test(val_uint16, enc_uint16);
+  istream_test(val_uint32, enc_uint32);
+  istream_test(val_uint64, enc_uint64);
+  istream_test(val_array, enc_array);
+  istream_test(val_vector, enc_vector);
+  istream_test(val_struct, enc_struct);
 }
 
 // TODO(rlb@ipv.sx) Test failure cases

--- a/test/tree_math_test.cpp
+++ b/test/tree_math_test.cpp
@@ -1,8 +1,8 @@
 #include "tree_math.h"
-
 #include "common.h"
 #include "tls_syntax.h"
-#include <catch.hpp>
+
+#include <gtest/gtest.h>
 #include <vector>
 
 using namespace mls;
@@ -175,7 +175,7 @@ vector_test(F function, bytes answer_data)
   tls::vector<uint32_t, 4> vals;
   tls::unmarshal(answer_data, vals);
   for (uint32_t i = 0; i < vals.size(); ++i) {
-    REQUIRE(function(i) == vals[i]);
+    ASSERT_EQ(function(i), vals[i]);
   }
 }
 
@@ -186,31 +186,31 @@ size_scope(F function)
   return [=](uint32_t x) -> auto { return function(x, answers::size); };
 }
 
-TEST_CASE("Tree math functions match expected outputs", "[tree-math]")
+TEST(TreeMathTest, Root)
 {
-  SECTION("root")
-  {
-    tls::vector<uint32_t, 4> vals;
-    tls::unmarshal(answers::root_data, vals);
-    for (uint32_t n = 1; n < vals.size() - 1; n += 1) {
-      REQUIRE(tree_math::root(n) == vals[n - 1]);
-    }
+  tls::vector<uint32_t, 4> vals;
+  tls::unmarshal(answers::root_data, vals);
+  for (uint32_t n = 1; n < vals.size() - 1; n += 1) {
+    ASSERT_EQ(tree_math::root(n), vals[n - 1]);
   }
+}
 
-  SECTION("left") { vector_test(tree_math::left, answers::left_data); }
+TEST(TreeMathTest, Left)
+{
+  vector_test(tree_math::left, answers::left_data);
+}
 
-  SECTION("right")
-  {
-    vector_test(size_scope(tree_math::right), answers::right_data);
-  }
+TEST(TreeMathTest, Right)
+{
+  vector_test(size_scope(tree_math::right), answers::right_data);
+}
 
-  SECTION("parent")
-  {
-    vector_test(size_scope(tree_math::parent), answers::parent_data);
-  }
+TEST(TreeMathTest, Parent)
+{
+  vector_test(size_scope(tree_math::parent), answers::parent_data);
+}
 
-  SECTION("sibling")
-  {
-    vector_test(size_scope(tree_math::sibling), answers::sibling_data);
-  }
+TEST(TreeMathTest, Sibling)
+{
+  vector_test(size_scope(tree_math::sibling), answers::sibling_data);
 }

--- a/test/tree_math_test.cpp
+++ b/test/tree_math_test.cpp
@@ -1,6 +1,6 @@
-#include "tree_math.h"
 #include "common.h"
 #include "tls_syntax.h"
+#include "tree_math.h"
 
 #include <gtest/gtest.h>
 #include <vector>


### PR DESCRIPTION
This PR converts the tests from Catch to Gtest.  It looks like Gtest integrates more cleanly with CMake than Catch does, and as a result we should get more flexibility, e.g., to change the working directory from which tests are done.

As a little bonus, this PR also adds tests for `Roster` functions, which were missing before.