### PR TITLE
Scale down tree math tests

### DIFF
--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -9,7 +9,7 @@ TreeMathTestVectors
 generate_tree_math()
 {
   TreeMathTestVectors tv;
-  tv.n_leaves = LeafCount{ 255 };
+  tv.n_leaves = LeafCount{ 63 };
 
   for (uint32_t n = 1; n <= tv.n_leaves.val; ++n) {
     auto w = NodeCount{ LeafCount{ n } };
@@ -31,15 +31,15 @@ generate_tree_math()
     auto sibling = tree_math::sibling(NodeIndex{ x }, w);
     tv.sibling.push_back(sibling);
 
-    auto dirpath = tree_math::dirpath(NodeIndex{ x },  w);
+    auto dirpath = tree_math::dirpath(NodeIndex{ x }, w);
     tv.dirpath.push_back(dirpath);
 
-    auto copath = tree_math::copath(NodeIndex{ x },  w);
+    auto copath = tree_math::copath(NodeIndex{ x }, w);
     tv.copath.push_back(copath);
 
-    for (uint32_t l = 0; l < tv.n_leaves.val-1; ++l) {
+    for (uint32_t l = 0; l < tv.n_leaves.val - 1; ++l) {
       auto ancestors = std::vector<NodeIndex>();
-      for (uint32_t r = l+1; r < tv.n_leaves.val; ++r) {
+      for (uint32_t r = l + 1; r < tv.n_leaves.val; ++r) {
         auto a = tree_math::ancestor(LeafIndex(l), LeafIndex(r));
         ancestors.push_back(a);
       }

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -178,7 +178,7 @@ struct TreeBaseKeySource : public BaseKeySource
   {
     // Find an ancestor that is populated
     auto dirpath = tree_math::dirpath(NodeIndex{ sender }, width);
-    dirpath.insert(dirpath.begin(), NodeIndex{sender});
+    dirpath.insert(dirpath.begin(), NodeIndex{ sender });
     dirpath.push_back(tree_math::root(width));
     uint32_t curr = 0;
     for (; curr < dirpath.size(); ++curr) {

--- a/src/ratchet_tree.cpp
+++ b/src/ratchet_tree.cpp
@@ -264,7 +264,7 @@ RatchetTree::decap(LeafIndex from, const bytes& context, const DirectPath& path)
   }
 
   auto dirpath = tree_math::dirpath(NodeIndex{ from }, node_size());
-  dirpath.insert(dirpath.begin(), NodeIndex{from});
+  dirpath.insert(dirpath.begin(), NodeIndex{ from });
 
   // Handle the leaf node
   if (!path.nodes[0].node_secrets.empty()) {

--- a/src/tree_math.cpp
+++ b/src/tree_math.cpp
@@ -153,7 +153,7 @@ copath(NodeIndex x, NodeCount w)
   std::vector<NodeIndex> path;
   path.push_back(x);
   // exclude root
-  for (size_t i = 0; i < d.size()-1; ++i){
+  for (size_t i = 0; i < d.size() - 1; ++i) {
     path.push_back(d[i]);
   }
 
@@ -166,7 +166,9 @@ copath(NodeIndex x, NodeCount w)
 }
 
 // Common ancestor of two leaves
-NodeIndex ancestor(LeafIndex l, LeafIndex r) {
+NodeIndex
+ancestor(LeafIndex l, LeafIndex r)
+{
   auto ln = NodeIndex(l);
   auto rn = NodeIndex(r);
 
@@ -177,7 +179,7 @@ NodeIndex ancestor(LeafIndex l, LeafIndex r) {
     k += 1;
   }
 
-  return NodeIndex((ln.val << k) + (1 << (k-1)) - 1);
+  return NodeIndex((ln.val << k) + (1 << (k - 1)) - 1);
 }
 
 } // namespace tree_math

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -24,7 +24,15 @@ struct TreeMathTestVectors
   tls::vector<tls::vector<NodeIndex, 4>, 4> copath;
   tls::vector<tls::vector<NodeIndex, 4>, 4> ancestor;
 
-  TLS_SERIALIZABLE(n_leaves, root, left, right, parent, sibling, dirpath, copath, ancestor)
+  TLS_SERIALIZABLE(n_leaves,
+                   root,
+                   left,
+                   right,
+                   parent,
+                   sibling,
+                   dirpath,
+                   copath,
+                   ancestor)
 };
 
 /////
@@ -216,7 +224,7 @@ public:
     // Ensure that we have private keys for everything in the direct
     // path...
     auto dirpath = tree_math::dirpath(NodeIndex{ from }, node_size());
-    dirpath.insert(dirpath.begin(), NodeIndex{from});
+    dirpath.insert(dirpath.begin(), NodeIndex{ from });
 
     for (const auto& node : dirpath) {
       in_dirpath[node.val] = true;

--- a/test/tree_math_test.cpp
+++ b/test/tree_math_test.cpp
@@ -78,10 +78,10 @@ TEST_F(TreeMathTest, Copath)
 
 TEST_F(TreeMathTest, Ancestor)
 {
-  for (uint32_t l = 0; l < tv.n_leaves.val-1; ++l) {
+  for (uint32_t l = 0; l < tv.n_leaves.val - 1; ++l) {
     auto ancestors = std::vector<NodeIndex>();
-    for (uint32_t r = l+1; r < tv.n_leaves.val; ++r) {
-      ancestors.push_back(tree_math::ancestor(LeafIndex(l),LeafIndex(r)));
+    for (uint32_t r = l + 1; r < tv.n_leaves.val; ++r) {
+      ancestors.push_back(tree_math::ancestor(LeafIndex(l), LeafIndex(r)));
     }
     ASSERT_EQ(ancestors, tv.ancestor[l]);
   }


### PR DESCRIPTION
Using 255 leaves in the tree math tests was resulting in huge test vector files and tests taking forever (like 20sec per test, on a MacBook).  This PR just scales down the test size to make it go faster.  I don't think this degrades the testing value.