### PR TITLE
Remove boilerplate

### DIFF
--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -443,7 +443,7 @@ generate_basic_session()
     std::vector<ClientInitKey> client_init_keys;
     std::vector<TestSession> sessions;
     std::vector<bytes> seeds;
-    auto ciphersuites = CipherList{ suite };
+    auto ciphersuites = std::vector<CipherSuite>{ suite };
     for (size_t j = 0; j < tv.group_size; ++j) {
       bytes seed = { uint8_t(j), 0 };
       auto identity_priv = SignaturePrivateKey::derive(scheme, seed);

--- a/include/common.h
+++ b/include/common.h
@@ -57,6 +57,22 @@ operator<<(std::ostream& out, const bytes& data);
 typedef uint32_t epoch_t;
 
 ///
+/// Auto-generate equality and inequality operators for TLS-serializable things
+///
+
+template<typename T>
+inline typename std::enable_if<T::_tls_serializable, bool>::type
+operator==(const T& lhs, const T& rhs) {
+  return lhs._tls_fields_w() == rhs._tls_fields_w();
+}
+
+template<typename T>
+inline typename std::enable_if<T::_tls_serializable, bool>::type
+operator!=(const T& lhs, const T& rhs) {
+  return lhs._tls_fields_w() != rhs._tls_fields_w();
+}
+
+///
 /// Error types
 ///
 

--- a/include/common.h
+++ b/include/common.h
@@ -6,17 +6,6 @@
 #include <stdexcept>
 #include <vector>
 
-// Forward declarations to enable optional serialization below
-namespace tls {
-class ostream;
-class istream;
-
-ostream&
-operator<<(ostream& out, uint8_t data);
-istream&
-operator>>(istream& in, uint8_t& data);
-}
-
 namespace mls {
 
 ///

--- a/include/common.h
+++ b/include/common.h
@@ -74,13 +74,6 @@ public:
   using parent::parent;
 };
 
-class InvalidTLSSyntax : public std::invalid_argument
-{
-public:
-  using parent = std::invalid_argument;
-  using parent::parent;
-};
-
 class IncompatibleNodesError : public std::invalid_argument
 {
 public:

--- a/include/common.h
+++ b/include/common.h
@@ -9,18 +9,10 @@
 namespace mls {
 
 ///
-/// Protocol versions
-///
-
-typedef uint8_t ProtocolVersion;
-
-static const ProtocolVersion mls10Version = 0xFF;
-
-///
 /// Byte strings and serialization
 ///
 
-typedef std::vector<uint8_t> bytes;
+using bytes = std::vector<uint8_t>;
 
 bytes
 to_bytes(const std::string& ascii);
@@ -43,7 +35,7 @@ operator^(const bytes& lhs, const bytes& rhs);
 std::ostream&
 operator<<(std::ostream& out, const bytes& data);
 
-typedef uint32_t epoch_t;
+using epoch_t = uint32_t;
 
 ///
 /// Auto-generate equality and inequality operators for TLS-serializable things

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -26,6 +26,8 @@ enum struct SignatureScheme : uint16_t
   Ed448 = 0x0808
 };
 
+#define DUMMY_SIGNATURE_SCHEME SignatureScheme::P256_SHA256
+
 // Utility classes to avoid a bit of boilerplate
 class CipherAware
 {

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -20,11 +20,6 @@ enum struct CipherSuite : uint16_t
 
 typedef std::vector<CipherSuite> CipherList;
 
-tls::ostream&
-operator<<(tls::ostream& out, const CipherSuite& obj);
-tls::istream&
-operator>>(tls::istream& in, CipherSuite& obj);
-
 enum struct SignatureScheme : uint16_t
 {
   P256_SHA256 = 0x0403,
@@ -33,17 +28,15 @@ enum struct SignatureScheme : uint16_t
   Ed448 = 0x0808
 };
 
-tls::ostream&
-operator<<(tls::ostream& out, const SignatureScheme& obj);
-tls::istream&
-operator>>(tls::istream& in, SignatureScheme& obj);
-
 // Utility classes to avoid a bit of boilerplate
 class CipherAware
 {
 public:
-  CipherAware(CipherSuite suite);
-  CipherSuite cipher_suite() const;
+  CipherAware(CipherSuite suite)
+    : _suite(suite)
+  {}
+
+  CipherSuite cipher_suite() const { return _suite; }
 
 protected:
   CipherSuite _suite;
@@ -52,8 +45,11 @@ protected:
 class SignatureAware
 {
 public:
-  SignatureAware(SignatureScheme scheme);
-  SignatureScheme signature_scheme() const;
+  SignatureAware(SignatureScheme scheme)
+    : _scheme(scheme)
+  {}
+
+  SignatureScheme signature_scheme() const { return _scheme; }
 
 protected:
   SignatureScheme _scheme;

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -336,8 +336,6 @@ struct HPKECiphertext : public CipherAware
     , content(content_in)
   {}
 
-  friend bool operator==(const HPKECiphertext& lhs, const HPKECiphertext& rhs);
-
   TLS_SERIALIZABLE(ephemeral, content);
 };
 

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -337,8 +337,8 @@ struct HPKECiphertext : public CipherAware
   {}
 
   friend bool operator==(const HPKECiphertext& lhs, const HPKECiphertext& rhs);
-  friend tls::ostream& operator<<(tls::ostream& out, const HPKECiphertext& obj);
-  friend tls::istream& operator>>(tls::istream& in, HPKECiphertext& obj);
+
+  TLS_SERIALIZABLE(ephemeral, content);
 };
 
 } // namespace mls

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -18,8 +18,6 @@ enum struct CipherSuite : uint16_t
   X448_SHA512_AES256GCM = 0x0011
 };
 
-typedef std::vector<CipherSuite> CipherList;
-
 enum struct SignatureScheme : uint16_t
 {
   P256_SHA256 = 0x0403,

--- a/include/messages.h
+++ b/include/messages.h
@@ -24,9 +24,6 @@ struct RatchetNode : public CipherAware
   TLS_SERIALIZABLE(public_key, node_secrets);
 };
 
-bool
-operator==(const RatchetNode& lhs, const RatchetNode& rhs);
-
 // struct {
 //    RatchetNode nodes<0..2^16-1>;
 // } DirectPath;
@@ -37,9 +34,6 @@ struct DirectPath : public CipherAware
 
   TLS_SERIALIZABLE(nodes);
 };
-
-bool
-operator==(const DirectPath& lhs, const DirectPath& rhs);
 
 // struct {
 //     opaque client_init_key_id<0..255>;
@@ -84,11 +78,6 @@ struct ClientInitKey
   std::map<CipherSuite, DHPrivateKey> _private_keys;
 };
 
-bool
-operator==(const ClientInitKey& lhs, const ClientInitKey& rhs);
-bool
-operator!=(const ClientInitKey& lhs, const ClientInitKey& rhs);
-
 // struct {
 //   ProtocolVersion version;
 //   opaque group_id<0..255>;
@@ -118,9 +107,6 @@ struct WelcomeInfo : public CipherAware
 
   TLS_SERIALIZABLE(version, group_id, epoch, tree, interim_transcript_hash, init_secret);
 };
-
-bool
-operator==(const WelcomeInfo& lhs, const WelcomeInfo& rhs);
 
 // struct {
 //   opaque client_init_key_id<0..255>;
@@ -178,9 +164,6 @@ public:
   TLS_SERIALIZABLE(index, init_key, welcome_info_hash)
 };
 
-bool
-operator==(const Add& lhs, const Add& rhs);
-
 // struct {
 //     DirectPath path;
 // } Update;
