### PR TITLE
Streamline test vector structures

### DIFF
--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -544,7 +544,7 @@ verify_session_repro(const F& generator)
   verify_equal_marshaled(v0.group_size, v1.group_size);
   verify_equal_marshaled(v0.group_id, v1.group_id);
 
-  for (int i = 0; i < v0.cases.size(); ++i) {
+  for (size_t i = 0; i < v0.cases.size(); ++i) {
     // Randomized signatures break reproducibility
     if (!deterministic_signature_scheme(v0.cases[i].signature_scheme)) {
       continue;

--- a/test/ratchet_tree_test.cpp
+++ b/test/ratchet_tree_test.cpp
@@ -84,14 +84,12 @@ protected:
 TEST_F(RatchetTreeTest, Interop)
 {
   for (const auto& tc : tv.cases) {
-    auto suite = tc.cipher_suite;
-
-    TestRatchetTree tree{ suite };
+    TestRatchetTree tree{ tc.cipher_suite };
 
     // Add the leaves
     int tci = 0;
     for (uint32_t i = 0; i < tv.leaf_secrets.size(); ++i, ++tci) {
-      auto priv = HPKEPrivateKey::derive(suite, tv.leaf_secrets[i]);
+      auto priv = HPKEPrivateKey::derive(tc.cipher_suite, tv.leaf_secrets[i]);
       tree.add_leaf(LeafIndex{ i }, priv.public_key(), tc.credentials[i]);
       tree.encap(LeafIndex{ i }, {}, tv.leaf_secrets[i]);
       assert_tree_eq(tc.trees[tci], tree);

--- a/test/ratchet_tree_test.cpp
+++ b/test/ratchet_tree_test.cpp
@@ -79,17 +79,19 @@ protected:
       }
     }
   }
+};
 
-  void interop(const TreeTestVectors::TestCase& tc,
-               CipherSuite test_suite,
-               SignatureScheme test_scheme)
-  {
-    TestRatchetTree tree{ test_suite };
+TEST_F(RatchetTreeTest, Interop)
+{
+  for (const auto& tc : tv.cases) {
+    auto suite = tc.cipher_suite;
+
+    TestRatchetTree tree{ suite };
 
     // Add the leaves
     int tci = 0;
     for (uint32_t i = 0; i < tv.leaf_secrets.size(); ++i, ++tci) {
-      auto priv = HPKEPrivateKey::derive(test_suite, tv.leaf_secrets[i]);
+      auto priv = HPKEPrivateKey::derive(suite, tv.leaf_secrets[i]);
       tree.add_leaf(LeafIndex{ i }, priv.public_key(), tc.credentials[i]);
       tree.encap(LeafIndex{ i }, {}, tv.leaf_secrets[i]);
       assert_tree_eq(tc.trees[tci], tree);
@@ -101,16 +103,6 @@ protected:
       assert_tree_eq(tc.trees[tci], tree);
     }
   }
-};
-
-TEST_F(RatchetTreeTest, Interop)
-{
-  interop(tv.case_p256_p256,
-          CipherSuite::P256_SHA256_AES128GCM,
-          SignatureScheme::P256_SHA256);
-  interop(tv.case_x25519_ed25519,
-          CipherSuite::X25519_SHA256_AES128GCM,
-          SignatureScheme::Ed25519);
 }
 
 TEST_F(RatchetTreeTest, OneMember)

--- a/test/session_test.cpp
+++ b/test/session_test.cpp
@@ -346,7 +346,7 @@ protected:
   void follow_all(const SessionTestVectors::TestCase& tc)
   {
     auto suite = tc.cipher_suite;
-    auto scheme = tc.sig_scheme;
+    auto scheme = tc.signature_scheme;
     DeterministicHPKE lock;
     for (uint32_t i = 0; i < basic_tv.group_size; ++i) {
       bytes seed = { uint8_t(i), 0 };
@@ -360,17 +360,21 @@ protected:
   }
 };
 
-TEST_F(SessionInteropTest, BasicP256)
+TEST_F(SessionInteropTest, Basic)
 {
-  // XXX(rlb@ipv.sx): This test is disabled for the moment becuase
-  // it requires signatures to be reproducible.  Otherwise, the
-  // following endpoint will generate a different message than the
-  // other endpoints have seen.
-  // follow_all(basic_tv.case_p256_p256);
-}
+  for (const auto& tc : basic_tv.cases) {
+    // XXX(rlb@ipv.sx): Tests with randomized signature schemes are disabled for
+    // the moment because the testing scheme here requires signatures to be
+    // reprodudible.  Otherwise, the following endpoint will generate a
+    // different message than the other endpoints have seen.
+    //
+    // Note that encrypted tests are still OK (with deterministic signatures),
+    // since the transcript doesn't cover the MLSCiphertext, in particular, the
+    // sender data nonce and encrypted sender data.
+    if (!deterministic_signature_scheme(tc.signature_scheme)) {
+      continue;
+    }
 
-TEST_F(SessionInteropTest, BasicX25519)
-{
-  follow_all(basic_tv.case_x25519_ed25519);
-  follow_all(basic_tv.case_x25519_ed25519_encrypted);
+    follow_all(tc);
+  }
 }

--- a/test/test_vectors.cpp
+++ b/test/test_vectors.cpp
@@ -18,6 +18,27 @@ const std::string MessagesTestVectors::file_name = "./messages.bin";
 const std::string BasicSessionTestVectors::file_name = "./basic_session.bin";
 
 ///
+/// Test for deterministic signatures
+///
+
+bool
+deterministic_signature_scheme(SignatureScheme scheme)
+{
+  switch (scheme) {
+    case SignatureScheme::P256_SHA256:
+      return false;
+    case SignatureScheme::P521_SHA512:
+      return false;
+    case SignatureScheme::Ed25519:
+      return true;
+    case SignatureScheme::Ed448:
+      return true;
+    default:
+      return false;
+  }
+}
+
+///
 /// File Handling
 ///
 

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -82,20 +82,22 @@ struct HashRatchetTestVectors
   };
 
   typedef tls::vector<Step, 4> KeySequence;
-  typedef tls::vector<KeySequence, 4> TestCase;
+
+  struct TestCase
+  {
+    CipherSuite cipher_suite;
+    tls::vector<KeySequence, 4> key_sequences;
+
+    TLS_SERIALIZABLE(cipher_suite, key_sequences);
+  };
 
   uint32_t n_members;
   uint32_t n_generations;
   tls::opaque<1> base_secret;
 
-  TestCase case_p256;
-  TestCase case_x25519;
+  tls::vector<TestCase, 4> cases;
 
-  TLS_SERIALIZABLE(n_members,
-                   n_generations,
-                   base_secret,
-                   case_p256,
-                   case_x25519);
+  TLS_SERIALIZABLE(n_members, n_generations, base_secret, cases);
 };
 
 /////
@@ -146,10 +148,10 @@ struct KeyScheduleTestVectors
 
   struct TestCase
   {
-    CipherSuite suite;
+    CipherSuite cipher_suite;
     tls::vector<Epoch, 2> epochs;
 
-    TLS_SERIALIZABLE(suite, epochs);
+    TLS_SERIALIZABLE(cipher_suite, epochs);
   };
 
   uint32_t n_epochs;
@@ -157,15 +159,13 @@ struct KeyScheduleTestVectors
   tls::opaque<1> base_init_secret;
   tls::opaque<4> base_group_context;
 
-  TestCase case_p256;
-  TestCase case_x25519;
+  tls::vector<TestCase, 4> cases;
 
   TLS_SERIALIZABLE(n_epochs,
                    target_generation,
                    base_init_secret,
                    base_group_context,
-                   case_p256,
-                   case_x25519);
+                   cases);
 };
 
 /////
