### PR TITLE
Use the type system to clarify semantics of tree-related parameters

### DIFF
--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -12,12 +12,12 @@ generate_tree_math()
   tv.n_leaves = LeafCount{ 255 };
 
   for (uint32_t n = 1; n <= tv.n_leaves.val; ++n) {
-    auto w = tree_math::node_width(LeafCount{ n });
+    auto w = NodeCount{ LeafCount{ n } };
     auto val = tree_math::root(w);
     tv.root.push_back(val);
   }
 
-  auto w = tree_math::node_width(tv.n_leaves);
+  auto w = NodeCount{ tv.n_leaves };
   for (uint32_t x = 0; x < w.val; ++x) {
     auto left = tree_math::left(NodeIndex{ x });
     tv.left.push_back(left);
@@ -41,7 +41,7 @@ generate_resolution()
   ResolutionTestVectors tv;
   tv.n_leaves = LeafCount{ 7 };
 
-  auto width = tree_math::node_width(tv.n_leaves);
+  auto width = NodeCount{ tv.n_leaves };
   auto n_cases = (1 << width.val);
 
   tv.cases.resize(n_cases);

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -50,7 +50,7 @@ generate_resolution()
 
     auto nodes = ResolutionTestVectors::make_tree(t, width);
     for (uint32_t i = 0; i < width.val; ++i) {
-      auto res = tree_math::resolve(nodes, i);
+      auto res = tree_math::resolve(nodes, NodeIndex{ i });
       tv.cases[t][i] = ResolutionTestVectors::compact(res);
     }
   }
@@ -233,8 +233,8 @@ generate_messages()
 
   // Set the inputs
   tv.epoch = 0xA0A1A2A3;
-  tv.signer_index = 0xB0B1B2B3;
-  tv.removed = 0xC0C1C2C3;
+  tv.signer_index = LeafIndex{ 0xB0B1B2B3 };
+  tv.removed = LeafIndex{ 0xC0C1C2C3 };
   tv.user_id = bytes(16, 0xD1);
   tv.group_id = bytes(16, 0xD2);
   tv.uik_id = bytes(16, 0xD3);
@@ -272,8 +272,8 @@ generate_messages()
 
     auto ratchet_tree =
       RatchetTree{ suite, { tv.random, tv.random, tv.random, tv.random } };