@@ -195,9 +178,6 @@ public:
 
   TLS_SERIALIZABLE(path);
 };
-
-bool
-operator==(const Update& lhs, const Update& rhs);
 
 // struct {
 //     uint32 removed;
@@ -215,9 +195,6 @@ public:
 
   TLS_SERIALIZABLE(removed, path);
 };
-
-bool
-operator==(const Remove& lhs, const Remove& rhs);
 
 // Container class for all operations
 //
@@ -348,8 +325,5 @@ struct MLSCiphertext
   TLS_SERIALIZABLE(group_id, epoch, content_type, sender_data_nonce,
                    encrypted_sender_data, ciphertext);
 };
-
-bool
-operator==(const MLSCiphertext& lhs, const MLSCiphertext& rhs);
 
 } // namespace mls

--- a/include/messages.h
+++ b/include/messages.h
@@ -163,6 +163,7 @@ public:
   tls::opaque<1> welcome_info_hash;
 
   Add() = default;
+  Add(CipherSuite suite) {}
   Add(LeafIndex index, ClientInitKey init_key, bytes welcome_info_hash);
   static const GroupOperationType type;
 
@@ -212,20 +213,16 @@ public:
 //         case remove:    Remove;
 //     };
 // } GroupOperation;
-struct GroupOperation : public CipherAware, public std::variant<std::monostate, Add, Update, Remove>
+struct GroupOperation : public CipherAware,
+                        public tls::variant_variant<GroupOperationType, CipherSuite, Add, Update, Remove>
 {
-  using InnerOp = std::variant<std::monostate, Add, Update, Remove>;
-  GroupOperation();
+  using InnerOp = tls::variant_variant<GroupOperationType, CipherSuite, Add, Update, Remove>;
   GroupOperation(CipherSuite suite);
   GroupOperation(const Add& add);
   GroupOperation(const Update& update);
   GroupOperation(const Remove& remove);
 
   GroupOperationType type() const;
-
-  friend bool operator==(const GroupOperation& lhs, const GroupOperation& rhs);
-  friend tls::ostream& operator<<(tls::ostream& out, const GroupOperation& obj);
-  friend tls::istream& operator>>(tls::istream& in, GroupOperation& obj);
 };
 
 // enum {
@@ -260,8 +257,6 @@ enum struct ContentType : uint8_t
 // } MLSPlaintext;
 struct MLSPlaintext : public CipherAware
 {
-  using CipherAware::CipherAware;
-
   tls::opaque<1> group_id;
   epoch_t epoch;
   LeafIndex sender;
@@ -273,6 +268,7 @@ struct MLSPlaintext : public CipherAware
 
   tls::opaque<2> signature;
 
+  MLSPlaintext(CipherSuite suite);
   MLSPlaintext(bytes group_id,
                epoch_t epoch,
                LeafIndex sender,

--- a/include/messages.h
+++ b/include/messages.h
@@ -140,11 +140,6 @@ enum class GroupOperationType : uint8_t
   remove = 3,
 };
 
-tls::ostream&
-operator<<(tls::ostream& out, const GroupOperationType& obj);
-tls::istream&
-operator>>(tls::istream& in, GroupOperationType& obj);
-
 // struct {
 //     uint32 index;
 //     ClientInitKey init_key;
@@ -243,11 +238,6 @@ enum struct ContentType : uint8_t
   handshake = 1,
   application = 2,
 };
-
-tls::ostream&
-operator<<(tls::ostream& out, const ContentType& obj);
-tls::istream&
-operator>>(tls::istream& in, ContentType& obj);
 
 // struct {
 //     opaque group_id<0..255>;

--- a/include/messages.h
+++ b/include/messages.h
@@ -20,14 +20,12 @@ struct RatchetNode : public CipherAware
   RatchetNode(CipherSuite suite);
   RatchetNode(DHPublicKey public_key,
               const std::vector<HPKECiphertext>& node_secrets);
+
+  TLS_SERIALIZABLE(public_key, node_secrets);
 };
 
 bool
 operator==(const RatchetNode& lhs, const RatchetNode& rhs);
-tls::ostream&
-operator<<(tls::ostream& out, const RatchetNode& obj);
-tls::istream&
-operator>>(tls::istream& in, RatchetNode& obj);
 
 // struct {
 //    RatchetNode nodes<0..2^16-1>;
@@ -36,14 +34,12 @@ struct DirectPath : public CipherAware
 {
   tls::variant_vector<RatchetNode, CipherSuite, 2> nodes;
   DirectPath(CipherSuite suite);
+
+  TLS_SERIALIZABLE(nodes);
 };
 
 bool
 operator==(const DirectPath& lhs, const DirectPath& rhs);
-tls::ostream&
-operator<<(tls::ostream& out, const DirectPath& obj);
-tls::istream&
-operator>>(tls::istream& in, DirectPath& obj);
 
 // struct {
 //     opaque client_init_key_id<0..255>;
@@ -81,6 +77,9 @@ struct ClientInitKey
   bool verify() const;
   bytes to_be_signed() const;
 
+  TLS_SERIALIZABLE(client_init_key_id, supported_versions, cipher_suites,
+                   init_keys, credential, signature)
+
   private:
   std::map<CipherSuite, DHPrivateKey> _private_keys;
 };
@@ -89,10 +88,6 @@ bool
 operator==(const ClientInitKey& lhs, const ClientInitKey& rhs);
 bool
 operator!=(const ClientInitKey& lhs, const ClientInitKey& rhs);
-tls::ostream&
-operator<<(tls::ostream& out, const ClientInitKey& obj);
-tls::istream&
-operator>>(tls::istream& in, ClientInitKey& obj);
 
 // struct {
 //   ProtocolVersion version;
@@ -120,14 +115,12 @@ struct WelcomeInfo : public CipherAware
               const tls::opaque<1>& init_secret);
 
   bytes hash(CipherSuite suite) const;
+
+  TLS_SERIALIZABLE(version, group_id, epoch, tree, interim_transcript_hash, init_secret);
 };
 
 bool
 operator==(const WelcomeInfo& lhs, const WelcomeInfo& rhs);
-tls::ostream&
-operator<<(tls::ostream& out, const WelcomeInfo& obj);
-tls::istream&
-operator>>(tls::istream& in, WelcomeInfo& obj);
 
 // struct {
 //   opaque client_init_key_id<0..255>;
@@ -181,14 +174,12 @@ public:
   Add() = default;
   Add(LeafIndex index, ClientInitKey init_key, bytes welcome_info_hash);
   static const GroupOperationType type;
+
+  TLS_SERIALIZABLE(index, init_key, welcome_info_hash)
 };
 
 bool
 operator==(const Add& lhs, const Add& rhs);
-tls::ostream&
-operator<<(tls::ostream& out, const Add& obj);
-tls::istream&
-operator>>(tls::istream& in, Add& obj);
 
 // struct {
 //     DirectPath path;
@@ -201,14 +192,12 @@ public:
   Update(CipherSuite suite);
   Update(const DirectPath& path);
   static const GroupOperationType type;
+
+  TLS_SERIALIZABLE(path);
 };
 
 bool
 operator==(const Update& lhs, const Update& rhs);
-tls::ostream&
-operator<<(tls::ostream& out, const Update& obj);
-tls::istream&
-operator>>(tls::istream& in, Update& obj);
 
 // struct {
 //     uint32 removed;
@@ -223,14 +212,12 @@ public:
   Remove(CipherSuite suite);
   Remove(LeafIndex removed, const DirectPath& path);
   static const GroupOperationType type;
