### PR TITLE
Application Key Schedule

### DIFF
--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -196,19 +196,19 @@ generate_app_key_schedule()
     &tv.case_x25519,
   };
 
-  tv.n_participants = 16;
-  tv.n_messages = 16;
-  tv.app_secret = bytes(32, 0xA0);
+  tv.n_members = 16;
+  tv.n_generations = 16;
+  tv.application_secret = bytes(32, 0xA0);
 
   for (int i = 0; i < suites.size(); ++i) {
     auto suite = suites[i];
     auto test_case = cases[i];
 
-    for (uint32_t j = 0; j < tv.n_participants; ++j) {
-      ApplicationKeyChain chain(suite, j, tv.app_secret);
+    for (uint32_t j = 0; j < tv.n_members; ++j) {
+      ApplicationKeyChain chain(suite, j, tv.application_secret);
       test_case->emplace_back();
 
-      for (uint32_t k = 0; k < tv.n_messages; ++k) {
+      for (uint32_t k = 0; k < tv.n_generations; ++k) {
         auto kn = chain.get(k);
         test_case->at(j).push_back({ kn.secret, kn.key, kn.nonce });
       }

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -181,6 +181,43 @@ generate_key_schedule()
   return tv;
 }
 
+AppKeyScheduleTestVectors
+generate_app_key_schedule()
+{
+  AppKeyScheduleTestVectors tv;
+
+  std::vector<CipherSuite> suites{
+    CipherSuite::P256_SHA256_AES128GCM,
+    CipherSuite::X25519_SHA256_AES128GCM,
+  };
+
+  std::vector<AppKeyScheduleTestVectors::TestCase*> cases{
+    &tv.case_p256,
+    &tv.case_x25519,
+  };
+
+  tv.n_participants = 16;
+  tv.n_messages = 16;
+  tv.app_secret = bytes(32, 0xA0);
+
+  for (int i = 0; i < suites.size(); ++i) {
+    auto suite = suites[i];
+    auto test_case = cases[i];
+
+    for (uint32_t j = 0; j < tv.n_participants; ++j) {
+      ApplicationKeyChain chain(suite, j, tv.app_secret);
+      test_case->emplace_back();
+
+      for (uint32_t k = 0; k < tv.n_messages; ++k) {
+        auto kn = chain.get(k);
+        test_case->at(j).push_back({ kn.secret, kn.key, kn.nonce });
+      }
+    }
+  }
+
+  return tv;
+}
+
 MessagesTestVectors
 generate_messages()
 {
@@ -459,6 +496,9 @@ main()
   KeyScheduleTestVectors key_schedule = generate_key_schedule();
   write_test_vectors(key_schedule);
 
+  AppKeyScheduleTestVectors app_key_schedule = generate_app_key_schedule();
+  write_test_vectors(app_key_schedule);
+
   MessagesTestVectors messages = generate_messages();
   write_test_vectors(messages);
 
@@ -471,6 +511,7 @@ main()
   verify_reproducible(generate_resolution);
   verify_reproducible(generate_crypto);
   verify_reproducible(generate_key_schedule);
+  verify_reproducible(generate_app_key_schedule);
   verify_reproducible(generate_messages);
   verify_session_repro(generate_basic_session);
 
@@ -480,6 +521,7 @@ main()
     TestLoader<ResolutionTestVectors>::get();
     TestLoader<CryptoTestVectors>::get();
     TestLoader<KeyScheduleTestVectors>::get();
+    TestLoader<AppKeyScheduleTestVectors>::get();
     TestLoader<MessagesTestVectors>::get();
     TestLoader<BasicSessionTestVectors>::get();
   } catch (...) {

--- a/src/include/crypto.h
+++ b/src/include/crypto.h
@@ -175,6 +175,13 @@ constant_time_eq(const bytes& lhs, const bytes& rhs);
 bytes
 hkdf_extract(CipherSuite suite, const bytes& salt, const bytes& ikm);
 
+bytes
+hkdf_expand_label(CipherSuite suite,
+                  const bytes& secret,
+                  const std::string& label,
+                  const bytes& context,
+                  const size_t length);
+
 struct GroupState;
 
 bytes

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -15,15 +15,12 @@ protected:
 
   void interop(CipherSuite suite, const AppKeyScheduleTestVectors::TestCase& tc)
   {
-    ASSERT_EQ(tc.size(), tv.n_participants);
-    for (uint32_t j = 0; j < tv.n_participants; ++j) {
-      ApplicationKeyChain chain(suite, j, tv.app_secret);
-      std::cout << "app_secret: " << tv.app_secret << std::endl;
+    ASSERT_EQ(tc.size(), tv.n_members);
+    for (uint32_t j = 0; j < tv.n_members; ++j) {
+      ApplicationKeyChain chain(suite, j, tv.application_secret);
 
-      ASSERT_EQ(tc[j].size(), tv.n_messages);
-      for (uint32_t k = 0; k < tv.n_participants; ++k) {
-        std::cout << "step " << j << " " << k << std::endl;
-
+      ASSERT_EQ(tc[j].size(), tv.n_generations);
+      for (uint32_t k = 0; k < tv.n_generations; ++k) {
         auto kn = chain.get(k);
         ASSERT_EQ(tc[j][k].secret, kn.secret);
         ASSERT_EQ(tc[j][k].key, kn.key);

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -4,6 +4,41 @@
 
 using namespace mls;
 
+class AppKeyScheduleTest : public ::testing::Test
+{
+protected:
+  const AppKeyScheduleTestVectors& tv;
+
+  AppKeyScheduleTest()
+    : tv(TestLoader<AppKeyScheduleTestVectors>::get())
+  {}
+
+  void interop(CipherSuite suite, const AppKeyScheduleTestVectors::TestCase& tc)
+  {
+    ASSERT_EQ(tc.size(), tv.n_participants);
+    for (uint32_t j = 0; j < tv.n_participants; ++j) {
+      ApplicationKeyChain chain(suite, j, tv.app_secret);
+      std::cout << "app_secret: " << tv.app_secret << std::endl;
+
+      ASSERT_EQ(tc[j].size(), tv.n_messages);
+      for (uint32_t k = 0; k < tv.n_participants; ++k) {
+        std::cout << "step " << j << " " << k << std::endl;
+
+        auto kn = chain.get(k);
+        ASSERT_EQ(tc[j][k].secret, kn.secret);
+        ASSERT_EQ(tc[j][k].key, kn.key);
+        ASSERT_EQ(tc[j][k].nonce, kn.nonce);
+      }
+    }
+  }
+};
+
+TEST_F(AppKeyScheduleTest, Interop)
+{
+  interop(CipherSuite::P256_SHA256_AES128GCM, tv.case_p256);
+  interop(CipherSuite::X25519_SHA256_AES128GCM, tv.case_x25519);
+}
+
 class StateTest : public ::testing::Test
 {
 protected:

--- a/test/test_vectors.cpp
+++ b/test/test_vectors.cpp
@@ -171,14 +171,14 @@ operator<<(tls::ostream& str, const AppKeyScheduleTestVectors::Step& obj)
 tls::istream&
 operator>>(tls::istream& str, AppKeyScheduleTestVectors& obj)
 {
-  return str >> obj.n_participants >> obj.n_messages >> obj.app_secret >>
+  return str >> obj.n_members >> obj.n_generations >> obj.application_secret >>
          obj.case_p256 >> obj.case_x25519;
 }
 
 tls::ostream&
 operator<<(tls::ostream& str, const AppKeyScheduleTestVectors& obj)
 {
-  return str << obj.n_participants << obj.n_messages << obj.app_secret
+  return str << obj.n_members << obj.n_generations << obj.application_secret
              << obj.case_p256 << obj.case_x25519;
 }
 

--- a/test/test_vectors.cpp
+++ b/test/test_vectors.cpp
@@ -150,6 +150,39 @@ operator<<(tls::ostream& str, const KeyScheduleTestVectors& obj)
 }
 
 ///
+/// AppKeyScheduleTestVectors
+///
+
+const std::string AppKeyScheduleTestVectors::file_name =
+  "./app_key_schedule.bin";
+
+tls::istream&
+operator>>(tls::istream& str, AppKeyScheduleTestVectors::Step& obj)
+{
+  return str >> obj.secret >> obj.key >> obj.iv;
+}
+
+tls::ostream&
+operator<<(tls::ostream& str, const AppKeyScheduleTestVectors::Step& obj)
+{
+  return str << obj.secret << obj.key << obj.iv;
+}
+
+tls::istream&
+operator>>(tls::istream& str, AppKeyScheduleTestVectors& obj)
+{
+  return str >> obj.n_participants >> obj.n_messages >> obj.case_p256 >>
+         obj.case_x25519;
+}
+
+tls::ostream&
+operator<<(tls::ostream& str, const AppKeyScheduleTestVectors& obj)
+{
+  return str << obj.n_participants << obj.n_messages << obj.case_p256
+             << obj.case_x25519;
+}
+
+///
 /// MessagesTestVectors
 ///
 
@@ -296,5 +329,6 @@ template struct TestLoader<TreeMathTestVectors>;
 template struct TestLoader<ResolutionTestVectors>;
 template struct TestLoader<CryptoTestVectors>;
 template struct TestLoader<KeyScheduleTestVectors>;
+template struct TestLoader<AppKeyScheduleTestVectors>;
 template struct TestLoader<MessagesTestVectors>;
 template struct TestLoader<BasicSessionTestVectors>;

--- a/test/test_vectors.cpp
+++ b/test/test_vectors.cpp
@@ -159,13 +159,13 @@ const std::string AppKeyScheduleTestVectors::file_name =
 tls::istream&
 operator>>(tls::istream& str, AppKeyScheduleTestVectors::Step& obj)
 {
-  return str >> obj.secret >> obj.key >> obj.iv;
+  return str >> obj.secret >> obj.key >> obj.nonce;
 }
 
 tls::ostream&
 operator<<(tls::ostream& str, const AppKeyScheduleTestVectors::Step& obj)
 {
-  return str << obj.secret << obj.key << obj.iv;
+  return str << obj.secret << obj.key << obj.nonce;
 }
 
 tls::istream&

--- a/test/test_vectors.cpp
+++ b/test/test_vectors.cpp
@@ -171,15 +171,15 @@ operator<<(tls::ostream& str, const AppKeyScheduleTestVectors::Step& obj)
 tls::istream&
 operator>>(tls::istream& str, AppKeyScheduleTestVectors& obj)
 {
-  return str >> obj.n_participants >> obj.n_messages >> obj.case_p256 >>
-         obj.case_x25519;
+  return str >> obj.n_participants >> obj.n_messages >> obj.app_secret >>
+         obj.case_p256 >> obj.case_x25519;
 }
 
 tls::ostream&
 operator<<(tls::ostream& str, const AppKeyScheduleTestVectors& obj)
 {
-  return str << obj.n_participants << obj.n_messages << obj.case_p256
-             << obj.case_x25519;
+  return str << obj.n_participants << obj.n_messages << obj.app_secret
+             << obj.case_p256 << obj.case_x25519;
 }
 
 ///

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -142,7 +142,7 @@ struct AppKeyScheduleTestVectors
   {
     tls::opaque<1> secret;
     tls::opaque<1> key;
-    tls::opaque<1> iv;
+    tls::opaque<1> nonce;
   };
 
   typedef tls::vector<Step, 4> KeySequence;
@@ -157,9 +157,9 @@ struct AppKeyScheduleTestVectors
 };
 
 tls::istream&
-operator>>(tls::istream& str, KeyScheduleTestVectors& tv);
+operator>>(tls::istream& str, AppKeyScheduleTestVectors& tv);
 tls::ostream&
-operator<<(tls::ostream& str, const KeyScheduleTestVectors& tv);
+operator<<(tls::ostream& str, const AppKeyScheduleTestVectors& tv);
 
 /////
 

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -148,9 +148,9 @@ struct AppKeyScheduleTestVectors
   typedef tls::vector<Step, 4> KeySequence;
   typedef tls::vector<KeySequence, 4> TestCase;
 
-  uint32_t n_participants;
-  uint32_t n_messages;
-  tls::opaque<1> app_secret;
+  uint32_t n_members;
+  uint32_t n_generations;
+  tls::opaque<1> application_secret;
 
   TestCase case_p256;
   TestCase case_x25519;

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -134,6 +134,35 @@ operator<<(tls::ostream& str, const KeyScheduleTestVectors& tv);
 
 /////
 
+struct AppKeyScheduleTestVectors
+{
+  static const std::string file_name;
+
+  struct Step
+  {
+    tls::opaque<1> secret;
+    tls::opaque<1> key;
+    tls::opaque<1> iv;
+  };
+
+  typedef tls::vector<Step, 4> KeySequence;
+  typedef tls::vector<KeySequence, 4> TestCase;
+
+  uint32_t n_participants;
+  uint32_t n_messages;
+  tls::opaque<1> app_secret;
+
+  TestCase case_p256;
+  TestCase case_x25519;
+};
+
+tls::istream&
+operator>>(tls::istream& str, KeyScheduleTestVectors& tv);
+tls::ostream&
+operator<<(tls::ostream& str, const KeyScheduleTestVectors& tv);
+
+/////
+
 struct MessagesTestVectors
 {
   static const std::string file_name;


### PR DESCRIPTION
This PR adds the logic for deriving application keys based on an epoch's application secret, based on the specification in draft-ietf-mls-protocol-04.  It also adds code to generate and test against test vectors.

The application key derivation logic, however, is not connected to the state / session logic.  So it's still not yet possible to derive keys from a state / session.