### PR TITLE
Split path secrets from node secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ${BUILD_DIR}: CMakeLists.txt test/CMakeLists.txt cmd/CMakeLists.txt
 	cmake -H. -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug
 
 test: all
-	cd ${BUILD_DIR} && ctest
+	cd ${BUILD_DIR} && ctest #-V -R "RunningSessionTest.Update"
 
 gen: all
 	cd ${TEST_VECTOR_DIR} && ../../../${TEST_GEN}

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ${BUILD_DIR}: CMakeLists.txt test/CMakeLists.txt cmd/CMakeLists.txt
 	cmake -H. -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug
 
 test: all
-	cd ${BUILD_DIR} && ctest #-V -R "RunningSessionTest.Update"
+	cd ${BUILD_DIR} && ctest
 
 gen: all
 	cd ${TEST_VECTOR_DIR} && ../../../${TEST_GEN}

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -58,6 +58,7 @@ operator+(const bytes& lhs, const bytes& rhs)
 std::ostream&
 operator<<(std::ostream& out, const bytes& data)
 {
+  // Adjust this threshold to make output more compact
   auto threshold = 0xffff;
   if (data.size() < threshold) {
     return out << to_hex(data);

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -58,7 +58,13 @@ operator+(const bytes& lhs, const bytes& rhs)
 std::ostream&
 operator<<(std::ostream& out, const bytes& data)
 {
-  return out << to_hex(data);
+  auto threshold = 0xffff;
+  if (data.size() < threshold) {
+    return out << to_hex(data);
+  }
+
+  bytes abbrev(data.begin(), data.begin() + threshold);
+  return out << to_hex(abbrev) << "...";
 }
 
 } // namespace mls

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -12,8 +12,6 @@
 
 #include <string>
 
-#include <iostream>
-
 namespace mls {
 
 ///
@@ -1342,7 +1340,6 @@ setup_base(CipherSuite suite,
   bytes zero(Nh, 0);
   auto secret = hkdf_extract(suite, zero, zz);
   auto kem_context = enc + pkR.to_bytes();
-
   return setup_core(suite, HPKEMode::base, secret, kem_context, info);
 }
 
@@ -1358,11 +1355,6 @@ DHPublicKey::encrypt(const bytes& plaintext) const
 
   auto enc = ephemeral.public_key().to_bytes();
   auto zz = ephemeral.derive(*this);
-
-  std::cout << "=== SetupBaseI ===" << std::endl;
-  std::cout << "  enc: " << enc << std::endl;
-  std::cout << "  zz:  " << zz << std::endl;
-  std::cout << "  pkR: " << to_bytes() << std::endl;
 
   bytes key, nonce;
   bytes info;
@@ -1453,11 +1445,6 @@ DHPrivateKey::decrypt(const HPKECiphertext& ciphertext) const
   // SetupBaseR
   auto enc = ciphertext.ephemeral.to_bytes();
   auto zz = derive(ciphertext.ephemeral);
-
-  std::cout << "=== SetupBaseR ===" << std::endl;
-  std::cout << "  enc: " << enc << std::endl;
-  std::cout << "  zz:  " << zz << std::endl;
-  std::cout << "  pkR: " << public_key().to_bytes() << std::endl;
 
   bytes key, nonce;
   bytes info;

--- a/src/include/crypto.h
+++ b/src/include/crypto.h
@@ -302,6 +302,7 @@ public:
   static DHPrivateKey generate(CipherSuite suite);
   static DHPrivateKey parse(CipherSuite suite, const bytes& data);
   static DHPrivateKey derive(CipherSuite suite, const bytes& secret);
+  static DHPrivateKey node_derive(CipherSuite suite, const bytes& secret);
 
   bytes derive(const DHPublicKey& pub) const;
   bytes decrypt(const HPKECiphertext& ciphertext) const;

--- a/src/include/ratchet_tree.h
+++ b/src/include/ratchet_tree.h
@@ -104,8 +104,11 @@ public:
 
 private:
   tls::variant_vector<OptionalRatchetTreeNode, CipherSuite, 4> _nodes;
+  size_t _secret_size;
 
-  RatchetTreeNode new_node(const bytes& data) const;
+  RatchetTreeNode new_node(const bytes& path_secret) const;
+  bytes path_step(const bytes& path_secret) const;
+  bytes node_step(const bytes& path_secret) const;
 
   friend bool operator==(const RatchetTree& lhs, const RatchetTree& rhs);
   friend std::ostream& operator<<(std::ostream& out, const RatchetTree& obj);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -126,7 +126,7 @@ Session::make_init_key()
   // from the same secret.  Maybe we should include the ciphersuite
   // in the key derivation...
   for (auto suite : _supported_ciphersuites) {
-    auto init_priv = DHPrivateKey::derive(suite, _init_secret);
+    auto init_priv = DHPrivateKey::node_derive(suite, _init_secret);
     user_init_key.add_init_key(init_priv.public_key());
   }
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1,7 +1,5 @@
 #include "state.h"
 
-#include <iostream>
-
 namespace mls {
 
 ///
@@ -131,7 +129,6 @@ State::State(SignaturePrivateKey identity_priv,
     throw ProtocolError("Selected cipher suite not supported");
   }
 
-  std::cout << "***2> node_derive from " << init_secret << std::endl;
   auto init_priv = DHPrivateKey::node_derive(_suite, init_secret);
   if (*init_uik != init_priv.public_key()) {
     throw ProtocolError("Incorrect init key");
@@ -371,13 +368,6 @@ State::derive_epoch_secrets(CipherSuite suite,
 {
   auto state_bytes = tls::marshal(state);
   auto epoch_secret = hkdf_extract(suite, init_secret, update_secret);
-
-  std::cout << "=== derive ===" << std::endl;
-  std::cout << "  init:   " << init_secret << std::endl;
-  std::cout << "  update: " << update_secret << std::endl;
-  std::cout << "  epoch:  " << epoch_secret << std::endl;
-  std::cout << "  state:  " << state_bytes << std::endl;
-
   return {
     epoch_secret,
     derive_secret(suite, epoch_secret, "app", state_bytes),
@@ -447,14 +437,6 @@ State::sign(const GroupOperation& operation) const
   auto confirm_data = sig_data + sig;
   auto confirm = hmac(_suite, next._confirmation_key, confirm_data);
 
-  std::cout << "=== sign ===" << std::endl;
-  std::cout << "  hash: " << next._state.transcript_hash << std::endl;
-  std::cout << "  key: " << _identity_priv.public_key().to_bytes() << std::endl;
-  std::cout << "  sig: " << sig << std::endl;
-  std::cout << "    key:  " << next._confirmation_key << std::endl;
-  std::cout << "    data: " << confirm_data << std::endl;
-  std::cout << "  conf: " << confirm << std::endl;
-
   return Handshake{ _state.epoch, operation, _index, sig, confirm };
 }
 
@@ -469,14 +451,6 @@ State::verify(const Handshake& handshake) const
   auto confirm_data = sig_data + sig;
   auto confirm = hmac(_suite, _confirmation_key, confirm_data);
   auto confirm_ver = constant_time_eq(confirm, handshake.confirmation);
-
-  std::cout << "=== verify ===" << std::endl;
-  std::cout << "  hash: " << _state.transcript_hash << std::endl;
-  std::cout << "  key:  " << pub.to_bytes() << std::endl;
-  std::cout << "  sig:  " << sig << std::endl;
-  std::cout << "    key:  " << _confirmation_key << std::endl;
-  std::cout << "    data: " << confirm_data << std::endl;
-  std::cout << "  conf: " << confirm << std::endl;
 
   return sig_ver && confirm_ver;
 }

--- a/test/crypto_test.cpp
+++ b/test/crypto_test.cpp
@@ -282,6 +282,7 @@ TEST_F(CryptoTest, BasicDH)
                                    CipherSuite::X448_SHA512_AES256GCM };
 
   for (auto suite : suites) {
+    auto s = bytes{ 0, 1, 2, 3 };
     auto x = DHPrivateKey::generate(suite);
     auto y = DHPrivateKey::derive(suite, { 0, 1, 2, 3 });
 
@@ -298,6 +299,12 @@ TEST_F(CryptoTest, BasicDH)
     auto gXY = x.derive(gY);
     auto gYX = y.derive(gX);
     ASSERT_EQ(gXY, gYX);
+
+    auto nh = Digest(suite).output_size();
+    auto ns = hkdf_expand_label(suite, s, "node", {}, nh);
+    auto ny = DHPrivateKey::derive(suite, ns);
+    auto nz = DHPrivateKey::node_derive(suite, s);
+    ASSERT_EQ(ny, nz);
   }
 }
 

--- a/test/ratchet_tree_test.cpp
+++ b/test/ratchet_tree_test.cpp
@@ -3,71 +3,107 @@
 #include "tls_syntax.h"
 #include <gtest/gtest.h>
 
+#include <iostream>
+
 using namespace mls;
 
 class RatchetTreeTest : public ::testing::Test
 {
 protected:
-  const CipherSuite ciphersuite = CipherSuite::P256_SHA256_AES128GCM;
+  const CipherSuite suite = CipherSuite::P256_SHA256_AES128GCM;
 
   const bytes secretA = from_hex("00010203");
   const bytes secretB = from_hex("04050607");
   const bytes secretC = from_hex("08090a0b");
   const bytes secretD = from_hex("0c0d0e0f");
-  const bytes secretAB = from_hex(
-    "c6d44cf418f610e3fe9e1d9294ff43def81c6cdcad6cbb1820cff48d3aa4355d");
-  const bytes secretCD = from_hex(
-    "71b92110bf135c85581c8a128f6a19c0f6aca752b0c6c91e3571899cf09b145d");
-  const bytes secretABC = from_hex(
-    "e0e6e3c1c64422cc76229d0c35ba817a281f8fc4014faa3e9152428a08a73ab3");
-  const bytes secretABCD = from_hex(
-    "4e05f3b9649335c332f8a99cbaa56e637f3dc99a446f7f6af0f92ea7756717e0");
+
+  bytes secretAn;
+  bytes secretAB;
+  bytes secretCD;
+  bytes secretABC;
+  bytes secretABCD;
+
+  RatchetTreeTest()
+  {
+    auto secretA0n = hkdf_expand_label(suite, secretA, "node", {}, 32);
+    secretAn = secretA0n;
+
+    auto secretB1p = hkdf_expand_label(suite, secretB, "path", {}, 32);
+    auto secretB1n = hkdf_expand_label(suite, secretB1p, "node", {}, 32);
+    secretAB = secretB1n;
+
+    auto secretD1p = hkdf_expand_label(suite, secretD, "path", {}, 32);
+    auto secretD1n = hkdf_expand_label(suite, secretD1p, "node", {}, 32);
+    secretCD = secretD1n;
+
+    auto secretC1p = hkdf_expand_label(suite, secretC, "path", {}, 32);
+    auto secretC1n = hkdf_expand_label(suite, secretC1p, "node", {}, 32);
+    secretABC = secretC1n;
+
+    auto secretD2p = hkdf_expand_label(suite, secretD1p, "path", {}, 32);
+    auto secretD2n = hkdf_expand_label(suite, secretD2p, "node", {}, 32);
+    secretABCD = secretD2n;
+
+    std::cout << "B1p: " << secretB1p << std::endl;
+    std::cout << "B1n: " << secretB1n << std::endl;
+    std::cout << "C1p: " << secretC1p << std::endl;
+    std::cout << "C1n: " << secretC1n << std::endl;
+    std::cout << "D1p: " << secretD1p << std::endl;
+    std::cout << "D1n: " << secretD1n << std::endl;
+    std::cout << "D2p: " << secretD2p << std::endl;
+    std::cout << "D2n: " << secretD2n << std::endl;
+  }
 };
 
 TEST_F(RatchetTreeTest, OneMember)
 {
-  RatchetTree tree{ ciphersuite, secretA };
+  RatchetTree tree{ suite, secretA };
   ASSERT_EQ(tree.size(), 1);
-  ASSERT_EQ(tree.root_secret(), secretA);
+  ASSERT_EQ(tree.root_secret(), secretAn);
 }
 
 TEST_F(RatchetTreeTest, MultipleMembers)
 {
-  RatchetTree tree{ ciphersuite, { secretA, secretB, secretC, secretD } };
+  RatchetTree tree{ suite, { secretA, secretB, secretC, secretD } };
   ASSERT_EQ(tree.size(), 4);
   ASSERT_EQ(tree.root_secret(), secretABCD);
 }
 
 TEST_F(RatchetTreeTest, ByExtension)
 {
-  RatchetTree tree{ ciphersuite, secretA };
+  RatchetTree tree{ suite, secretA };
 
   tree.add_leaf(1, secretB);
   tree.set_path(1, secretB);
 
+  std::cout << "rootAB: " << tree.root_secret() << std::endl;
   ASSERT_EQ(tree.size(), 2);
   ASSERT_EQ(tree.root_secret(), secretAB);
+  RatchetTree directAB{ suite, { secretA, secretB } };
+  ASSERT_EQ(tree, directAB);
 
   tree.add_leaf(2, secretC);
   tree.set_path(2, secretC);
 
+  std::cout << "rootABC: " << tree.root_secret() << std::endl;
   ASSERT_EQ(tree.size(), 3);
   ASSERT_EQ(tree.root_secret(), secretABC);
 
   tree.add_leaf(3, secretD);
   tree.set_path(3, secretD);
 
+  std::cout << "rootABCD: " << tree.root_secret() << std::endl;
   ASSERT_EQ(tree.size(), 4);
   ASSERT_EQ(tree.root_secret(), secretABCD);
 
-  RatchetTree direct{ ciphersuite, { secretA, secretB, secretC, secretD } };
+  RatchetTree direct{ suite, { secretA, secretB, secretC, secretD } };
   ASSERT_EQ(tree, direct);
 }
 
 TEST_F(RatchetTreeTest, BySerialization)
 {
-  RatchetTree before{ ciphersuite, { secretA, secretB, secretC, secretD } };
-  RatchetTree after{ ciphersuite };
+  RatchetTree before{ suite, { secretA, secretB, secretC, secretD } };
+  RatchetTree after{ suite };
 
   tls::unmarshal(tls::marshal(before), after);
   ASSERT_EQ(before, after);
@@ -75,8 +111,8 @@ TEST_F(RatchetTreeTest, BySerialization)
 
 TEST_F(RatchetTreeTest, BySerializationWithBlanks)
 {
-  RatchetTree before{ ciphersuite, { secretA, secretB, secretC, secretD } };
-  RatchetTree after{ ciphersuite };
+  RatchetTree before{ suite, { secretA, secretB, secretC, secretD } };
+  RatchetTree after{ suite };
 
   before.blank_path(1);
   tls::unmarshal(tls::marshal(before), after);
@@ -88,10 +124,11 @@ TEST_F(RatchetTreeTest, EncryptDecrypt)
   size_t size = 5;
 
   // trees[i] represents a tree with a private key for only leaf i
-  std::vector<RatchetTree> trees(size, { ciphersuite });
+  std::vector<RatchetTree> trees(size, { suite });
   for (int i = 0; i < size; ++i) {
     auto secret = random_bytes(32);
-    auto priv = DHPrivateKey::derive(ciphersuite, secret);
+    auto node_secret = hkdf_expand_label(suite, secret, "node", {}, 32);
+    auto priv = DHPrivateKey::derive(suite, node_secret);
     auto pub = priv.public_key();
 
     for (int j = 0; j < size; ++j) {
@@ -104,6 +141,7 @@ TEST_F(RatchetTreeTest, EncryptDecrypt)
   }
 
   for (int i = 0; i < size; ++i) {
+    EXPECT_EQ(trees[i], trees[0]);
     ASSERT_EQ(trees[i].size(), size);
     ASSERT_TRUE(trees[i].check_invariant(i));
   }
@@ -113,11 +151,13 @@ TEST_F(RatchetTreeTest, EncryptDecrypt)
   for (int i = 0; i < size; ++i) {
     auto secret = random_bytes(32);
     auto ct = trees[i].encrypt(i, secret);
+    std::cout << "src: " << trees[i] << std::endl;
 
     for (int j = 0; j < size; ++j) {
       if (i == j) {
         trees[j].set_path(i, secret);
       } else {
+        std::cout << "dst: " << trees[j] << std::endl;
         auto info = trees[j].decrypt(i, ct);
         trees[j].merge_path(i, info);
       }

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -131,8 +131,6 @@ protected:
   {
     states.reserve(group_size);
 
-    std::cout << "~~~ RUN RUN RUN ~~~" << std::endl;
-
     auto init_secret_0 = random_bytes(32);
     auto identity_priv_0 = SignaturePrivateKey::generate(scheme);
     auto credential_0 = Credential::basic(user_id, identity_priv_0);
@@ -141,7 +139,6 @@ protected:
 
     for (size_t i = 1; i < group_size; i += 1) {
       auto init_secret = random_bytes(32);
-      std::cout << "***1> node_derive from " << init_secret << std::endl;
       auto init_priv = DHPrivateKey::node_derive(suite, init_secret);
       auto identity_priv = SignaturePrivateKey::generate(scheme);
       auto credential = Credential::basic(user_id, identity_priv);

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -62,7 +62,7 @@ protected:
       auto identity_priv = SignaturePrivateKey::generate(scheme);
       auto credential = Credential::basic(user_id, identity_priv);
       auto init_secret = random_bytes(32);
-      auto init_priv = DHPrivateKey::derive(suite, init_secret);
+      auto init_priv = DHPrivateKey::node_derive(suite, init_secret);
 
       auto user_init_key = UserInitKey{};
       user_init_key.add_init_key(init_priv.public_key());
@@ -131,6 +131,8 @@ protected:
   {
     states.reserve(group_size);
 
+    std::cout << "~~~ RUN RUN RUN ~~~" << std::endl;
+
     auto init_secret_0 = random_bytes(32);
     auto identity_priv_0 = SignaturePrivateKey::generate(scheme);
     auto credential_0 = Credential::basic(user_id, identity_priv_0);
@@ -139,7 +141,8 @@ protected:
 
     for (size_t i = 1; i < group_size; i += 1) {
       auto init_secret = random_bytes(32);
-      auto init_priv = DHPrivateKey::derive(suite, init_secret);
+      std::cout << "***1> node_derive from " << init_secret << std::endl;
+      auto init_priv = DHPrivateKey::node_derive(suite, init_secret);
       auto identity_priv = SignaturePrivateKey::generate(scheme);
       auto credential = Credential::basic(user_id, identity_priv);
 
@@ -205,8 +208,10 @@ TEST(OtherStateTest, CipherNegotiation)
   auto idkA = SignaturePrivateKey::generate(SignatureScheme::Ed25519);
   auto credA = Credential::basic({ 0, 1, 2, 3 }, idkA);
   auto insA = bytes{ 0, 1, 2, 3 };
-  auto inkA1 = DHPrivateKey::derive(CipherSuite::P256_SHA256_AES128GCM, insA);
-  auto inkA2 = DHPrivateKey::derive(CipherSuite::X25519_SHA256_AES128GCM, insA);
+  auto inkA1 =
+    DHPrivateKey::node_derive(CipherSuite::P256_SHA256_AES128GCM, insA);
+  auto inkA2 =
+    DHPrivateKey::node_derive(CipherSuite::X25519_SHA256_AES128GCM, insA);
 
   auto uikA = UserInitKey{};
   uikA.add_init_key(inkA1.public_key());


### PR DESCRIPTION
This PR implements the changes in -04 that split the "path secrets" used for hashing up the tree from the "node secrets" used for for deriving the keys in the tree.