+
+  TLS_SERIALIZABLE(removed, path);
 };
 
 bool
 operator==(const Remove& lhs, const Remove& rhs);
-tls::ostream&
-operator<<(tls::ostream& out, const Remove& obj);
-tls::istream&
-operator>>(tls::istream& in, Remove& obj);
 
 // Container class for all operations
 //
@@ -357,13 +344,12 @@ struct MLSCiphertext
   tls::opaque<1> sender_data_nonce;
   tls::opaque<1> encrypted_sender_data;
   tls::opaque<4> ciphertext;
+
+  TLS_SERIALIZABLE(group_id, epoch, content_type, sender_data_nonce,
+                   encrypted_sender_data, ciphertext);
 };
 
 bool
 operator==(const MLSCiphertext& lhs, const MLSCiphertext& rhs);
-tls::ostream&
-operator<<(tls::ostream& out, const MLSCiphertext& obj);
-tls::istream&
-operator>>(tls::istream& in, MLSCiphertext& obj);
 
 } // namespace mls

--- a/include/messages.h
+++ b/include/messages.h
@@ -9,6 +9,15 @@
 
 namespace mls {
 
+///
+/// Protocol versions
+///
+
+enum class ProtocolVersion : uint8_t
+{
+  mls10 = 0xFF,
+};
+
 // struct {
 //    DHPublicKey public_key;
 //    HPKECiphertext node_secrets<0..2^16-1>;
@@ -61,7 +70,7 @@ struct ClientInitKey
 
   ClientInitKey();
   ClientInitKey(bytes client_init_key_id,
-                const CipherList& supported_ciphersuites,
+                const std::vector<CipherSuite>& supported_ciphersuites,
                 const bytes& init_secret,
                 const Credential& credential);
 

--- a/include/messages.h
+++ b/include/messages.h
@@ -5,6 +5,7 @@
 #include "ratchet_tree.h"
 #include "tls_syntax.h"
 #include <optional>
+#include <variant>
 
 namespace mls {
 
@@ -202,24 +203,16 @@ public:
 //         case remove:    Remove;
 //     };
 // } GroupOperation;
-//
-// NB: This is a "pseudo-union" type, in that only one of the struct
-// members will be populated with a non-zero value.  This is a bit
-// wasteful of memory, but necessary to avoid the silliness of C++
-// union types over structs.
-struct GroupOperation : public CipherAware
+struct GroupOperation : public CipherAware, public std::variant<std::monostate, Add, Update, Remove>
 {
-  GroupOperationType type;
-
-  std::optional<Add> add;
-  std::optional<Update> update;
-  std::optional<Remove> remove;
-
+  using InnerOp = std::variant<std::monostate, Add, Update, Remove>;
   GroupOperation();
   GroupOperation(CipherSuite suite);
   GroupOperation(const Add& add);
   GroupOperation(const Update& update);
   GroupOperation(const Remove& remove);
+
+  GroupOperationType type() const;
 
   friend bool operator==(const GroupOperation& lhs, const GroupOperation& rhs);
   friend tls::ostream& operator<<(tls::ostream& out, const GroupOperation& obj);

--- a/include/ratchet_tree.h
+++ b/include/ratchet_tree.h
@@ -5,7 +5,6 @@
 #include "crypto.h"
 #include "tls_syntax.h"
 #include "tree_math.h"
-#include <iosfwd>
 #include <optional>
 
 namespace mls {
@@ -29,6 +28,8 @@ public:
   void merge(const RatchetTreeNode& other);
   void set_credential(const Credential& cred);
 
+  TLS_SERIALIZABLE(_pub, _cred);
+
 private:
   std::optional<DHPrivateKey> _priv;
   DHPublicKey _pub;
@@ -42,11 +43,6 @@ private:
                          const RatchetTreeNode& rhs);
   friend bool operator!=(const RatchetTreeNode& lhs,
                          const RatchetTreeNode& rhs);
-  friend std::ostream& operator<<(std::ostream& out,
-                                  const RatchetTreeNode& node);
-  friend tls::ostream& operator<<(tls::ostream& out,
-                                  const RatchetTreeNode& obj);
-  friend tls::istream& operator>>(tls::istream& in, RatchetTreeNode& obj);
 };
 
 // XXX(rlb@ipv.sx): We have to subclass optional<T> in order to
@@ -130,6 +126,8 @@ public:
   bool check_credentials() const;
   bool check_invariant(LeafIndex from) const;
 
+  TLS_SERIALIZABLE(_nodes)
+
 protected:
   RatchetTreeNodeVector _nodes;
   size_t _secret_size;
@@ -146,7 +144,9 @@ protected:
   void set_hash_all(NodeIndex index);
 
   friend bool operator==(const RatchetTree& lhs, const RatchetTree& rhs);
-  friend std::ostream& operator<<(std::ostream& out, const RatchetTree& obj);
+
+  // XXX(rlb): These are still necessary because operator>> triggers the
+  // computation of the tree hash
   friend tls::ostream& operator<<(tls::ostream& out, const RatchetTree& obj);
   friend tls::istream& operator>>(tls::istream& in, RatchetTree& obj);
 };

--- a/include/ratchet_tree.h
+++ b/include/ratchet_tree.h
@@ -36,13 +36,6 @@ private:
 
   // A credential is populated iff this is a leaf node
   tls::optional<Credential> _cred;
-
-  friend RatchetTreeNode operator+(const RatchetTreeNode& lhs,
-                                   const RatchetTreeNode& rhs);
-  friend bool operator==(const RatchetTreeNode& lhs,
-                         const RatchetTreeNode& rhs);
-  friend bool operator!=(const RatchetTreeNode& lhs,
-                         const RatchetTreeNode& rhs);
 };
 
 // XXX(rlb@ipv.sx): We have to subclass optional<T> in order to
@@ -143,10 +136,9 @@ protected:
   void set_hash_path(LeafIndex index);
   void set_hash_all(NodeIndex index);
 
-  friend bool operator==(const RatchetTree& lhs, const RatchetTree& rhs);
-
   // XXX(rlb): These are still necessary because operator>> triggers the
   // computation of the tree hash
+  friend bool operator==(const RatchetTree& lhs, const RatchetTree& rhs);
   friend tls::ostream& operator<<(tls::ostream& out, const RatchetTree& obj);
   friend tls::istream& operator>>(tls::istream& in, RatchetTree& obj);
 };

--- a/include/state.h
+++ b/include/state.h
@@ -21,12 +21,9 @@ struct GroupContext
   epoch_t epoch;
   tls::opaque<1> tree_hash;
   tls::opaque<1> transcript_hash;
-};
 
-tls::ostream&
-operator<<(tls::ostream& out, const GroupContext& obj);
-tls::istream&
-operator>>(tls::istream& out, GroupContext& obj);
+  TLS_SERIALIZABLE(group_id, epoch, tree_hash, transcript_hash)
+};
 
 // XXX(rlb@ipv.sx): This is implemented in "const mode", where we
 // never ratchet forward the base secret.  This allows for maximal

--- a/include/tls_syntax.h
+++ b/include/tls_syntax.h
@@ -36,7 +36,6 @@ public:
 };
 
 // A variant class attached to a type enum