@@ -253,24 +253,25 @@ struct TreeTestVectors
 
   struct TestCase
   {
+    CipherSuite cipher_suite;
+    SignatureScheme signature_scheme;
     tls::vector<Credential, 4> credentials;
     tls::vector<TreeCase, 4> trees;
 
-    TLS_SERIALIZABLE(credentials, trees);
+    TLS_SERIALIZABLE(cipher_suite, signature_scheme, credentials, trees);
   };
 
   tls::vector<tls::opaque<1>, 4> leaf_secrets;
   tls::vector<Credential, 4> credentials;
-  TestCase case_p256_p256;
-  TestCase case_x25519_ed25519;
+  tls::vector<TestCase, 4> cases;
 
-  TLS_SERIALIZABLE(leaf_secrets,
-                   credentials,
-                   case_p256_p256,
-                   case_x25519_ed25519);
+  TLS_SERIALIZABLE(leaf_secrets, credentials, cases);
 };
 
 /////
+
+bool
+deterministic_signature_scheme(SignatureScheme scheme);
 
 struct MessagesTestVectors
 {
@@ -279,7 +280,7 @@ struct MessagesTestVectors
   struct TestCase
   {
     CipherSuite cipher_suite;
-    SignatureScheme sig_scheme;
+    SignatureScheme signature_scheme;
 
     tls::opaque<4> client_init_key;
     tls::opaque<4> group_info;
@@ -293,7 +294,7 @@ struct MessagesTestVectors
     tls::opaque<4> ciphertext;
 
     TLS_SERIALIZABLE(cipher_suite,
-                     sig_scheme,
+                     signature_scheme,
                      client_init_key,
                      group_info,
                      key_package,
@@ -316,8 +317,7 @@ struct MessagesTestVectors
   tls::opaque<1> sig_seed;
   tls::opaque<1> random;
 
-  TestCase case_p256_p256;
-  TestCase case_x25519_ed25519;
+  tls::vector<TestCase, 4> cases;
 
   TLS_SERIALIZABLE(epoch,
                    signer_index,
@@ -328,8 +328,7 @@ struct MessagesTestVectors
                    dh_seed,
                    sig_seed,
                    random,
-                   case_p256_p256,
-                   case_x25519_ed25519);
+                   cases);
 };
 
 /////
@@ -429,13 +428,13 @@ struct SessionTestVectors
   struct TestCase
   {
     CipherSuite cipher_suite;
-    SignatureScheme sig_scheme;
+    SignatureScheme signature_scheme;
     bool encrypt;
     tls::vector<ClientInitKey, 4> client_init_keys;
     tls::vector<Epoch, 4> transcript;
 
     TLS_SERIALIZABLE(cipher_suite,
-                     sig_scheme,
+                     signature_scheme,
                      encrypt,
                      client_init_keys,
                      transcript);
@@ -444,17 +443,9 @@ struct SessionTestVectors
   uint32_t group_size;
   tls::opaque<1> group_id;
 
-  TestCase case_p256_p256;
-  TestCase case_p256_p256_encrypted;
-  TestCase case_x25519_ed25519;
-  TestCase case_x25519_ed25519_encrypted;
+  tls::vector<TestCase, 4> cases;
 
-  TLS_SERIALIZABLE(group_size,
-                   group_id,
-                   case_p256_p256,
-                   case_p256_p256_encrypted,
-                   case_x25519_ed25519,
-                   case_x25519_ed25519_encrypted);
+  TLS_SERIALIZABLE(group_size, group_id, cases);
 };
 
 struct BasicSessionTestVectors : SessionTestVectors


### PR DESCRIPTION
Noticed that the manual enumeration of test cases (by ciphersuite, signature scheme, etc.) made it more cumbersome than necessary to run tests.  This change should make it simpler to write tests against the test vector files, and make it easier to support new ciphersuites (etc.) in the future.