### PR TITLE
Enable updates to DH keys

### DIFF
--- a/include/crypto.h
+++ b/include/crypto.h
@@ -266,6 +266,7 @@ class DHPublicKey : public PublicKey
 public:
   using PublicKey::PublicKey;
   DHPublicKey();
+  void update(const bytes& delta);
   HPKECiphertext encrypt(const bytes& plaintext) const;
 
 private:
@@ -282,6 +283,7 @@ public:
   static DHPrivateKey derive(CipherSuite suite, const bytes& secret);
   static DHPrivateKey node_derive(CipherSuite suite, const bytes& secret);
 
+  void update(const bytes& delta);
   bytes derive(const DHPublicKey& pub) const;
   bytes decrypt(const HPKECiphertext& ciphertext) const;
 

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -459,10 +459,10 @@ TypedDelete(OpenSSLKey* ptr)
 /// Curve orders
 ///
 static const char* n25519 =
-  "1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed";
+  "80000000000000000000000000000000a6f7cef517bce6b2c09318d2e7ae9f68";
 static const char* n448 =
-  "3fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49ae"
-  "d63690216cc2728dc58f552378c292ab5844f3";
+  "fffffffffffffffffffffffffffffffffffffffffffffffffffffffdf3288fa7113b6d26bb58"
+  "da4085b309ca37163d548de30a4aad6113cc";
 static const char* n256 =
   "ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551";
 static const char* n521 =
@@ -689,7 +689,7 @@ public:
       updated.get(), cpriv.get(), cdelta.get(), order.get(), ctx.get());
 
     // Negate if necessary
-    if (BN_is_bit_set(updated.get(), high_order_bit()) != 0) {
+    if (BN_is_bit_set(updated.get(), high_order_bit()) == 0) {
       BN_sub(updated.get(), order.get(), updated.get());
     }
 
@@ -698,11 +698,14 @@ public:
     bytes updated_priv(BN_num_bytes(updated.get()));
     BN_bn2bin(updated.get(), updated_priv.data());
     std::reverse(updated_priv.begin(), updated_priv.end());
+
     set_private(updated_priv);
   }
 
   void update_public(const bytes& delta) override
   {
+    auto clamped = delta;
+    std::reverse(clamped.begin(), clamped.end());
     auto enum_type = static_cast<RawKeyType>(_type);
     auto raw_key = RawKey(enum_type);
     raw_key.set_private(delta);

--- a/test/crypto_test.cpp
+++ b/test/crypto_test.cpp
@@ -312,10 +312,10 @@ TEST_F(CryptoTest, BasicDH)
 TEST_F(CryptoTest, DHUpdate)
 {
   std::vector<CipherSuite> suites{
-    // CipherSuite::P256_SHA256_AES128GCM,
-    // CipherSuite::P521_SHA512_AES256GCM,
+    CipherSuite::P256_SHA256_AES128GCM,
+    CipherSuite::P521_SHA512_AES256GCM,
     CipherSuite::X25519_SHA256_AES128GCM,
-    // CipherSuite::X448_SHA512_AES256GCM,
+    CipherSuite::X448_SHA512_AES256GCM,
   };
 
   for (auto suite : suites) {
@@ -326,16 +326,11 @@ TEST_F(CryptoTest, DHUpdate)
     auto key_size = xG.to_bytes().size();
     auto d = random_bytes(key_size);
 
-    std::cout << "x  " << x.public_key().to_bytes() << std::endl;
-
     auto dx = x;
     dx.update(d);
-    std::cout << "x   " << x.public_key().to_bytes() << std::endl;
-    std::cout << "dx  " << dx.public_key().to_bytes() << std::endl;
 
     auto d_xG = xG;
     d_xG.update(d);
-    std::cout << "d_x " << d_xG.to_bytes() << std::endl;
 
     ASSERT_NE(x, dx);
     ASSERT_NE(x.public_key(), dx.public_key());


### PR DESCRIPTION
This PR implements the core of the "updateable PKE" scheme described by Joël Alwen on the mailing list.  It could be the basis for implementing re-randomized TreeKEM.