-// TODO: Enable this to pass a args to a ctor
 template<typename Te, typename... Tp>
 class variant : public std::variant<Tp...>
 {
@@ -312,7 +311,7 @@ write_variant(tls::ostream& str, const std::variant<Tp...>& v)
 {
   using curr_type = std::variant_alternative_t<I, std::variant<Tp...>>;
   if (std::holds_alternative<curr_type>(v)) {
-    str << curr_type::type << std::get<curr_type>(v);
+    str << curr_type::type << std::get<I>(v);
     return;
   }
 
@@ -493,11 +492,12 @@ read_variant(tls::istream& str, Te target_type, std::variant<Tp...>& v, Tc... co
 {
   using curr_type = std::variant_alternative_t<I, std::variant<Tp...>>;
   if (curr_type::type == target_type) {
-    str >> v.template emplace<curr_type>(context...);
+    v.template emplace<I>(context...);
+    str >> std::get<I>(v);
     return;
   }
 
-  read_variant<I + 1, Te, Tp...>(str, target_type, v);
+  read_variant<I + 1>(str, target_type, v, context...);
 }
 
 template<typename Te, typename... Tp>
@@ -515,7 +515,7 @@ template<typename Te, typename Tc, typename... Tp>
 tls::istream&
 operator>>(tls::istream& str, variant_variant<Te, Tc, Tp...>& v)
 {
-  using local_variant = variant<Te, Tc, Tp...>;
+  using local_variant = variant_variant<Te, Tc, Tp...>;
   typename local_variant::type_enum target_type;
   str >> target_type;
   read_variant(str, target_type, v, v._context);

--- a/include/tls_syntax.h
+++ b/include/tls_syntax.h
@@ -263,6 +263,14 @@ operator<<(tls::ostream& out, const optional_base<T>& opt)
   return out << uint8_t(1) << opt.value();
 }
 
+// Enum writer
+template<typename T, std::enable_if_t<std::is_enum<T>::value, int> = 0>
+tls::ostream&
+operator<<(tls::ostream& str, const T& val) {
+  auto u = static_cast<std::underlying_type_t<T>>(val);
+  return str << u;
+}
+
 // Struct writer (enabled by macro)
 template<size_t I = 0, typename... Tp>
 inline typename std::enable_if<I == sizeof...(Tp), void>::type
@@ -400,6 +408,18 @@ operator>>(tls::istream& in, optional_base<T>& opt)
     default:
       throw std::invalid_argument("Malformed optional");
   }
+}
+
+// Enum reader
+// XXX(rlb): It would be nice if this could enforce that the values are valid,
+// but C++ doesn't seem to have that ability.
+template<typename T, std::enable_if_t<std::is_enum<T>::value, int> = 0>
+tls::istream&
+operator>>(tls::istream& str, T& val) {
+  std::underlying_type_t<T> u;
+  str >> u;
+  val = static_cast<T>(u);
+  return str;
 }
 
 // Struct reader (enabled by macro)

--- a/include/tree_math.h
+++ b/include/tree_math.h
@@ -4,6 +4,8 @@
 #include <cstdint>
 #include <vector>
 
+#include "tls_syntax.h"
+
 // The below functions provide the index calculus for the tree
 // structures used in MLS.  They are premised on a "flat"
 // representation of a balanced binary tree.  Leaf nodes are
@@ -27,12 +29,6 @@
 //
 //    01x = <00x, 10x>
 
-// Fordward declaration of TLS streams
-namespace tls {
-class istream;
-class ostream;
-}
-
 namespace mls {
 
 // Index types go in the overall namespace
@@ -49,12 +45,9 @@ struct UInt32
   explicit UInt32(uint32_t val_in)
     : val(val_in)
   {}
-};
 
-tls::istream&
-operator>>(tls::istream& in, UInt32& obj);
-tls::ostream&
-operator<<(tls::ostream& out, const UInt32& obj);
+  TLS_SERIALIZABLE(val);
+};
 
 struct NodeCount;
 
@@ -73,10 +66,7 @@ struct NodeCount : public UInt32
 struct LeafIndex : public UInt32
 {
   using UInt32::UInt32;
-
   bool operator<(const LeafIndex other) const { return val < other.val; }
-  bool operator==(const LeafIndex other) const { return val == other.val; }
-  bool operator!=(const LeafIndex other) const { return val != other.val; }
 };
 
 struct NodeIndex : public UInt32
@@ -85,9 +75,6 @@ struct NodeIndex : public UInt32
   explicit NodeIndex(const LeafIndex x)
     : UInt32(2 * x.val)
   {}
-
-  bool operator==(const NodeIndex other) const { return val == other.val; }
-  bool operator!=(const NodeIndex other) const { return val != other.val; }
 };
 
 // Internal namespace to keep these generic names clean

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -6,25 +6,6 @@
 namespace mls {
 
 ///
-/// CredentialType
-///
-
-tls::ostream&
-operator<<(tls::ostream& out, CredentialType type)
-{
-  return out << uint8_t(type);
-}
-
-tls::istream&
-operator>>(tls::istream& in, CredentialType& type)
-{
-  uint8_t temp;
-  in >> temp;
-  type = CredentialType(temp);
-  return in;
-}
-
-///
 /// BasicCredential
 ///
 

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -867,13 +867,9 @@ struct HKDFLabel
   uint16_t length;
   tls::opaque<1> label;
   tls::opaque<4> context;
-};
 
-tls::ostream&
-operator<<(tls::ostream& out, const HKDFLabel& obj)
-{
-  return out << obj.length << obj.label << obj.context;
-}
+  TLS_SERIALIZABLE(length, label, context);
+};
 
 bytes
 hkdf_expand_label(CipherSuite suite,
@@ -1291,13 +1287,9 @@ struct HPKEContext
   uint8_t mode;
   tls::opaque<2> kem_context;
   tls::opaque<2> info;
-};
 
-tls::ostream&
-operator<<(tls::ostream& out, const HPKEContext& obj)
-{
-  return out << obj.ciphersuite << obj.mode << obj.kem_context << obj.info;
-}
+  TLS_SERIALIZABLE(ciphersuite, mode, kem_context, info)
+};
 
 static std::pair<bytes, bytes>
 setup_core(CipherSuite suite,
@@ -1569,18 +1561,6 @@ bool
 operator==(const HPKECiphertext& lhs, const HPKECiphertext& rhs)
 {
   return (lhs.ephemeral == rhs.ephemeral) && (lhs.content == rhs.content);
-}
-
-tls::ostream&
-operator<<(tls::ostream& out, const HPKECiphertext& obj)
-{
-  return out << obj.ephemeral << obj.content;
-}
-
-tls::istream&
-operator>>(tls::istream& in, HPKECiphertext& obj)
-{
-  return in >> obj.ephemeral >> obj.content;
 }
 
 } // namespace mls

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -1553,14 +1553,4 @@ SignaturePrivateKey::SignaturePrivateKey(SignatureScheme scheme,
   _pub = std::make_unique<SignaturePublicKey>(scheme, key->dup_public());
 }
 
