### PR TITLE
Improved Efficiency

### DIFF
--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -349,7 +349,11 @@ generate_messages()
                    { tv.random, tv.random, tv.random, tv.random },
                    { cred, cred, cred, cred } };
     ratchet_tree.blank_path(LeafIndex{ 2 });
-    auto direct_path = ratchet_tree.encrypt(LeafIndex{ 0 }, tv.random);
+
+    DirectPath direct_path(ratchet_tree.cipher_suite());
+    bytes dummy;
+    std::tie(direct_path, dummy) =
+      ratchet_tree.encrypt(LeafIndex{ 0 }, tv.random);
 
     // Construct CIK
     auto client_init_key = ClientInitKey{};

--- a/src/include/ratchet_tree.h
+++ b/src/include/ratchet_tree.h
@@ -104,7 +104,7 @@ public:
     std::vector<RatchetTreeNode> nodes;
   };
 
-  DirectPath encrypt(LeafIndex from, const bytes& leaf) const;
+  std::tuple<DirectPath, bytes> encrypt(LeafIndex from, const bytes& leaf);
   MergePath decrypt(LeafIndex from, const DirectPath& path) const;
   void merge_path(LeafIndex from, const MergePath& path);
 

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -41,6 +41,8 @@ protected:
   std::map<epoch_t, State> _state;
   epoch_t _current_epoch;
 
+  std::optional<std::tuple<bytes, State>> _outbound_cache;
+
   void make_init_key();
   void add_state(epoch_t prior_epoch, const State& state);
   State& current_state();

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -25,7 +25,7 @@ public:
   std::pair<bytes, bytes> start(const bytes& group_id,
                                 const bytes& client_init_key);
 
-  std::pair<bytes, bytes> add(const bytes& client_init_key) const;
+  std::pair<bytes, bytes> add(const bytes& client_init_key);
   bytes update(const bytes& leaf_secret);
   bytes remove(const bytes& evict_secret, uint32_t index);
 

--- a/src/include/state.h
+++ b/src/include/state.h
@@ -115,19 +115,19 @@ public:
 
   // Generate a Add message
   std::tuple<Welcome, MLSPlaintext, State> add(
-    const UserInitKey& user_init_key) const;
+    const ClientInitKey& client_init_key) const;
 
   // Generate an Add message at a specific location
   std::tuple<Welcome, MLSPlaintext, State> add(
     uint32_t index,
-    const UserInitKey& user_init_key) const;
+    const ClientInitKey& client_init_key) const;
 
   // Generate an Update message (for post-compromise security)
   std::tuple<MLSPlaintext, State> update(const bytes& leaf_secret);
 
   // Generate a Remove message (to remove another participant)
   std::tuple<MLSPlaintext, State> remove(const bytes& leaf_secret,
-                                         uint32_t index) const;
+                                         uint32_t index);
 
   ///
   /// Generic handshake message handler
@@ -200,7 +200,8 @@ private:
   // A zero vector, for convenience
   bytes _zero;
 
-  State handle(const MLSPlaintext& handshake, bool skipVerify) const;
+  // Apply a group operation (without verification)
+  State apply(const MLSPlaintext& handshake) const;
 
   // Handle an Add (for existing participants only)
   bytes handle(const Add& add);

--- a/src/include/state.h
+++ b/src/include/state.h
@@ -100,7 +100,7 @@ public:
 
   // Negotiate an initial state with another peer based on their
   // ClientInitKey