-    ratchet_tree.blank_path(2);
-    auto direct_path = ratchet_tree.encrypt(0, tv.random);
+    ratchet_tree.blank_path(LeafIndex{ 2 });
+    auto direct_path = ratchet_tree.encrypt(LeafIndex{ 0 }, tv.random);
 
     auto cred = Credential::basic(tv.user_id, sig_key);
     auto roster = Roster{};

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -9,25 +9,26 @@ TreeMathTestVectors
 generate_tree_math()
 {
   TreeMathTestVectors tv;
-  tv.n_leaves = 255;
+  tv.n_leaves = LeafCount{ 255 };
 
-  for (int n = 1; n <= tv.n_leaves; ++n) {
-    auto val = mls::tree_math::root(n);
+  for (uint32_t n = 1; n <= tv.n_leaves.val; ++n) {
+    auto w = tree_math::node_width(LeafCount{ n });
+    auto val = tree_math::root(w);
     tv.root.push_back(val);
   }
 
-  auto n = tv.n_leaves;
-  for (int x = 0; x < tree_math::node_width(tv.n_leaves); ++x) {
-    auto left = mls::tree_math::left(x);
+  auto w = tree_math::node_width(tv.n_leaves);
+  for (uint32_t x = 0; x < w.val; ++x) {
+    auto left = tree_math::left(NodeIndex{ x });
     tv.left.push_back(left);
 
-    auto right = mls::tree_math::right(x, n);
+    auto right = tree_math::right(NodeIndex{ x }, w);
     tv.right.push_back(right);
 
-    auto parent = mls::tree_math::parent(x, n);
+    auto parent = tree_math::parent(NodeIndex{ x }, w);
     tv.parent.push_back(parent);
 
-    auto sibling = mls::tree_math::sibling(x, n);
+    auto sibling = tree_math::sibling(NodeIndex{ x }, w);
     tv.sibling.push_back(sibling);
   }
 
@@ -38,17 +39,17 @@ ResolutionTestVectors
 generate_resolution()
 {
   ResolutionTestVectors tv;
-  tv.n_leaves = 7;
+  tv.n_leaves = LeafCount{ 7 };
 
   auto width = tree_math::node_width(tv.n_leaves);
-  auto n_cases = (1 << width);
+  auto n_cases = (1 << width.val);
 
   tv.cases.resize(n_cases);
   for (uint32_t t = 0; t < n_cases; ++t) {
-    tv.cases[t].resize(width);
+    tv.cases[t].resize(width.val);
 
     auto nodes = ResolutionTestVectors::make_tree(t, width);
-    for (uint32_t i = 0; i < width; ++i) {
+    for (uint32_t i = 0; i < width.val; ++i) {
       auto res = tree_math::resolve(nodes, i);
       tv.cases[t][i] = ResolutionTestVectors::compact(res);
     }
@@ -92,14 +93,13 @@ generate_crypto()
 
     // HKDF-Extract
     test_case->hkdf_extract_out =
-      mls::hkdf_extract(suite, tv.hkdf_extract_salt, tv.hkdf_extract_ikm);
+      hkdf_extract(suite, tv.hkdf_extract_salt, tv.hkdf_extract_ikm);
 
     // Derive-Secret
-    test_case->derive_secret_out =
-      mls::derive_secret(suite,
-                         tv.derive_secret_secret,
-                         derive_secret_label_string,
-                         tv.derive_secret_context);
+    test_case->derive_secret_out = derive_secret(suite,
+                                                 tv.derive_secret_secret,
+                                                 derive_secret_label_string,
+                                                 tv.derive_secret_context);
 
     // Derive-Key-Pair
     auto priv = DHPrivateKey::derive(suite, tv.derive_key_pair_seed);
@@ -107,7 +107,7 @@ generate_crypto()
     test_case->derive_key_pair_pub = pub;
 
     // HPKE
-    mls::test::DeterministicHPKE lock;
+    test::DeterministicHPKE lock;
     test_case->ecies_out = pub.encrypt(tv.ecies_plaintext);
   }
 
@@ -259,7 +259,7 @@ generate_messages()
   tv.user_init_key_all = tls::marshal(uik_all);
 
   // Construct a test case for each suite
-  mls::test::DeterministicHPKE lock;
+  test::DeterministicHPKE lock;
   for (int i = 0; i < suites.size(); ++i) {
     auto suite = suites[i];
     auto scheme = schemes[i];
@@ -342,7 +342,7 @@ generate_basic_session()
   tv.group_size = 5;
   tv.group_id = bytes(16, 0xA0);
 
-  mls::test::DeterministicHPKE lock;
+  test::DeterministicHPKE lock;
   for (int i = 0; i < suites.size(); ++i) {
     auto suite = suites[i];
     auto scheme = schemes[i];
@@ -350,7 +350,7 @@ generate_basic_session()
     std::vector<SessionTestVectors::Epoch> transcript;
 
     // Initialize empty sessions
-    std::vector<mls::test::TestSession> sessions;
+    std::vector<test::TestSession> sessions;
     std::vector<bytes> seeds;
     auto ciphersuites = CipherList{ suite };
     for (int j = 0; j < tv.group_size; ++j) {

--- a/src/include/messages.h
+++ b/src/include/messages.h
@@ -107,7 +107,7 @@ struct WelcomeInfo : public CipherAware
 {
   tls::opaque<1> group_id;
   epoch_t epoch;
-  uint32_t index;
+  LeafIndex index;
   Roster roster;
   RatchetTree tree;
   tls::opaque<1> transcript_hash;
@@ -120,7 +120,7 @@ struct WelcomeInfo : public CipherAware
 
   WelcomeInfo(tls::opaque<2> group_id,
               epoch_t epoch,
-              uint32_t index,
+              LeafIndex index,
               Roster roster,
               RatchetTree tree,
               tls::opaque<1> transcript_hash,
@@ -188,12 +188,12 @@ operator>>(tls::istream& in, GroupOperationType& obj);
 struct Add
 {
 public:
-  uint32_t index;
+  LeafIndex index;
   UserInitKey init_key;
 
   Add() {}
 
-  Add(uint32_t index, const UserInitKey& init_key)
+  Add(LeafIndex index, const UserInitKey& init_key)
     : index(index)
     , init_key(init_key)
   {}
@@ -243,7 +243,7 @@ operator>>(tls::istream& in, Update& obj);
 struct Remove : public CipherAware
 {
 public:
-  uint32_t removed;
+  LeafIndex removed;
   DirectPath path;
 
   Remove(CipherSuite suite)
@@ -251,7 +251,7 @@ public:
     , path(suite)
   {}
 
-  Remove(uint32_t removed, const DirectPath& path)
+  Remove(LeafIndex removed, const DirectPath& path)
     : CipherAware(path)
     , removed(removed)
     , path(path)
@@ -351,7 +351,7 @@ struct Handshake : public CipherAware
   epoch_t prior_epoch;
   GroupOperation operation;
 
-  uint32_t signer_index;
+  LeafIndex signer_index;
   tls::opaque<2> signature;
   tls::opaque<1> confirmation;
 
@@ -364,7 +364,7 @@ struct Handshake : public CipherAware
 
   Handshake(epoch_t prior_epoch,
             const GroupOperation& operation,
-            uint32_t signer_index,
+            LeafIndex signer_index,
             const bytes& signature,
             const bytes& confirmation)
     : CipherAware(operation)

--- a/src/include/ratchet_tree.h
+++ b/src/include/ratchet_tree.h
@@ -3,6 +3,7 @@
 #include "common.h"
 #include "crypto.h"
 #include "tls_syntax.h"
+#include "tree_math.h"
 #include <iosfwd>
 
 namespace mls {
@@ -106,6 +107,8 @@ private:
   tls::variant_vector<OptionalRatchetTreeNode, CipherSuite, 4> _nodes;
   size_t _secret_size;
 
+  NodeCount node_size() const;
+  LeafCount leaf_size() const;
   RatchetTreeNode new_node(const bytes& path_secret) const;
   bytes path_step(const bytes& path_secret) const;
   bytes node_step(const bytes& path_secret) const;

--- a/src/include/ratchet_tree.h
+++ b/src/include/ratchet_tree.h
@@ -108,7 +108,6 @@ private:
   size_t _secret_size;
 
   NodeCount node_size() const;
-  LeafCount leaf_size() const;
   RatchetTreeNode new_node(const bytes& path_secret) const;
   bytes path_step(const bytes& path_secret) const;
   bytes node_step(const bytes& path_secret) const;

--- a/src/include/ratchet_tree.h
+++ b/src/include/ratchet_tree.h
@@ -70,6 +70,17 @@ struct OptionalRatchetTreeNode : public optional<RatchetTreeNode>
   }
 };
 
+struct RatchetTreeNodeVector
+  : public tls::variant_vector<OptionalRatchetTreeNode, CipherSuite, 4>
+{
+  typedef tls::variant_vector<OptionalRatchetTreeNode, CipherSuite, 4> parent;
+  using parent::parent;
+  using parent::operator[];
+
+  OptionalRatchetTreeNode& operator[](const NodeIndex index);
+  const OptionalRatchetTreeNode& operator[](const NodeIndex index) const;
+};
+
 struct RatchetNode;
 struct DirectPath;
 
@@ -104,7 +115,7 @@ public:
   bool check_invariant(LeafIndex from) const;
 
 private:
-  tls::variant_vector<OptionalRatchetTreeNode, CipherSuite, 4> _nodes;
+  RatchetTreeNodeVector _nodes;
   size_t _secret_size;
 
   NodeCount node_size() const;

--- a/src/include/ratchet_tree.h
+++ b/src/include/ratchet_tree.h
@@ -86,22 +86,22 @@ public:
     std::vector<bytes> secrets;
   };
 
-  DirectPath encrypt(uint32_t from, const bytes& leaf) const;
-  MergeInfo decrypt(uint32_t from, const DirectPath& path) const;
-  void merge_path(uint32_t from, const MergeInfo& info);
+  DirectPath encrypt(LeafIndex from, const bytes& leaf) const;
+  MergeInfo decrypt(LeafIndex from, const DirectPath& path) const;
+  void merge_path(LeafIndex from, const MergeInfo& info);
 
-  void add_leaf(uint32_t index, const DHPublicKey& pub);
-  void add_leaf(uint32_t index, const bytes& leaf_secret);
-  void blank_path(uint32_t index);
-  void set_path(uint32_t index, const bytes& leaf);
+  void add_leaf(LeafIndex index, const DHPublicKey& pub);
+  void add_leaf(LeafIndex index, const bytes& leaf_secret);
+  void blank_path(LeafIndex index);
+  void set_path(LeafIndex index, const bytes& leaf);
 
-  uint32_t leaf_span() const;
-  void truncate(uint32_t leaves);
+  LeafCount leaf_span() const;
+  void truncate(LeafCount leaves);
 
   uint32_t size() const;
-  bool occupied(uint32_t index) const;
+  bool occupied(LeafIndex index) const;
   bytes root_secret() const;
-  bool check_invariant(size_t from) const;
+  bool check_invariant(LeafIndex from) const;
 
 private:
   tls::variant_vector<OptionalRatchetTreeNode, CipherSuite, 4> _nodes;

--- a/src/include/state.h
+++ b/src/include/state.h
@@ -144,7 +144,7 @@ public:
   /// Accessors
   ///
   epoch_t epoch() const { return _state.epoch; }
-  uint32_t index() const { return _index; }
+  LeafIndex index() const { return _index; }
   CipherSuite cipher_suite() const { return _suite; }
   bytes epoch_secret() const { return _epoch_secret; }
   bytes application_secret() const { return _application_secret; }
@@ -178,7 +178,7 @@ private:
   tls::opaque<1> _init_secret;
 
   // Per-participant state
-  uint32_t _index;
+  LeafIndex _index;
   SignaturePrivateKey _identity_priv;
   bytes _cached_leaf_secret;
 
@@ -186,13 +186,13 @@ private:
   bytes _zero;
 
   // Specific operation handlers
-  State handle(uint32_t signer_index, const GroupOperation& operation) const;
+  State handle(LeafIndex signer_index, const GroupOperation& operation) const;
 
   // Handle a Add (for existing participants only)
   void handle(const Add& add);
 
   // Handle an Update (for the participant that sent the update)
-  void handle(uint32_t index, const Update& update);
+  void handle(LeafIndex index, const Update& update);
 
   // Handle a Remove (for the remaining participants, obviously)
   void handle(const Remove& remove);
@@ -205,7 +205,7 @@ private:
   friend tls::ostream& operator<<(tls::ostream& out, const State& obj);
 
   // Inner logic shared by Update, self-Update, and Remove handlers
-  void update_leaf(uint32_t index,
+  void update_leaf(LeafIndex index,
                    const DirectPath& path,
                    const optional<bytes>& leaf_secret);
 

--- a/src/include/tree_math.h
+++ b/src/include/tree_math.h
@@ -54,14 +54,18 @@ operator>>(tls::istream& in, UInt32& obj);
 tls::ostream&
 operator<<(tls::ostream& out, const UInt32& obj);
 
+struct NodeCount;
+
 struct LeafCount : public UInt32
 {
   using UInt32::UInt32;
+  explicit LeafCount(const NodeCount w);
 };
 
 struct NodeCount : public UInt32
 {
   using UInt32::UInt32;
+  explicit NodeCount(const LeafCount n);
 };
 
 struct LeafIndex : public UInt32
@@ -75,7 +79,7 @@ struct LeafIndex : public UInt32
 struct NodeIndex : public UInt32
 {
   using UInt32::UInt32;
-  explicit NodeIndex(LeafIndex x)
+  explicit NodeIndex(const LeafIndex x)
     : UInt32(2 * x.val)
   {}
 
@@ -88,13 +92,6 @@ namespace tree_math {
 
 uint32_t
 level(NodeIndex x);
-
-// Tree size properties
-NodeCount
-node_width(LeafCount n);
-
-LeafCount
-size_from_width(NodeCount w);
 
 // Node relationships
 NodeIndex

--- a/src/include/tree_math.h
+++ b/src/include/tree_math.h
@@ -64,8 +64,24 @@ struct NodeCount : public UInt32
   using UInt32::UInt32;
 };
 
-typedef uint32_t LeafIndex;
-typedef uint32_t NodeIndex;
+struct LeafIndex : public UInt32
+{
+  using UInt32::UInt32;
+
+  bool operator==(const LeafIndex other) const { return val == other.val; }
+  bool operator!=(const LeafIndex other) const { return val != other.val; }
+};
+
+struct NodeIndex : public UInt32
+{
+  using UInt32::UInt32;
+  explicit NodeIndex(LeafIndex x)
+    : UInt32(2 * x.val)
+  {}
+
+  bool operator==(const NodeIndex other) const { return val == other.val; }
+  bool operator!=(const NodeIndex other) const { return val != other.val; }
+};
 
 // Internal namespace to keep these generic names clean
 namespace tree_math {
@@ -85,31 +101,31 @@ NodeIndex
 root(NodeCount w);
 
 NodeIndex
-left(LeafIndex x);
+left(NodeIndex x);
 
 NodeIndex
-right(LeafIndex x, NodeCount w);
+right(NodeIndex x, NodeCount w);
 
 NodeIndex
-parent(LeafIndex x, NodeCount w);
+parent(NodeIndex x, NodeCount w);
 
 NodeIndex
-sibling(LeafIndex x, NodeCount w);
+sibling(NodeIndex x, NodeCount w);
 
 std::vector<NodeIndex>
-dirpath(LeafIndex x, NodeCount w);
+dirpath(NodeIndex x, NodeCount w);
 
 std::vector<NodeIndex>
-copath(LeafIndex x, NodeCount w);
+copath(NodeIndex x, NodeCount w);
 
 // XXX(rlb@ipv.sx): The templating here is looser than I would like.
 // Really it should be something like vector<optional<T>>
 template<typename T>
-std::vector<uint32_t>
-resolve(const T& nodes, LeafIndex target)
+std::vector<NodeIndex>
+resolve(const T& nodes, NodeIndex target)
 {
   // Resolution of a populated node is the node itself
-  if (nodes[target]) {
+  if (nodes[target.val]) {
     return { target };
   }
 

--- a/src/include/tree_math.h
+++ b/src/include/tree_math.h
@@ -27,48 +27,86 @@
 //
 //    01x = <00x, 10x>
 
+// Fordward declaration of TLS streams
+namespace tls {
+class istream;
+class ostream;
+}
+
 namespace mls {
+
+// Index types go in the overall namespace
+struct UInt32
+{
+  uint32_t val;
+
+  UInt32()
+    : val(0)
+  {}
+
+  explicit UInt32(uint32_t val)
+    : val(val)
+  {}
+};
+
+tls::istream&
+operator>>(tls::istream& in, UInt32& obj);
+tls::ostream&
+operator<<(tls::ostream& out, const UInt32& obj);
+
+struct LeafCount : public UInt32
+{
+  using UInt32::UInt32;
+};
+
+struct NodeCount : public UInt32
+{
+  using UInt32::UInt32;
+};
+
+typedef uint32_t LeafIndex;
+typedef uint32_t NodeIndex;
 
 // Internal namespace to keep these generic names clean
 namespace tree_math {
 
 uint32_t
-level(uint32_t x);
+level(NodeIndex x);
 
 // Tree size properties
-uint32_t
-node_width(uint32_t n);
+NodeCount
+node_width(LeafCount n);
 
-uint32_t
-size_from_width(uint32_t w);
+LeafCount
+size_from_width(NodeCount w);
 
 // Node relationships
-uint32_t
-root(uint32_t n);
+NodeIndex
+root(NodeCount w);
 
-uint32_t
-left(uint32_t x);
+NodeIndex
+left(LeafIndex x);
 
-uint32_t
-right(uint32_t x, uint32_t n);
+NodeIndex
+right(LeafIndex x, NodeCount w);
 
-uint32_t
-parent(uint32_t x, uint32_t n);
+NodeIndex
+parent(LeafIndex x, NodeCount w);
 
-uint32_t
-sibling(uint32_t x, uint32_t n);
+NodeIndex
+sibling(LeafIndex x, NodeCount w);
 
-std::vector<uint32_t>
-dirpath(uint32_t x, uint32_t n);
+std::vector<NodeIndex>
+dirpath(LeafIndex x, NodeCount w);
 
-std::vector<uint32_t>
-copath(uint32_t x, uint32_t n);
+std::vector<NodeIndex>
+copath(LeafIndex x, NodeCount w);
 
 // XXX(rlb@ipv.sx): The templating here is looser than I would like.
 // Really it should be something like vector<optional<T>>
 template<typename T>
 std::vector<uint32_t>
-resolve(const T& nodes, uint32_t target)
+resolve(const T& nodes, LeafIndex target)
 {
   // Resolution of a populated node is the node itself
   if (nodes[target]) {
@@ -80,7 +118,7 @@ resolve(const T& nodes, uint32_t target)
     return {};
   }
 
-  auto n = size_from_width(nodes.size());
+  auto n = NodeCount{ uint32_t(nodes.size()) };
   auto l = resolve(nodes, left(target));
   auto r = resolve(nodes, right(target, n));
   l.insert(l.end(), r.begin(), r.end());

--- a/src/ratchet_tree.cpp
+++ b/src/ratchet_tree.cpp
@@ -345,14 +345,14 @@ RatchetTree::leaf_span() const
 void
 RatchetTree::truncate(LeafCount leaves)
 {
-  auto w = tree_math::node_width(LeafCount{ leaves });
+  auto w = NodeCount{ leaves };
   _nodes.resize(w.val);
 }
 
 uint32_t
 RatchetTree::size() const
 {
-  return leaf_size().val;
+  return LeafCount{ node_size() }.val;
 }
 
 bool
@@ -404,12 +404,6 @@ NodeCount
 RatchetTree::node_size() const
 {
   return NodeCount{ uint32_t(_nodes.size()) };
-}
-
-LeafCount
-RatchetTree::leaf_size() const
-{
-  return tree_math::size_from_width(node_size());
 }
 
 RatchetTreeNode

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -174,7 +174,7 @@ namespace test {
 uint32_t
 TestSession::index() const
 {
-  return current_state().index();
+  return current_state().index().val;
 }
 
 epoch_t

--- a/src/tree_math.cpp
+++ b/src/tree_math.cpp
@@ -1,9 +1,30 @@
 #include "tree_math.h"
+#include "common.h"
 #include "tls_syntax.h"
 
 #include <algorithm>
 
+static uint32_t one = 0x01;
+
 namespace mls {
+
+LeafCount::LeafCount(const NodeCount w)
+{
+  if (w.val == 0) {
+    val = 0;
+    return;
+  }
+
+  if ((w.val & one) == 0) {
+    throw InvalidParameterError("Only odd node counts describe trees");
+  }
+
+  val = (w.val >> one) + 1;
+}
+
+NodeCount::NodeCount(const LeafCount n)
+  : UInt32(2 * (n.val - 1) + 1)
+{}
 
 tls::istream&
 operator>>(tls::istream& in, UInt32& obj)
@@ -18,8 +39,6 @@ operator<<(tls::ostream& out, const UInt32& obj)
 }
 
 namespace tree_math {
-
-static uint32_t one = 0x01;
 
 static uint32_t
 log2(uint32_t x)
@@ -47,22 +66,6 @@ level(NodeIndex x)
     k += 1;
   }
   return k;
-}
-
-NodeCount
-node_width(LeafCount n)
-{
-  return NodeCount{ 2 * (n.val - 1) + 1 };
-}
-
-LeafCount
-size_from_width(NodeCount w)
-{
-  if (w.val == 0) {
-    return LeafCount{ 0 };
-  }
-
-  return LeafCount{ (w.val >> one) + 1 };
 }
 
 NodeIndex

--- a/src/tree_math.cpp
+++ b/src/tree_math.cpp
@@ -38,12 +38,12 @@ log2(uint32_t x)
 uint32_t
 level(NodeIndex x)
 {
-  if ((x & one) == 0) {
+  if ((x.val & one) == 0) {
     return 0;
   }
 
   uint32_t k = 0;
-  while (((x >> k) & one) == 1) {
+  while (((x.val >> k) & one) == 1) {
     k += 1;
   }
   return k;
@@ -68,7 +68,7 @@ size_from_width(NodeCount w)
 NodeIndex
 root(NodeCount w)
 {
-  return (one << log2(w.val)) - 1;
+  return NodeIndex{ (one << log2(w.val)) - 1 };
 }
 
 NodeIndex
@@ -78,7 +78,7 @@ left(NodeIndex x)
     return x;
   }
 
-  return x ^ (one << (level(x) - 1));
+  return NodeIndex{ x.val ^ (one << (level(x) - 1)) };
 }
 
 NodeIndex
@@ -88,8 +88,8 @@ right(NodeIndex x, NodeCount w)
     return x;
   }
 
-  uint32_t r = x ^ (uint32_t(0x03) << (level(x) - 1));
-  while (r >= w.val) {
+  NodeIndex r{ x.val ^ (uint32_t(0x03) << (level(x) - 1)) };
+  while (r.val >= w.val) {
     r = left(r);
   }
   return r;
@@ -99,7 +99,7 @@ static NodeIndex
 parent_step(NodeIndex x)
 {
   auto k = level(x);
-  return (x | (one << k)) & ~(one << (k + 1));
+  return NodeIndex{ (x.val | (one << k)) & ~(one << (k + 1)) };
 }
 
 NodeIndex
@@ -110,7 +110,7 @@ parent(NodeIndex x, NodeCount w)
   }
 
   auto p = parent_step(x);
-  while (p >= w.val) {
+  while (p.val >= w.val) {
     p = parent_step(p);
   }
   return p;
@@ -120,11 +120,11 @@ NodeIndex
 sibling(NodeIndex x, NodeCount w)
 {
   auto p = parent(x, w);
-  if (x < p) {
+  if (x.val < p.val) {
     return right(p, w);
   }
 
-  if (x > p) {
+  if (x.val > p.val) {
     return left(p);
   }
 
@@ -138,7 +138,7 @@ dirpath(NodeIndex x, NodeCount w)
   std::vector<NodeIndex> d;
 
   auto r = root(w);
-  for (auto c = x; c != r; c = parent(c, w)) {
+  for (auto c = x; c.val != r.val; c = parent(c, w)) {
     d.push_back(c);
   }
 
@@ -149,7 +149,7 @@ std::vector<NodeIndex>
 copath(NodeIndex x, NodeCount w)
 {
   auto d = dirpath(x, w);
-  std::vector<uint32_t> c(d.size());
+  std::vector<NodeIndex> c(d.size());
   for (size_t i = 0; i < d.size(); ++i) {
     c[i] = sibling(d[i], w);
   }

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -44,8 +44,8 @@ protected:
     auto ratchet_tree =
       RatchetTree{ tc.cipher_suite,
                    { tv.random, tv.random, tv.random, tv.random } };
-    ratchet_tree.blank_path(2);
-    auto direct_path = ratchet_tree.encrypt(0, tv.random);
+    ratchet_tree.blank_path(LeafIndex{ 2 });
+    auto direct_path = ratchet_tree.encrypt(LeafIndex{ 0 }, tv.random);
 
     auto cred = Credential::basic(tv.user_id, sig_key);
     auto roster = Roster{};

--- a/test/test_vectors.cpp
+++ b/test/test_vectors.cpp
@@ -31,9 +31,9 @@ operator<<(tls::ostream& str, const TreeMathTestVectors& obj)
 const std::string ResolutionTestVectors::file_name = "./resolution.bin";
 
 std::vector<bool>
-ResolutionTestVectors::make_tree(uint32_t t, uint32_t n)
+ResolutionTestVectors::make_tree(uint32_t t, NodeCount w)
 {
-  auto vec = std::vector<bool>(n);
+  auto vec = std::vector<bool>(w.val);
   for (int i = 0; i < vec.size(); ++i) {
     vec[i] = t & 1;
     t >>= 1;
@@ -42,13 +42,13 @@ ResolutionTestVectors::make_tree(uint32_t t, uint32_t n)
 }
 
 std::vector<uint8_t>
-ResolutionTestVectors::compact(const std::vector<uint32_t>& res)
+ResolutionTestVectors::compact(const std::vector<NodeIndex>& res)
 {
   std::vector<uint8_t> out(res.size());
   std::transform(res.begin(),
                  res.end(),
                  out.begin(),
-                 [](uint32_t c) -> uint8_t { return c; });
+                 [](NodeIndex c) -> uint8_t { return c; });
   return out;
 }
 

--- a/test/test_vectors.cpp
+++ b/test/test_vectors.cpp
@@ -48,7 +48,7 @@ ResolutionTestVectors::compact(const std::vector<NodeIndex>& res)
   std::transform(res.begin(),
                  res.end(),
                  out.begin(),
-                 [](NodeIndex c) -> uint8_t { return c; });
+                 [](NodeIndex c) -> uint8_t { return c.val; });
   return out;
 }
 

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -179,9 +179,9 @@ struct MessagesTestVectors
     tls::opaque<4> remove;
   };
 
-  uint32_t epoch;
-  uint32_t signer_index;
-  uint32_t removed;
+  epoch_t epoch;
+  LeafIndex signer_index;
+  LeafIndex removed;
   tls::opaque<1> user_id;
   tls::opaque<1> group_id;
   tls::opaque<1> uik_id;

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -3,6 +3,7 @@
 #include "session.h"
 #include "state.h"
 #include "tls_syntax.h"
+#include "tree_math.h"
 #include <string>
 
 using namespace mls;
@@ -11,12 +12,12 @@ struct TreeMathTestVectors
 {
   static const std::string file_name;
 
-  uint32_t n_leaves = 255;
-  tls::vector<uint32_t, 4> root;
-  tls::vector<uint32_t, 4> left;
-  tls::vector<uint32_t, 4> right;
-  tls::vector<uint32_t, 4> parent;
-  tls::vector<uint32_t, 4> sibling;
+  LeafCount n_leaves{ 255 };
+  tls::vector<NodeIndex, 4> root;
+  tls::vector<NodeIndex, 4> left;
+  tls::vector<NodeIndex, 4> right;
+  tls::vector<NodeIndex, 4> parent;
+  tls::vector<NodeIndex, 4> sibling;
 };
 
 tls::istream&
@@ -33,10 +34,10 @@ struct ResolutionTestVectors
   typedef tls::vector<uint8_t, 1> Resolution;
   typedef tls::vector<Resolution, 2> ResolutionCase;
 
-  static std::vector<bool> make_tree(uint32_t t, uint32_t n);
-  static std::vector<uint8_t> compact(const std::vector<uint32_t>& res);
+  static std::vector<bool> make_tree(uint32_t t, NodeCount w);
+  static std::vector<uint8_t> compact(const std::vector<NodeIndex>& res);
 
-  uint32_t n_leaves;
+  LeafCount n_leaves;
   tls::vector<ResolutionCase, 4> cases;
 };
 

--- a/test/tree_math_test.cpp
+++ b/test/tree_math_test.cpp
@@ -15,33 +15,34 @@ class TreeMathTest : public ::testing::Test
 {
 protected:
   const TreeMathTestVectors& tv;
-  uint32_t width;
+  NodeCount width;
 
   TreeMathTest()
     : tv(TestLoader<TreeMathTestVectors>::get())
   {
-    width = tree_math::node_width(tv.n_leaves);
+    width = tree_math::node_width(LeafCount{ tv.n_leaves });
   }
 
   template<typename F>
   auto size_scope(F function)
   {
-    return [=](uint32_t x) -> auto { return function(x, tv.n_leaves); };
+    return [=](uint32_t x) -> auto { return function(x, width); };
   }
 
   template<typename F, typename A>
   void vector_test(F function, A answers)
   {
-    for (uint32_t i = 0; i < width; ++i) {
-      ASSERT_EQ(function(i), answers[i]);
+    for (uint32_t i = 0; i < width.val; ++i) {
+      ASSERT_EQ(function(NodeIndex{ i }), answers[i]);
     }
   }
 };
 
 TEST_F(TreeMathTest, Root)
 {
-  for (uint32_t n = 1; n <= tv.n_leaves; ++n) {
-    ASSERT_EQ(tree_math::root(n), tv.root[n - 1]);
+  for (uint32_t n = 1; n <= tv.n_leaves.val; ++n) {
+    const auto w = tree_math::node_width(LeafCount{ n });
+    ASSERT_EQ(tree_math::root(w), tv.root[n - 1]);
   }
 }
 
@@ -69,12 +70,12 @@ TEST(ResolutionTest, Interop)
 {
   auto tv = TestLoader<ResolutionTestVectors>::get();
 
-  auto width = tree_math::node_width(tv.n_leaves);
-  auto n_cases = (1 << width);
+  auto width = tree_math::node_width(LeafCount{ tv.n_leaves });
+  auto n_cases = (1 << width.val);
 
   for (uint32_t t = 0; t < n_cases; ++t) {
     auto nodes = ResolutionTestVectors::make_tree(t, width);
-    for (uint32_t i = 0; i < width; ++i) {
+    for (uint32_t i = 0; i < width.val; ++i) {
       auto res = tree_math::resolve(nodes, i);
       auto compact = ResolutionTestVectors::compact(res);
       ASSERT_EQ(compact, tv.cases[t][i]);

--- a/test/tree_math_test.cpp
+++ b/test/tree_math_test.cpp
@@ -20,7 +20,7 @@ protected:
   TreeMathTest()
     : tv(TestLoader<TreeMathTestVectors>::get())
   {
-    width = tree_math::node_width(LeafCount{ tv.n_leaves });
+    width = NodeCount{ tv.n_leaves };
   }
 
   template<typename F>
@@ -41,7 +41,7 @@ protected:
 TEST_F(TreeMathTest, Root)
 {
   for (uint32_t n = 1; n <= tv.n_leaves.val; ++n) {
-    const auto w = tree_math::node_width(LeafCount{ n });
+    const auto w = NodeCount{ LeafCount{ n } };
     ASSERT_EQ(tree_math::root(w), tv.root[n - 1]);
   }
 }
@@ -70,7 +70,7 @@ TEST(ResolutionTest, Interop)
 {
   auto tv = TestLoader<ResolutionTestVectors>::get();
 
-  auto width = tree_math::node_width(LeafCount{ tv.n_leaves });
+  auto width = NodeCount{ tv.n_leaves };
   auto n_cases = (1 << width.val);
 
   for (uint32_t t = 0; t < n_cases; ++t) {

--- a/test/tree_math_test.cpp
+++ b/test/tree_math_test.cpp
@@ -26,7 +26,7 @@ protected:
   template<typename F>
   auto size_scope(F function)
   {
-    return [=](uint32_t x) -> auto { return function(x, width); };
+    return [=](NodeIndex x) -> auto { return function(x, width); };
   }
 
   template<typename F, typename A>
@@ -76,7 +76,7 @@ TEST(ResolutionTest, Interop)
   for (uint32_t t = 0; t < n_cases; ++t) {
     auto nodes = ResolutionTestVectors::make_tree(t, width);
     for (uint32_t i = 0; i < width.val; ++i) {
-      auto res = tree_math::resolve(nodes, i);
+      auto res = tree_math::resolve(nodes, NodeIndex{ i });
       auto compact = ResolutionTestVectors::compact(res);
       ASSERT_EQ(compact, tv.cases[t][i]);
     }


### PR DESCRIPTION
It has been unclear when an index refers to a **node** index, and when it refers to a **leaf**.  This PR changes from using raw `uint32_t` values to using structs that wrap `uint32_t`, so that we can use the C++ type system to avoid confusion.  This also lets us make some conversions more readable and elegant, e.g., instead of `2 * leaf_index`, you have `NodeIndex{ leaf_index }`.

There's still an unfortunate amount of wrapping and unwrapping in here.  I might try to reduce that a bit (e.g., with some more operators), but there's a balance to be struck between avoiding unwrapping and allowing inappropriate conversions / comparisons.