-///
-/// HPKECiphertext
-///
-
-bool
-operator==(const HPKECiphertext& lhs, const HPKECiphertext& rhs)
-{
-  return (lhs.ephemeral == rhs.ephemeral) && (lhs.content == rhs.content);
-}
-
 } // namespace mls

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -13,63 +13,9 @@
 
 namespace mls {
 
-///
-/// CipherSuite and SignatureScheme
-///
-
 static const CipherSuite unknown_suite = static_cast<CipherSuite>(0xFFFF);
 static const SignatureScheme unknown_scheme =
   static_cast<SignatureScheme>(0xFFFF);
-
-tls::ostream&
-operator<<(tls::ostream& out, const CipherSuite& obj)
-{
-  return out << static_cast<uint16_t>(obj);
-}
-
-tls::istream&
-operator>>(tls::istream& in, CipherSuite& obj)
-{
-  uint16_t val;
-  in >> val;
-  obj = static_cast<CipherSuite>(val);
-  return in;
-}
-
-tls::ostream&
-operator<<(tls::ostream& out, const SignatureScheme& obj)
-{
-  return out << static_cast<uint16_t>(obj);
-}
-
-tls::istream&
-operator>>(tls::istream& in, SignatureScheme& obj)
-{
-  uint16_t val;
-  in >> val;
-  obj = static_cast<SignatureScheme>(val);
-  return in;
-}
-
-CipherAware::CipherAware(CipherSuite suite)
-  : _suite(suite)
-{}
-
-CipherSuite
-CipherAware::cipher_suite() const
-{
-  return _suite;
-}
-
-SignatureAware::SignatureAware(SignatureScheme scheme)
-  : _scheme(scheme)
-{}
-
-SignatureScheme
-SignatureAware::signature_scheme() const
-{
-  return _scheme;
-}
 
 ///
 /// Test mode controls

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -26,18 +26,6 @@ operator==(const RatchetNode& lhs, const RatchetNode& rhs)
          (lhs.node_secrets == rhs.node_secrets);
 }
 
-tls::ostream&
-operator<<(tls::ostream& out, const RatchetNode& obj)
-{
-  return out << obj.public_key << obj.node_secrets;
-}
-
-tls::istream&
-operator>>(tls::istream& in, RatchetNode& obj)
-{
-  return in >> obj.public_key >> obj.node_secrets;
-}
-
 // DirectPath
 
 DirectPath::DirectPath(CipherSuite suite)
@@ -49,18 +37,6 @@ bool
 operator==(const DirectPath& lhs, const DirectPath& rhs)
 {
   return (lhs.nodes == rhs.nodes);
-}
-
-tls::ostream&
-operator<<(tls::ostream& out, const DirectPath& obj)
-{
-  return out << obj.nodes;
-}
-
-tls::istream&
-operator>>(tls::istream& in, DirectPath& obj)
-{
-  return in >> obj.nodes;
 }
 
 // ClientInitKey
@@ -174,21 +150,6 @@ operator!=(const ClientInitKey& lhs, const ClientInitKey& rhs)
   return !(lhs == rhs);
 }
 
-tls::ostream&
-operator<<(tls::ostream& out, const ClientInitKey& obj)
-{
-  return out << obj.client_init_key_id << obj.supported_versions
-             << obj.cipher_suites << obj.init_keys << obj.credential
-             << obj.signature;
-}
-
-tls::istream&
-operator>>(tls::istream& in, ClientInitKey& obj)
-{
-  return in >> obj.client_init_key_id >> obj.supported_versions >>
-         obj.cipher_suites >> obj.init_keys >> obj.credential >> obj.signature;
-}
-
 // WelcomeInfo
 
 WelcomeInfo::WelcomeInfo(CipherSuite suite)
@@ -226,28 +187,6 @@ operator==(const WelcomeInfo& lhs, const WelcomeInfo& rhs)
          (lhs.epoch == rhs.epoch) && (lhs.tree == rhs.tree) &&
          (lhs.interim_transcript_hash == rhs.interim_transcript_hash) &&
          (lhs.init_secret == rhs.init_secret);
-}
-
-tls::ostream&
-operator<<(tls::ostream& out, const WelcomeInfo& obj)
-{
-  return out << obj.version << obj.group_id << obj.epoch << obj.tree
-             << obj.interim_transcript_hash << obj.init_secret;
-}
-
-tls::istream&
-operator>>(tls::istream& in, WelcomeInfo& obj)
-{
-  in >> obj.version >> obj.group_id >> obj.epoch;
-
-  // Set the tree struct to use the correct ciphersuite for this
-  // group
-  obj.tree = RatchetTree(obj.cipher_suite());
-
-  in >> obj.tree;
-  in >> obj.interim_transcript_hash;
-  in >> obj.init_secret;
-  return in;
 }
 
 // Welcome
@@ -335,18 +274,6 @@ operator==(const Add& lhs, const Add& rhs)
          (lhs.welcome_info_hash == rhs.welcome_info_hash);
 }
 
-tls::ostream&
-operator<<(tls::ostream& out, const Add& obj)
-{
-  return out << obj.index << obj.init_key << obj.welcome_info_hash;
-}
-
-tls::istream&
-operator>>(tls::istream& in, Add& obj)
-{
-  return in >> obj.index >> obj.init_key >> obj.welcome_info_hash;
-}
-
 // Update
 
 Update::Update(CipherSuite suite)
@@ -365,18 +292,6 @@ bool
 operator==(const Update& lhs, const Update& rhs)
 {
   return (lhs.path == rhs.path);
-}
-
-tls::ostream&
-operator<<(tls::ostream& out, const Update& obj)
-{
-  return out << obj.path;
-}
-
-tls::istream&
-operator>>(tls::istream& in, Update& obj)
-{
-  return in >> obj.path;
 }
 
 // Remove
@@ -398,18 +313,6 @@ bool
 operator==(const Remove& lhs, const Remove& rhs)
 {
   return (lhs.path == rhs.path);
-}
-
-tls::ostream&
-operator<<(tls::ostream& out, const Remove& obj)
-{
-  return out << obj.removed << obj.path;
-}
-
-tls::istream&
-operator>>(tls::istream& in, Remove& obj)
-{
-  return in >> obj.removed >> obj.path;
 }
 
 // GroupOperation
@@ -732,21 +635,6 @@ operator==(const MLSCiphertext& lhs, const MLSCiphertext& rhs)
 
   return group_id && epoch && content_type && sender_data_nonce &&
          encrypted_sender_data && ciphertext;
-}
-
-tls::ostream&
-operator<<(tls::ostream& out, const MLSCiphertext& obj)
-{
-  return out << obj.group_id << obj.epoch << obj.content_type
-             << obj.sender_data_nonce << obj.encrypted_sender_data
-             << obj.ciphertext;
-}
-
-tls::istream&
-operator>>(tls::istream& in, MLSCiphertext& obj)
-{
-  return in >> obj.group_id >> obj.epoch >> obj.content_type >>
-         obj.sender_data_nonce >> obj.encrypted_sender_data >> obj.ciphertext;
 }
 
 } // namespace mls

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -198,23 +198,6 @@ operator>>(tls::istream& in, Welcome& obj)
   return in;
 }
 
-// GroupOperationType
-
-tls::ostream&
-operator<<(tls::ostream& out, const GroupOperationType& obj)
-{
-  return out << uint8_t(obj);
-}
-
-tls::istream&
-operator>>(tls::istream& in, GroupOperationType& obj)
-{
-  uint8_t type;
-  in >> type;
-  obj = GroupOperationType(type);
-  return in;
-}
-
 // Add
 
 Add::Add(LeafIndex index_in,
@@ -342,23 +325,6 @@ operator>>(tls::istream& in, GroupOperation& obj)
       throw InvalidParameterError("Unknown group operation type");
   }
 
-  return in;
-}
-
-// ContentType
-
-tls::ostream&
-operator<<(tls::ostream& out, const ContentType& obj)
-{
-  return out << static_cast<uint8_t>(obj);
-}
-
-tls::istream&
-operator>>(tls::istream& in, ContentType& obj)
-{
-  uint8_t val;
-  in >> val;
-  obj = static_cast<ContentType>(val);
   return in;
 }
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -19,25 +19,12 @@ RatchetNode::RatchetNode(DHPublicKey public_key_in,
   , node_secrets(node_secrets_in)
 {}
 
-bool
-operator==(const RatchetNode& lhs, const RatchetNode& rhs)
-{
-  return (lhs.public_key == rhs.public_key) &&
-         (lhs.node_secrets == rhs.node_secrets);
-}
-
 // DirectPath
 
 DirectPath::DirectPath(CipherSuite suite)
   : CipherAware(suite)
   , nodes(suite)
 {}
-
-bool
-operator==(const DirectPath& lhs, const DirectPath& rhs)
-{
-  return (lhs.nodes == rhs.nodes);
-}
 
 // ClientInitKey
 
@@ -132,24 +119,6 @@ ClientInitKey::to_be_signed() const
   return out.bytes();
 }
 