-  typedef std::pair<State, std::pair<Welcome, MLSPlaintext>> InitialInfo;
+  typedef std::tuple<Welcome, MLSPlaintext, State> InitialInfo;
   static InitialInfo negotiate(
     const bytes& group_id,
     const std::vector<CipherSuite> supported_ciphersuites,
@@ -114,19 +114,20 @@ public:
   ///
 
   // Generate a Add message
-  std::pair<Welcome, MLSPlaintext> add(
-    const ClientInitKey& client_init_key) const;
+  std::tuple<Welcome, MLSPlaintext, State> add(
+    const UserInitKey& user_init_key) const;
 
   // Generate an Add message at a specific location
-  std::pair<Welcome, MLSPlaintext> add(
+  std::tuple<Welcome, MLSPlaintext, State> add(
     uint32_t index,
-    const ClientInitKey& client_init_key) const;
+    const UserInitKey& user_init_key) const;
 
   // Generate an Update message (for post-compromise security)
-  MLSPlaintext update(const bytes& leaf_secret);
+  std::tuple<MLSPlaintext, State> update(const bytes& leaf_secret);
 
   // Generate a Remove message (to remove another participant)
-  MLSPlaintext remove(const bytes& leaf_secret, uint32_t index);
+  std::tuple<MLSPlaintext, State> remove(const bytes& leaf_secret,
+                                         uint32_t index) const;
 
   ///
   /// Generic handshake message handler
@@ -230,7 +231,7 @@ private:
 
   // Signing of handshake messages (including creation of the
   // confirmation MAC)
-  MLSPlaintext sign(const GroupOperation& operation) const;
+  std::tuple<MLSPlaintext, State> sign(const GroupOperation& operation) const;
 
   // Signature verification over a handshake message
   bool verify(const MLSPlaintext& pt) const;

--- a/src/include/state.h
+++ b/src/include/state.h
@@ -123,11 +123,11 @@ public:
     const ClientInitKey& client_init_key) const;
 
   // Generate an Update message (for post-compromise security)
-  std::tuple<MLSPlaintext, State> update(const bytes& leaf_secret);
+  std::tuple<MLSPlaintext, State> update(const bytes& leaf_secret) const;
 
   // Generate a Remove message (to remove another participant)
   std::tuple<MLSPlaintext, State> remove(const bytes& leaf_secret,
-                                         uint32_t index);
+                                         uint32_t index) const;
 
   ///
   /// Generic handshake message handler

--- a/src/include/state.h
+++ b/src/include/state.h
@@ -100,8 +100,7 @@ public:
 
   // Negotiate an initial state with another peer based on their
   // ClientInitKey
-  typedef std::tuple<Welcome, MLSPlaintext, State> InitialInfo;
-  static InitialInfo negotiate(
+  static std::tuple<Welcome, MLSPlaintext, State> negotiate(
     const bytes& group_id,
     const std::vector<CipherSuite> supported_ciphersuites,
     const bytes& leaf_secret,
@@ -119,7 +118,7 @@ public:
 
   // Generate an Add message at a specific location
   std::tuple<Welcome, MLSPlaintext, State> add(
-    uint32_t index,
+    LeafIndex index,
     const ClientInitKey& client_init_key) const;
 
   // Generate an Update message (for post-compromise security)
@@ -127,7 +126,7 @@ public:
 
   // Generate a Remove message (to remove another participant)
   std::tuple<MLSPlaintext, State> remove(const bytes& leaf_secret,
-                                         uint32_t index) const;
+                                         LeafIndex index) const;
 
   ///
   /// Generic handshake message handler
@@ -195,13 +194,14 @@ private:
   // Per-participant state
   LeafIndex _index;
   SignaturePrivateKey _identity_priv;
-  bytes _cached_leaf_secret;
 
   // A zero vector, for convenience
   bytes _zero;
 
-  // Apply a group operation (without verification)
-  State apply(const MLSPlaintext& handshake) const;
+  // Ratchet the key schedule forward and sign the operation that
+  // caused the transition
+  MLSPlaintext ratchet_and_sign(const GroupOperation& op,
+                                const bytes& update_secret);
 
   // Handle an Add (for existing participants only)
   bytes handle(const Add& add);
@@ -229,10 +229,6 @@ private:
 
   // Derive the secrets for an epoch, given some new entropy
   void update_epoch_secrets(const bytes& update_secret);
-
-  // Signing of handshake messages (including creation of the
-  // confirmation MAC)
-  std::tuple<MLSPlaintext, State> sign(const GroupOperation& operation) const;
 
   // Signature verification over a handshake message
   bool verify(const MLSPlaintext& pt) const;

--- a/src/ratchet_tree.cpp
+++ b/src/ratchet_tree.cpp
@@ -365,7 +365,7 @@ RatchetTree::decrypt(LeafIndex from, const DirectPath& path) const
         throw InvalidParameterError("Incorrect node public key");
       }
 