-// XXX(rlb@ipv.sx): Don't compare signature, since some signature
-// algorithms are non-deterministic.  Instead, we just verify that
-// the public keys are the same and both signatures are valid over
-// the same contents.
-bool
-operator==(const ClientInitKey& lhs, const ClientInitKey& rhs)
-{
-  return (lhs.cipher_suites == rhs.cipher_suites) &&
-         (lhs.init_keys == rhs.init_keys) &&
-         (lhs.credential == rhs.credential) && (lhs.signature == rhs.signature);
-}
-
-bool
-operator!=(const ClientInitKey& lhs, const ClientInitKey& rhs)
-{
-  return !(lhs == rhs);
-}
-
 // WelcomeInfo
 
 WelcomeInfo::WelcomeInfo(CipherSuite suite)
@@ -178,15 +147,6 @@ WelcomeInfo::hash(CipherSuite suite) const
 {
   auto marshaled = tls::marshal(*this);
   return Digest(suite).write(marshaled).digest();
-}
-
-bool
-operator==(const WelcomeInfo& lhs, const WelcomeInfo& rhs)
-{
-  return (lhs.version == rhs.version) && (lhs.group_id == rhs.group_id) &&
-         (lhs.epoch == rhs.epoch) && (lhs.tree == rhs.tree) &&
-         (lhs.interim_transcript_hash == rhs.interim_transcript_hash) &&
-         (lhs.init_secret == rhs.init_secret);
 }
 
 // Welcome
@@ -267,13 +227,6 @@ Add::Add(LeafIndex index_in,
 
 const GroupOperationType Add::type = GroupOperationType::add;
 
-bool
-operator==(const Add& lhs, const Add& rhs)
-{
-  return (lhs.index == rhs.index) && (lhs.init_key == rhs.init_key) &&
-         (lhs.welcome_info_hash == rhs.welcome_info_hash);
-}
-
 // Update
 
 Update::Update(CipherSuite suite)
@@ -287,12 +240,6 @@ Update::Update(const DirectPath& path_in)
 {}
 
 const GroupOperationType Update::type = GroupOperationType::update;
-
-bool
-operator==(const Update& lhs, const Update& rhs)
-{
-  return (lhs.path == rhs.path);
-}
 
 // Remove
 
@@ -308,12 +255,6 @@ Remove::Remove(LeafIndex removed_in, const DirectPath& path_in)
 {}
 
 const GroupOperationType Remove::type = GroupOperationType::remove;
-
-bool
-operator==(const Remove& lhs, const Remove& rhs)
-{
-  return (lhs.path == rhs.path);
-}
 
 // GroupOperation
 
@@ -618,23 +559,6 @@ operator>>(tls::istream& in, MLSPlaintext& obj)
 
   in >> obj.signature;
   return in;
-}
-
-// MLSCiphertext
-
-bool
-operator==(const MLSCiphertext& lhs, const MLSCiphertext& rhs)
-{
-  auto group_id = (lhs.group_id == rhs.group_id);
-  auto epoch = (lhs.epoch == rhs.epoch);
-  auto content_type = (lhs.content_type == rhs.content_type);
-  auto sender_data_nonce = (lhs.sender_data_nonce == rhs.sender_data_nonce);
-  auto encrypted_sender_data =
-    (lhs.encrypted_sender_data == rhs.encrypted_sender_data);
-  auto ciphertext = (lhs.ciphertext == rhs.ciphertext);
-
-  return group_id && epoch && content_type && sender_data_nonce &&
-         encrypted_sender_data && ciphertext;
 }
 
 } // namespace mls

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -1,5 +1,7 @@
 #include "messages.h"
 
+#include <iostream>
+
 #define DUMMY_CIPHERSUITE CipherSuite::P256_SHA256_AES128GCM
 
 namespace mls {
@@ -263,56 +265,85 @@ GroupOperation::GroupOperation(const Remove& remove)
   , InnerOp(remove.cipher_suite(), remove)
 {}
 
-GroupOperationType
-GroupOperation::type() const
-{
-  switch (index()) {
-    case 0:
-      return GroupOperationType::add;
-    case 1:
-      return GroupOperationType::update;
-    case 2:
-      return GroupOperationType::remove;
-  }
-
-  throw std::bad_variant_access();
-}
-
-bool
-operator==(const GroupOperation& lhs, const GroupOperation& rhs)
-{
-  return GroupOperation::InnerOp(lhs) == GroupOperation::InnerOp(rhs);
-}
-
 // MLSPlaintext
+
+const ContentType HandshakeData::type = ContentType::handshake;
+const ContentType ApplicationData::type = ContentType::application;
 
 MLSPlaintext::MLSPlaintext(CipherSuite suite)
   : CipherAware(suite)
-  , operation(suite)
+  , content(suite, ApplicationData{ suite })
 {}
+
+MLSPlaintext::MLSPlaintext(CipherSuite suite,
+                           bytes group_id_in,
+                           epoch_t epoch_in,
+                           LeafIndex sender_in,
+                           ContentType content_type_in,
+                           bytes content_in)
+  : CipherAware(suite)
+  , group_id(group_id_in)
+  , epoch(epoch_in)
+  , sender(sender_in)
+  , content(suite, ApplicationData{ suite })
+{
+  int cut = content_in.size() - 1;
+  for (; content_in[cut] == 0 && cut >= 0; cut -= 1) {
+  }
+  if (content_in[cut] != 0x01) {
+    throw ProtocolError("Invalid marker byte");
+  }
+
+  uint16_t sig_len;
+  auto start = content_in.begin();
+  auto sig_len_bytes = bytes(start + cut - 2, start + cut);
+  tls::unmarshal(sig_len_bytes, sig_len);
+  cut -= 2;
+  if (sig_len > cut) {
+    throw ProtocolError("Invalid signature size");
+  }
+
+  signature = bytes(start + cut - sig_len, start + cut);
+  auto content_data = bytes(start, start + cut - sig_len);
+
+  switch (content_type_in) {
+    case ContentType::handshake: {
+      auto& operation = content.emplace<HandshakeData>(suite);
+      tls::unmarshal(content_data, operation);
+      break;
+    }
+
+    case ContentType::application: {
+      auto& application_data = content.emplace<ApplicationData>();
+      tls::unmarshal(content_data, application_data);
+      break;
+    }
+
+    default:
+      throw InvalidParameterError("Unknown content type");
+  }
+}
 
 MLSPlaintext::MLSPlaintext(bytes group_id_in,
                            epoch_t epoch_in,
                            LeafIndex sender_in,
-                           GroupOperation operation_in)
+                           const GroupOperation& operation_in)
   : CipherAware(operation_in.cipher_suite())
   , group_id(std::move(group_id_in))
   , epoch(epoch_in)
   , sender(sender_in)