-      merge_path.nodes.push_back(new_node(path_secret));
+      merge_path.nodes.push_back(temp);
     } else {
       merge_path.nodes.emplace_back(path_node.public_key);
     }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -68,11 +68,11 @@ Session::start(const bytes& group_id, const bytes& client_init_key_bytes)
 }
 
 std::pair<bytes, bytes>
-Session::add(const bytes& client_init_key_bytes) const
+Session::add(const bytes& client_init_key_bytes)
 {
   ClientInitKey client_init_key;
   tls::unmarshal(client_init_key_bytes, client_init_key);
-  auto welcome_add_state = current_state().add(user_init_key);
+  auto welcome_add_state = current_state().add(client_init_key);
   auto welcome = tls::marshal(std::get<0>(welcome_add_state));
   auto add = tls::marshal(std::get<1>(welcome_add_state));
   auto state = std::get<2>(welcome_add_state);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -99,7 +99,7 @@ Session::update(const bytes& leaf_secret)
 bytes
 Session::remove(const bytes& evict_secret, uint32_t index)
 {
-  auto remove_state = current_state().remove(evict_secret, index);
+  auto remove_state = current_state().remove(evict_secret, LeafIndex{ index });
   auto remove = tls::marshal(std::get<0>(remove_state));
   auto state = std::get<1>(remove_state);
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -60,13 +60,11 @@ Session::start(const bytes& group_id, const bytes& client_init_key_bytes)
                                _credential,
                                client_init_key);
 
-  auto root = init.first;
-  add_state(0, root);
+  add_state(0, std::get<2>(init));
 
-  auto welcome_add = init.second;
-  auto welcome = tls::marshal(welcome_add.first);
-  auto add = tls::marshal(welcome_add.second);
-  return std::pair<bytes, bytes>(welcome, add);
+  auto welcome = tls::marshal(std::get<0>(init));
+  auto add = tls::marshal(std::get<1>(init));
+  return std::make_pair(welcome, add);
 }
 
 std::pair<bytes, bytes>
@@ -74,24 +72,38 @@ Session::add(const bytes& client_init_key_bytes) const
 {
   ClientInitKey client_init_key;
   tls::unmarshal(client_init_key_bytes, client_init_key);
-  auto welcome_add = current_state().add(client_init_key);
-  auto welcome = tls::marshal(welcome_add.first);
-  auto add = tls::marshal(welcome_add.second);
+  auto welcome_add_state = current_state().add(user_init_key);
+  auto welcome = tls::marshal(std::get<0>(welcome_add_state));
+  auto add = tls::marshal(std::get<1>(welcome_add_state));
+  auto state = std::get<2>(welcome_add_state);
+
+  _outbound_cache = std::make_tuple(add, state);
+
   return std::pair<bytes, bytes>(welcome, add);
 }
 
 bytes
 Session::update(const bytes& leaf_secret)
 {
-  auto update = current_state().update(leaf_secret);
-  return tls::marshal(update);
+  auto update_state = current_state().update(leaf_secret);
+  auto update = tls::marshal(std::get<0>(update_state));
+  auto state = std::get<1>(update_state);
+
+  _outbound_cache = std::make_tuple(update, state);
+
+  return update;
 }
 
 bytes
 Session::remove(const bytes& evict_secret, uint32_t index)
 {
-  auto update = current_state().remove(evict_secret, index);
-  return tls::marshal(update);
+  auto remove_state = current_state().remove(evict_secret, index);
+  auto remove = tls::marshal(std::get<0>(remove_state));
+  auto state = std::get<1>(remove_state);
+
+  _outbound_cache = std::make_tuple(remove, state);
+
+  return remove;
 }
 
 void
@@ -112,6 +124,16 @@ Session::handle(const bytes& handshake_data)
 {
   MLSPlaintext handshake{ current_state().cipher_suite() };
   tls::unmarshal(handshake_data, handshake);
+
+  if (_outbound_cache.has_value()) {
+    auto message = std::get<0>(_outbound_cache.value());
+    auto state = std::get<1>(_outbound_cache.value());
+    if (message == handshake_data) {
+      add_state(handshake.epoch, state);
+      _outbound_cache = std::nullopt;
+      return;
+    }
+  }
 
   auto next = current_state().handle(handshake);
   add_state(handshake.epoch, next);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1,7 +1,5 @@
 #include "state.h"
 
-#include <iostream>
-
 namespace mls {
 
 ///
@@ -159,7 +157,7 @@ State::State(SignaturePrivateKey identity_priv,
   }
 }
 
-State::InitialInfo
+std::tuple<Welcome, MLSPlaintext, State>
 State::negotiate(const bytes& group_id,
                  const std::vector<CipherSuite> supported_ciphersuites,
                  const bytes& leaf_secret,
@@ -201,90 +199,61 @@ State::negotiate(const bytes& group_id,
 std::tuple<Welcome, MLSPlaintext, State>
 State::add(const ClientInitKey& client_init_key) const
 {
-  return add(_tree.size(), client_init_key);
+  return add(LeafIndex{ _tree.size() }, client_init_key);
 }
 
 std::tuple<Welcome, MLSPlaintext, State>
-State::add(uint32_t index, const ClientInitKey& client_init_key) const
+State::add(LeafIndex index, const ClientInitKey& client_init_key) const
 {
   if (!client_init_key.verify()) {
     throw InvalidParameterError("bad signature on user init key");
   }
 
-  auto pub = client_init_key.find_init_key(_suite);
-  if (!pub) {
+  auto maybe_pub = client_init_key.find_init_key(_suite);
+  if (!maybe_pub.has_value()) {
     throw ProtocolError("New member does not support the group's ciphersuite");
   }
+  auto pub = maybe_pub.value();
 
+  // Add to the tree
+  auto next = *this;
+  next._tree.add_leaf(index, pub, client_init_key.credential);
+
+  // Construct the welcome message
   auto welcome_info_str = welcome_info();
   auto welcome =
-    Welcome{ client_init_key.client_init_key_id, *pub, welcome_info_str };
+    Welcome{ client_init_key.client_init_key_id, pub, welcome_info_str };
   auto welcome_tuple = std::make_tuple(welcome);
 
   auto welcome_info_hash = welcome_info_str.hash(_suite);
-  auto add_state =
-    sign(Add{ LeafIndex{ index }, client_init_key, welcome_info_hash });
-  return std::tuple_cat(welcome_tuple, add_state);
+  auto add = Add{ LeafIndex{ index }, client_init_key, welcome_info_hash };
+  auto handshake = next.ratchet_and_sign(add, _zero);
+  return std::make_tuple(welcome, handshake, next);
 }
 
 std::tuple<MLSPlaintext, State>
-State::update(const bytes& leaf_secret)
+State::update(const bytes& leaf_secret) const
 {
-  /* xxx
-  auto path = _tree.encrypt(_index, leaf_secret);
-  _cached_leaf_secret = leaf_secret;
-  return sign(Update{ path });
-  */
-
   auto next = *this;
   DirectPath path(_suite);
   bytes update_secret;
   std::tie(path, update_secret) = next._tree.encrypt(_index, leaf_secret);
+
   auto update = Update{ path };
-
-  // TODO encapsulate the below in a new ratchet_and_sign() method
-  auto handshake = MLSPlaintext{ _group_id, _epoch, _index, update };
-  next.update_transcript_hash(handshake);
-  next._epoch += 1;
-  next.update_epoch_secrets(update_secret);
-
-  handshake.confirmation =
-    hmac(_suite, next._confirmation_key, next._confirmed_transcript_hash);
-  handshake.sign(_identity_priv);
-
-  std::cout << "conf_gen " << _index.val << std::endl;
-  std::cout << "         " << next._confirmation_key << std::endl;
-  std::cout << "       + " << next._confirmed_transcript_hash << std::endl;
-  std::cout << "       = " << handshake.confirmation << std::endl;
-
-  next._interim_transcript_hash = _interim_transcript_hash;
-  next.update_transcript_hash(handshake);
-
+  auto handshake = next.ratchet_and_sign(update, update_secret);
   return std::make_tuple(handshake, next);
 }
 
 std::tuple<MLSPlaintext, State>
-State::remove(const bytes& leaf_secret, uint32_t index)
+State::remove(const bytes& leaf_secret, LeafIndex index) const
 {
-  if (index >= _tree.size()) {
+  if (index.val >= _tree.size()) {
     throw InvalidParameterError("Index too large for tree");
   }
 
-  if (index == _index.val) {
+  if (index == _index) {
     throw InvalidParameterError("Cannot self-remove");
   }
-
-  /* xxx
-  auto tree = _tree;
-  tree.blank_path(LeafIndex{ index });
-  auto cut = tree.leaf_span();
-  tree.truncate(cut);
-
-  _cached_leaf_secret = leaf_secret;
-  auto path = tree.encrypt(_index, leaf_secret);
-
-  return sign(Remove{ LeafIndex{ index }, path });
-  */
 
   auto next = *this;
   next._tree.blank_path(LeafIndex{ index });
@@ -296,20 +265,7 @@ State::remove(const bytes& leaf_secret, uint32_t index)
   std::tie(path, update_secret) = next._tree.encrypt(_index, leaf_secret);
 
   auto remove = Remove{ LeafIndex{ index }, path };
-
-  // TODO encapsulate the below in a new ratchet_and_sign() method
-  auto handshake = MLSPlaintext{ _group_id, _epoch, _index, remove };
-  next.update_transcript_hash(handshake);
-  next._epoch += 1;
-  next.update_epoch_secrets(update_secret);
-
-  handshake.confirmation =
-    hmac(_suite, next._confirmation_key, next._confirmed_transcript_hash);
-  handshake.sign(_identity_priv);
-
-  next._interim_transcript_hash = _interim_transcript_hash;
-  next.update_transcript_hash(handshake);
-
+  auto handshake = next.ratchet_and_sign(remove, update_secret);
   return std::make_tuple(handshake, next);
 }
 
@@ -317,9 +273,56 @@ State::remove(const bytes& leaf_secret, uint32_t index)
 /// Message handlers
 ///
 
-State
-State::apply(const MLSPlaintext& handshake) const
+MLSPlaintext
+State::ratchet_and_sign(const GroupOperation& op, const bytes& update_secret)
 {
+  auto handshake = MLSPlaintext{ _group_id, _epoch, _index, op };
+
+  _confirmed_transcript_hash = Digest(_suite)
+                                 .write(_interim_transcript_hash)
+                                 .write(handshake.content())
+                                 .digest();
+
+  _epoch += 1;
+  update_epoch_secrets(update_secret);
+
+  handshake.confirmation =
+    hmac(_suite, _confirmation_key, _confirmed_transcript_hash);
+  handshake.sign(_identity_priv);
+
+  _interim_transcript_hash = Digest(_suite)
+                               .write(_confirmed_transcript_hash)
+                               .write(handshake.auth_data())
+                               .digest();
+
+  return handshake;
+}
+
+State
+State::handle(const MLSPlaintext& handshake) const
+{
+  // Pre-validate the MLSPlaintext
+  if (handshake.group_id != _group_id) {
+    throw InvalidParameterError("GroupID mismatch");
+  }
+
+  if (handshake.epoch != _epoch) {
+    throw InvalidParameterError("Epoch mismatch");
+  }
+
+  if (handshake.content_type != ContentType::handshake) {
+    throw InvalidParameterError("Incorrect content type");
+  }
+
+  if (handshake.sender == _index) {
+    throw InvalidParameterError("Handle own messages with caching");
+  }
+
+  if (!verify(handshake)) {
+    throw ProtocolError("Invalid handshake message signature");
+  }
+
+  // Apply the operation
   const auto& operation = handshake.operation.value();
   auto next = *this;
 
@@ -339,37 +342,6 @@ State::apply(const MLSPlaintext& handshake) const
   next.update_transcript_hash(handshake);
   next._epoch += 1;
   next.update_epoch_secrets(update_secret);
-  return next;
-}
-
-State
-State::handle(const MLSPlaintext& handshake) const
-{
-  // Pre-validate the MLSPlaintext
-  if (handshake.group_id != _group_id) {
-    throw InvalidParameterError("GroupID mismatch");
-  }
-
-  if (handshake.epoch != _epoch) {
-    throw InvalidParameterError("Epoch mismatch");
-  }
-
-  if (handshake.content_type != ContentType::handshake) {
-    throw InvalidParameterError("Incorrect content type");
-  }
-
-  if (handshake.sender == _index &&
-      handshake.operation.value().type != GroupOperationType::add) {
-    // xxx: remove add caveat
-    throw InvalidParameterError("Handle own messages with caching");
-  }
-
-  if (!verify(handshake)) {
-    throw ProtocolError("Invalid handshake message signature");
-  }
-
-  // Apply the operation
-  auto next = apply(handshake);
 
   // Verify the  confirmation MAC
   if (!next.verify_confirmation(handshake.confirmation)) {
@@ -414,17 +386,6 @@ bytes
 State::handle(LeafIndex sender, const Update& update)
 {
   std::optional<bytes> leaf_secret = std::nullopt;
-  /* xxx
-  if (sender == _index) {
-    if (_cached_leaf_secret.empty()) {
-      throw InvalidParameterError("Got self-update without generating one");
-    }
-
-    leaf_secret = _cached_leaf_secret;
-    _cached_leaf_secret.clear();
-  }
-  */
-
   return update_leaf(sender, update.path, leaf_secret);
 }
 
@@ -436,18 +397,6 @@ State::handle(LeafIndex sender, const Remove& remove)
   _tree.truncate(cut);
 
   std::optional<bytes> leaf_secret = std::nullopt;
-  /* xxx
-  if (sender == _index) {
-    if (_cached_leaf_secret.empty()) {
-      throw InvalidParameterError(
-        "Got remove from myself without generating one");
-    }
-
-    leaf_secret = _cached_leaf_secret;
-    _cached_leaf_secret.clear();
-  }
-  */
-
   return update_leaf(sender, remove.path, leaf_secret);
 }
 
@@ -551,12 +500,6 @@ State::update_transcript_hash(const MLSPlaintext& plaintext)
                                .write(_confirmed_transcript_hash)
                                .write(plaintext.auth_data())
                                .digest();
-
-  std::cout << "upd_tx " << _index.val << std::endl;
-  std::cout << "    ++ " << plaintext.content() << std::endl;
-  std::cout << "    -> " << _confirmed_transcript_hash << std::endl;
-  std::cout << "    ++ " << plaintext.auth_data() << std::endl;
-  std::cout << "    -> " << _interim_transcript_hash << std::endl;
 }
 
 bytes
@@ -579,15 +522,6 @@ State::update_leaf(LeafIndex index,
 void
 State::update_epoch_secrets(const bytes& update_secret)
 {
-  std::cout << "upd_epch " << _index.val << std::endl;
-  std::cout << "    init " << _init_secret << std::endl;
-  std::cout << "     upd " << update_secret << std::endl;
-  std::cout << "     gid " << _group_id << std::endl;
-  std::cout << "    epch " << _epoch << std::endl;
-  std::cout << "      th " << _tree.root_hash() << std::endl;
-  std::cout << "      tx " << _confirmed_transcript_hash << std::endl;
-  std::cout << "    tree " << _tree << std::endl << std::endl;
-
   auto group_context_str = GroupContext{
     _group_id,
     _epoch,
@@ -654,26 +588,6 @@ sender_data_aad(const tls::opaque<1>& group_id,
   return w.bytes();
 }
 
-std::tuple<MLSPlaintext, State>
-State::sign(const GroupOperation& operation) const
-{
-  auto handshake = MLSPlaintext{ _group_id, _epoch, _index, operation };
-
-  // Apply the operation
-  auto next = apply(handshake);
-
-  // Compute the confirmation MAC and signature
-  handshake.confirmation =
-    hmac(_suite, next._confirmation_key, next._confirmed_transcript_hash);
-  handshake.sign(_identity_priv);
-
-  // Reset the state's transcript hash to use the signed message
-  next._interim_transcript_hash = _interim_transcript_hash;
-  next.update_transcript_hash(handshake);
-
-  return std::make_tuple(handshake, next);
-}
-
 bool
 State::verify(const MLSPlaintext& pt) const
 {
@@ -685,13 +599,6 @@ bool
 State::verify_confirmation(const bytes& confirmation) const
 {
   auto confirm = hmac(_suite, _confirmation_key, _confirmed_transcript_hash);
-
-  std::cout << "conf_ver " << _index.val << std::endl;
-  std::cout << "         " << _confirmation_key << std::endl;
-  std::cout << "       + " << _confirmed_transcript_hash << std::endl;
-  std::cout << "       = " << confirm << std::endl;
-  std::cout << "       ? " << confirmation << std::endl;
-
   return constant_time_eq(confirm, confirmation);
 }
 

--- a/test/crypto_test.cpp
+++ b/test/crypto_test.cpp
@@ -212,7 +212,7 @@ protected:
     auto derive_key_pair_pub = derive_key_pair_priv.public_key();
     ASSERT_EQ(derive_key_pair_pub, test_case.derive_key_pair_pub);
 
-    ::mls::test::DeterministicHPKE lock;
+    mls::test::DeterministicHPKE lock;
     auto ecies_out = derive_key_pair_pub.encrypt(tv.ecies_plaintext);
     ASSERT_EQ(ecies_out, test_case.ecies_out);
   }

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -47,7 +47,11 @@ protected:
                    { tv.random, tv.random, tv.random, tv.random },
                    { cred, cred, cred, cred } };
     ratchet_tree.blank_path(LeafIndex{ 2 });
-    auto direct_path = ratchet_tree.encrypt(LeafIndex{ 0 }, tv.random);
+
+    DirectPath direct_path(ratchet_tree.cipher_suite());
+    bytes dummy;
+    std::tie(direct_path, dummy) =
+      ratchet_tree.encrypt(LeafIndex{ 0 }, tv.random);
 
     // ClientInitKey
     ClientInitKey client_init_key_c;

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -242,7 +242,7 @@ TEST(OtherStateTest, CipherNegotiation)
 
   // Bob should choose P-256
   auto initialB =
-    State::negotiate(group_id, supported_ciphers, insB, idkB, credB, uikA);
+    State::negotiate(group_id, supported_ciphers, insB, idkB, credB, cikA);
   auto stateB = std::get<2>(initialB);
   ASSERT_EQ(stateB.cipher_suite(), CipherSuite::P256_SHA256_AES128GCM);
 


### PR DESCRIPTION
Earlier versions spent a lot of time performing duplicative operations.  The primary cause of this extra work is use of `State::handle()` to generate the provisional state used in generating a confirmation MAC, instead of using the tree modifications already done.  Likewise, the sender of an operation has already computed the tree, so there's no need to recompute if you cache it.

This PR uses far fewer crypto operations, at the cost of (1) having to cache the provisional state, and (2) some duplication of code between the sending and receiving sides.