-  , content_type(ContentType::handshake)
-  , operation(std::move(operation_in))
+  , content(operation_in.cipher_suite(), HandshakeData{ operation_in, {} })
 {}
 
 MLSPlaintext::MLSPlaintext(bytes group_id_in,
                            epoch_t epoch_in,
                            LeafIndex sender_in,
-                           bytes application_data_in)
+                           const ApplicationData& application_data_in)
   : CipherAware(DUMMY_CIPHERSUITE)
   , group_id(std::move(group_id_in))
   , epoch(epoch_in)
   , sender(sender_in)
-  , content_type(ContentType::application)
-  , application_data(std::move(application_data_in))
+  , content(DUMMY_CIPHERSUITE, application_data_in)
 {}
 
 // struct {
@@ -325,11 +356,11 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
 bytes
 MLSPlaintext::marshal_content(size_t padding_size) const
 {
-  bytes content;
-  if (content_type == ContentType::handshake) {
-    content = tls::marshal(operation.value());
-  } else if (content_type == ContentType::application) {
-    content = application_data;
+  bytes marshaled;
+  if (content.type() == ContentType::handshake) {
+    marshaled = tls::marshal(std::get<HandshakeData>(content));
+  } else if (content.type() == ContentType::application) {
+    marshaled = tls::marshal(std::get<ApplicationData>(content));
   } else {
     throw InvalidParameterError("Unknown content type");
   }
@@ -337,45 +368,8 @@ MLSPlaintext::marshal_content(size_t padding_size) const
   uint16_t sig_len = signature.size();
   auto marker = bytes{ 0x01 };
   auto pad = zero_bytes(padding_size);
-  content = content + signature + tls::marshal(sig_len) + marker + pad;
-  return content;
-}
-
-void
-MLSPlaintext::unmarshal_content(CipherSuite suite, const bytes& marshaled)
-{
-  int cut = marshaled.size() - 1;
-  for (; marshaled[cut] == 0 && cut >= 0; cut -= 1) {
-  }
-  if (marshaled[cut] != 0x01) {
-    throw ProtocolError("Invalid marker byte");
-  }
-
-  uint16_t sig_len;
-  auto start = marshaled.begin();
-  auto sig_len_bytes = bytes(start + cut - 2, start + cut);
-  tls::unmarshal(sig_len_bytes, sig_len);
-  cut -= 2;
-  if (sig_len > cut) {
-    throw ProtocolError("Invalid signature size");
-  }
-
-  signature = bytes(start + cut - sig_len, start + cut);
-  auto content = bytes(start, start + cut - sig_len);
-
-  switch (content_type) {
-    case ContentType::handshake:
-      operation.emplace(suite);
-      tls::unmarshal(content, operation.value());
-      break;
-
-    case ContentType::application:
-      application_data = content;
-      break;
-
-    default:
-      throw InvalidParameterError("Unknown content type");
-  }
+  marshaled = marshaled + signature + tls::marshal(sig_len) + marker + pad;
+  return marshaled;
 }
 
 // struct {
@@ -386,10 +380,12 @@ MLSPlaintext::unmarshal_content(CipherSuite suite, const bytes& marshaled)
 //   GroupOperation operation;
 // } MLSPlaintextOpContent;
 bytes
-MLSPlaintext::content() const
+MLSPlaintext::op_content() const
 {
+  auto& handshake_data = std::get<HandshakeData>(content);
   tls::ostream w;
-  w << group_id << epoch << sender << content_type << operation.value();
+  w << group_id << epoch << sender << content.type()
+    << handshake_data.operation;
   return w.bytes();
 }
 
@@ -400,8 +396,9 @@ MLSPlaintext::content() const
 bytes
 MLSPlaintext::auth_data() const
 {
+  auto& handshake_data = std::get<HandshakeData>(content);
   tls::ostream w;
-  w << confirmation << signature;
+  w << handshake_data.confirmation << signature;
   return w.bytes();
 }
 
@@ -409,20 +406,7 @@ bytes
 MLSPlaintext::to_be_signed() const
 {
   tls::ostream w;
-  w << group_id << epoch << sender << content_type;
-  switch (content_type) {
-    case ContentType::handshake:
-      w << operation.value() << confirmation;
-      break;
-
-    case ContentType::application:
-      w << application_data;
-      break;
-
-    default:
-      throw InvalidParameterError("Unknown content type");
-  }
-
+  w << group_id << epoch << sender << content;
   return w.bytes();
 }
 
@@ -430,6 +414,7 @@ void
 MLSPlaintext::sign(const SignaturePrivateKey& priv)
 {
   auto tbs = to_be_signed();
+  std::cout << "sig: " << tbs << std::endl;
   signature = priv.sign(tbs);
 }
 
@@ -437,55 +422,8 @@ bool
 MLSPlaintext::verify(const SignaturePublicKey& pub) const
 {
   auto tbs = to_be_signed();
+  std::cout << "ver: " << tbs << std::endl;
   return pub.verify(tbs, signature);
-}
-
-bool
-operator==(const MLSPlaintext& lhs, const MLSPlaintext& rhs)
-{
-  auto group_id = (lhs.group_id == rhs.group_id);
-  auto epoch = (lhs.epoch == rhs.epoch);
-  auto sender = (lhs.sender == rhs.sender);
-  auto content_type = (lhs.content_type == rhs.content_type);
-  auto operation = ((lhs.content_type == ContentType::handshake) &&
-                    (lhs.operation.value() == rhs.operation.value()));
-  auto application_data = ((lhs.content_type == ContentType::application) &&
-                           (lhs.operation.value() == rhs.operation.value()));
-  auto signature = (lhs.signature == rhs.signature);
-
-  return group_id && epoch && sender && content_type &&
-         (operation || application_data) && signature;
-}
-
-tls::ostream&
-operator<<(tls::ostream& out, const MLSPlaintext& obj)
-{
-  out.write_raw(obj.to_be_signed());
-  out << obj.signature;
-  return out;
-}
-
-tls::istream&
-operator>>(tls::istream& in, MLSPlaintext& obj)
-{
-  in >> obj.group_id >> obj.epoch >> obj.sender >> obj.content_type;
-
-  switch (obj.content_type) {
-    case ContentType::handshake:
-      obj.operation.emplace(obj._suite);
-      in >> obj.operation.value() >> obj.confirmation;
-      break;
-
-    case ContentType::application:
-      in >> obj.application_data;
-      break;
-
-    default:
-      throw InvalidParameterError("Unknown content type");
-  }
-
-  in >> obj.signature;
-  return in;
 }
 
 } // namespace mls

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -29,15 +29,16 @@ DirectPath::DirectPath(CipherSuite suite)
 // ClientInitKey
 
 ClientInitKey::ClientInitKey()
-  : supported_versions(1, mls10Version)
+  : supported_versions(1, ProtocolVersion::mls10)
 {}
 
-ClientInitKey::ClientInitKey(bytes client_init_key_id_in,
-                             const CipherList& supported_ciphersuites,
-                             const bytes& init_secret,
-                             const Credential& credential_in)
+ClientInitKey::ClientInitKey(
+  bytes client_init_key_id_in,
+  const std::vector<CipherSuite>& supported_ciphersuites,
+  const bytes& init_secret,
+  const Credential& credential_in)
   : client_init_key_id(std::move(client_init_key_id_in))
-  , supported_versions(1, mls10Version)
+  , supported_versions(1, ProtocolVersion::mls10)
 {
   // XXX(rlb@ipv.sx) - It's probably not OK to derive all the keys
   // from the same secret.  Maybe we should include the ciphersuite
@@ -123,7 +124,7 @@ ClientInitKey::to_be_signed() const
 
 WelcomeInfo::WelcomeInfo(CipherSuite suite)
   : CipherAware(suite)
-  , version(mls10Version)
+  , version(ProtocolVersion::mls10)
   , epoch(0)
   , tree(suite)
 {}
@@ -134,7 +135,7 @@ WelcomeInfo::WelcomeInfo(tls::opaque<2> group_id_in,
                          const tls::opaque<1>& interim_transcript_hash_in,
                          const tls::opaque<1>& init_secret_in)
   : CipherAware(tree_in.cipher_suite())
-  , version(mls10Version)
+  , version(ProtocolVersion::mls10)
   , group_id(std::move(group_id_in))
   , epoch(epoch_in)
   , tree(std::move(tree_in))

--- a/src/ratchet_tree.cpp
+++ b/src/ratchet_tree.cpp
@@ -103,26 +103,6 @@ operator!=(const RatchetTreeNode& lhs, const RatchetTreeNode& rhs)
   return !(lhs == rhs);
 }
 
-std::ostream&
-operator<<(std::ostream& out, const RatchetTreeNode& node)
-{
-  auto cred = tls::marshal(node._cred);
-  return out << node._pub.to_bytes();
-}
-
-tls::ostream&
-operator<<(tls::ostream& out, const RatchetTreeNode& obj)
-{
-  return out << obj._pub << obj._cred;
-}
-
-tls::istream&
-operator>>(tls::istream& in, RatchetTreeNode& obj)
-{
-  obj._priv = std::nullopt;
-  return in >> obj._pub >> obj._cred;
-}
-
 ///
 /// OptionalRatchetTreeNode
 ///
@@ -158,25 +138,17 @@ struct LeafNodeInfo
 {
   DHPublicKey public_key;
   Credential credential;
-};
 
-tls::ostream&
-operator<<(tls::ostream& out, const LeafNodeInfo& obj)
-{
-  return out << obj.public_key << obj.credential;
-}
+  TLS_SERIALIZABLE(public_key, credential);
+};
 
 struct LeafNodeHashInput
 {
   const uint8_t hash_type = 0;
   tls::optional<LeafNodeInfo> info;
-};
 
-tls::ostream&
-operator<<(tls::ostream& out, const LeafNodeHashInput& obj)
-{
-  return out << obj.hash_type << obj.info;
-}
+  TLS_SERIALIZABLE(hash_type, info);
+};
 
 void
 OptionalRatchetTreeNode::set_leaf_hash(CipherSuite suite)
@@ -203,14 +175,9 @@ struct ParentNodeHashInput
   tls::optional<DHPublicKey> public_key;
   tls::opaque<1> left_hash;
   tls::opaque<1> right_hash;
-};
 
-tls::ostream&
-operator<<(tls::ostream& out, const ParentNodeHashInput& obj)
-{
-  return out << obj.hash_type << obj.public_key << obj.left_hash
-             << obj.right_hash;
-}
+  TLS_SERIALIZABLE(hash_type, public_key, left_hash, right_hash);
+};
 
 void
 OptionalRatchetTreeNode::set_hash(CipherSuite suite,
@@ -226,16 +193,6 @@ OptionalRatchetTreeNode::set_hash(CipherSuite suite,
 
   auto hash_input = tls::marshal(hash_input_str);
   _hash = Digest(suite).write(hash_input).digest();
-}
-
-std::ostream&
-operator<<(std::ostream& out, const OptionalRatchetTreeNode& opt)
-{
-  if (!opt.has_value()) {
-    return out << "_";
-  }
-
-  return out << opt.value();
 }
 
 ///
@@ -732,15 +689,6 @@ operator==(const RatchetTree& lhs, const RatchetTree& rhs)
   }
 
   return true;
-}
-
-std::ostream&
-operator<<(std::ostream& out, const RatchetTree& obj)
-{
-  for (const auto& node : obj._nodes) {
-    out << node << " ";
-  }
-  return out;
 }
 
 tls::ostream&

--- a/src/ratchet_tree.cpp
+++ b/src/ratchet_tree.cpp
@@ -90,19 +90,6 @@ RatchetTreeNode::merge(const RatchetTreeNode& other)
   // Credential is immutable
 }
 
-bool
-operator==(const RatchetTreeNode& lhs, const RatchetTreeNode& rhs)
-{
-  // Equality is based on public attributes only
-  return (lhs._pub == rhs._pub) && (lhs._cred == rhs._cred);
-}
-
-bool
-operator!=(const RatchetTreeNode& lhs, const RatchetTreeNode& rhs)
-{
-  return !(lhs == rhs);
-}
-
 ///
 /// OptionalRatchetTreeNode
 ///

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -3,24 +3,6 @@
 namespace mls {
 
 ///
-/// GroupContext
-///
-
-tls::ostream&
-operator<<(tls::ostream& out, const GroupContext& obj)
-{
-  return out << obj.group_id << obj.epoch << obj.tree_hash
-             << obj.transcript_hash;
-}
-
-tls::istream&
-operator>>(tls::istream& out, GroupContext& obj)
-{
-  return out >> obj.group_id >> obj.epoch >> obj.tree_hash >>
-         obj.transcript_hash;
-}
-
-///
 /// KeyChain
 ///
 

--- a/src/tree_math.cpp
+++ b/src/tree_math.cpp
@@ -26,18 +26,6 @@ NodeCount::NodeCount(const LeafCount n)
   : UInt32(2 * (n.val - 1) + 1)
 {}
 
-tls::istream&
-operator>>(tls::istream& in, UInt32& obj)
-{
-  return in >> obj.val;
-}
-
-tls::ostream&
-operator<<(tls::ostream& out, const UInt32& obj)
-{
-  return out << obj.val;
-}
-
 namespace tree_math {
 
 static uint32_t

--- a/test/session_test.cpp
+++ b/test/session_test.cpp
@@ -7,8 +7,8 @@ using namespace mls;
 class SessionTest : public ::testing::Test
 {
 protected:
-  const CipherList suites{ CipherSuite::P256_SHA256_AES128GCM,
-                           CipherSuite::X25519_SHA256_AES128GCM };
+  const std::vector<CipherSuite> suites{ CipherSuite::P256_SHA256_AES128GCM,
+                                         CipherSuite::X25519_SHA256_AES128GCM };
   const SignatureScheme scheme = SignatureScheme::Ed25519;
   const int group_size = 5;
   const size_t secret_size = 32;

--- a/test/tls_syntax_test.cpp
+++ b/test/tls_syntax_test.cpp
@@ -10,24 +10,14 @@ struct ExampleStruct
   uint16_t a;
   tls::vector<uint8_t, 2> b;
   std::array<uint32_t, 4> c;
+
+  TLS_SERIALIZABLE(a, b, c)
 };
 
 bool
 operator==(const ExampleStruct& lhs, const ExampleStruct& rhs)
 {
   return (lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c);
-}
-
-tls::ostream&
-operator<<(tls::ostream& out, const ExampleStruct& data)
-{
-  return out << data.a << data.b << data.c;
-}
-
-tls::istream&
-operator>>(tls::istream& in, ExampleStruct& data)
-{
-  return in >> data.a >> data.b >> data.c;
 }
 
 struct MustInitialize


### PR DESCRIPTION
This is a clean-up PR that simplifies several things, especially around TLS serialization

* TLS serialization operators `<<` and `>>` can now be auto-generated based on a list of fields (`TLS_SERIALIZABLE(...)`)
* For classes that are TLS serializable, as above, new template `==` and `!=` operators apply
* Enum classes are now automatically TLS serialized
* GroupOperation now uses `std::variant` instead of a home-grown union approach
* `typedef` replaced by `using`

Submitting now to get CI and make sure this all works on Linux.  Might add more later.