### PR TITLE
Move from `tls::` types to type traits

### DIFF
--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -32,10 +32,10 @@ generate_tree_math()
     tv.sibling.push_back(sibling);
 
     auto dirpath = tree_math::dirpath(NodeIndex{ x }, w);
-    tv.dirpath.push_back(dirpath);
+    tv.dirpath.push_back(TreeMathTestVectors::NodeVector{ dirpath });
 
     auto copath = tree_math::copath(NodeIndex{ x }, w);
-    tv.copath.push_back(copath);
+    tv.copath.push_back(TreeMathTestVectors::NodeVector{ copath });
 
     for (uint32_t l = 0; l < tv.n_leaves.val - 1; ++l) {
       auto ancestors = std::vector<NodeIndex>();
@@ -43,7 +43,7 @@ generate_tree_math()
         auto a = tree_math::ancestor(LeafIndex(l), LeafIndex(r));
         ancestors.push_back(a);
       }
-      tv.ancestor.push_back(ancestors);
+      tv.ancestor.emplace_back(TreeMathTestVectors::NodeVector{ ancestors });
     }
   }
 
@@ -112,7 +112,8 @@ generate_hash_ratchet()
       HashRatchet ratchet{ suite, NodeIndex{ LeafIndex{ j } }, tv.base_secret };
       for (uint32_t k = 0; k < tv.n_generations; ++k) {
         auto key_nonce = ratchet.get(k);
-        tc.key_sequences.at(j).push_back({ key_nonce.key, key_nonce.nonce });
+        tc.key_sequences.at(j).steps.push_back(
+          { key_nonce.key, key_nonce.nonce });
       }
     }
 
@@ -165,10 +166,9 @@ generate_key_schedule()
       auto ctx = tls::marshal(group_context);
       epoch = epoch.next(LeafCount{ n_members }, update_secret, ctx);
 
-      auto handshake_keys =
-        tls::vector<KeyScheduleTestVectors::KeyAndNonce, 4>();
+      auto handshake_keys = std::vector<KeyScheduleTestVectors::KeyAndNonce>();
       auto application_keys =
-        tls::vector<KeyScheduleTestVectors::KeyAndNonce, 4>();
+        std::vector<KeyScheduleTestVectors::KeyAndNonce>();
       for (LeafIndex k{ 0 }; k.val < n_members; ++k.val) {
         auto hs = epoch.handshake_keys.get(k, tv.target_generation);
         handshake_keys.push_back({ hs.key, hs.nonce });
@@ -209,11 +209,13 @@ TreeTestVectors::TreeCase
 tree_to_case(const TestRatchetTree& tree)
 {
   auto nodes = tree.nodes();
-  TreeTestVectors::TreeCase tc(nodes.size());
+  TreeTestVectors::TreeCase tc{};
+  tc.nodes.resize(nodes.size());
   for (size_t i = 0; i < nodes.size(); ++i) {
-    tc[i].hash = nodes[i].hash();
+    tc.nodes[i].hash = nodes[i].hash();
     if (nodes[i].has_value()) {
-      tc[i].public_key = nodes[i]->public_key().to_bytes();
+      tc.nodes[i].public_key =
+        TreeTestVectors::Bytes1{ nodes[i]->public_key().to_bytes() };
     }
   }
   return tc;
@@ -237,7 +239,7 @@ generate_tree()
   size_t n_leaves = 10;
   tv.leaf_secrets.resize(n_leaves);
   for (size_t i = 0; i < n_leaves; ++i) {
-    tv.leaf_secrets[i] = { uint8_t(i) };
+    tv.leaf_secrets[i].data = { uint8_t(i) };
   }
 
   for (size_t i = 0; i < suites.size(); ++i) {
@@ -257,9 +259,9 @@ generate_tree()
       auto cred = Credential::basic(id, sig.public_key());
       tc.credentials.push_back(cred);
 
-      auto priv = HPKEPrivateKey::derive(suite, tv.leaf_secrets[j]);
+      auto priv = HPKEPrivateKey::derive(suite, tv.leaf_secrets[j].data);
       tree.add_leaf(LeafIndex{ j }, priv.public_key(), tc.credentials[j]);
-      tree.encap(LeafIndex{ j }, {}, tv.leaf_secrets[j]);
+      tree.encap(LeafIndex{ j }, {}, tv.leaf_secrets[j].data);
       tc.trees.push_back(tree_to_case(tree));
     }
 
@@ -364,10 +366,10 @@ generate_messages()
 
     // Construct Commit
     auto commit = Commit{
-      { tv.random, tv.random },
-      { tv.random, tv.random },
-      { tv.random, tv.random },
-      { tv.random, tv.random },
+      { { tv.random }, { tv.random } },
+      { { tv.random }, { tv.random } },
+      { { tv.random }, { tv.random } },
+      { { tv.random }, { tv.random } },
       direct_path,
     };
 

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -557,10 +557,6 @@ verify_session_repro(const F& generator)
   auto v0 = generator();
   auto v1 = generator();
 
-  // Obviously, inputs should repro
-  verify_equal_marshaled(v0.group_size, v1.group_size);
-  verify_equal_marshaled(v0.group_id, v1.group_id);
-
   for (size_t i = 0; i < v0.cases.size(); ++i) {
     // Randomized signatures break reproducibility
     if (!deterministic_signature_scheme(v0.cases[i].signature_scheme)) {

--- a/include/credential.h
+++ b/include/credential.h
@@ -5,17 +5,6 @@
 
 namespace mls {
 
-// enum {
-//     basic(0),
-//     x509(1),
-//     (255)
-// } CredentialType;
-enum struct CredentialType : uint8_t
-{
-  basic = 0,
-  x509 = 1,
-};
-
 // struct {
 //     opaque identity<0..2^16-1>;
 //     SignatureScheme algorithm;
@@ -33,8 +22,6 @@ struct BasicCredential
 
   bytes identity;
   SignaturePublicKey public_key;
-
-  static const CredentialType type;
 };
 
 tls::ostream&
@@ -43,6 +30,17 @@ tls::istream&
 operator>>(tls::istream& str, BasicCredential& obj);
 bool
 operator==(const BasicCredential& lhs, const BasicCredential& rhs);
+
+// enum {
+//     basic(0),
+//     x509(1),
+//     (255)
+// } CredentialType;
+enum struct CredentialType : uint8_t
+{
+  basic = 0,
+  x509 = 1,
+};
 
 // struct {
 //     CredentialType credential_type;
@@ -64,10 +62,11 @@ public:
   static Credential basic(const bytes& identity,
                           const SignaturePublicKey& public_key);
 
-  TLS_SERIALIZABLE(_cred)
+  TLS_SERIALIZABLE(_cred);
+  TLS_TRAITS(tls::variant<CredentialType>);
 
 private:
-  tls::variant<CredentialType, BasicCredential> _cred;
+  std::variant<BasicCredential> _cred;
 };
 
 } // namespace mls

--- a/include/credential.h
+++ b/include/credential.h
@@ -5,6 +5,17 @@
 
 namespace mls {
 
+// enum {
+//     basic(0),
+//     x509(1),
+//     (255)
+// } CredentialType;
+enum struct CredentialType : uint8_t
+{
+  basic = 0,
+  x509 = 1,
+};
+
 // struct {
 //     opaque identity<0..2^16-1>;
 //     SignatureScheme algorithm;
@@ -22,6 +33,8 @@ struct BasicCredential
 
   bytes identity;
   SignaturePublicKey public_key;
+
+  static const CredentialType type;
 };
 
 tls::ostream&
@@ -30,17 +43,6 @@ tls::istream&
 operator>>(tls::istream& str, BasicCredential& obj);
 bool
 operator==(const BasicCredential& lhs, const BasicCredential& rhs);
-
-// enum {
-//     basic(0),
-//     x509(1),
-//     (255)
-// } CredentialType;
-enum struct CredentialType : uint8_t
-{
-  basic = 0,
-  x509 = 1,
-};
 
 // struct {
 //     CredentialType credential_type;

--- a/include/credential.h
+++ b/include/credential.h
@@ -62,8 +62,8 @@ public:
   static Credential basic(const bytes& identity,
                           const SignaturePublicKey& public_key);
 
-  TLS_SERIALIZABLE(_cred);
-  TLS_TRAITS(tls::variant<CredentialType>);
+  TLS_SERIALIZABLE(_cred)
+  TLS_TRAITS(tls::variant<CredentialType>)
 
 private:
   std::variant<BasicCredential> _cred;

--- a/include/credential.h
+++ b/include/credential.h
@@ -26,12 +26,12 @@ struct BasicCredential
   BasicCredential()
   {}
 
-  BasicCredential(tls::opaque<2> identity_in, SignaturePublicKey public_key_in)
+  BasicCredential(bytes identity_in, SignaturePublicKey public_key_in)
     : identity(std::move(identity_in))
     , public_key(std::move(public_key_in))
   {}
 
-  tls::opaque<2> identity;
+  bytes identity;
   SignaturePublicKey public_key;
 
   static const CredentialType type;

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -88,15 +88,16 @@ hkdf_expand_label(CipherSuite suite,
 // HPKE Keys
 struct HPKECiphertext
 {
-  tls::opaque<2> kem_output;
-  tls::opaque<4> ciphertext;
+  bytes kem_output;
+  bytes ciphertext;
 
   TLS_SERIALIZABLE(kem_output, ciphertext);
+  TLS_TRAITS(tls::vector_trait<2>, tls::vector_trait<4>);
 };
 
 struct HPKEPublicKey
 {
-  tls::opaque<2> data;
+  bytes data;
 
   HPKEPublicKey() = default;
   HPKEPublicKey(const bytes& data);
@@ -105,6 +106,7 @@ struct HPKEPublicKey
   bytes to_bytes() const;
 
   TLS_SERIALIZABLE(data);
+  TLS_TRAITS(tls::vector_trait<2>);
 };
 
 class HPKEPrivateKey
@@ -118,12 +120,13 @@ public:
   HPKEPublicKey public_key() const;
 
   TLS_SERIALIZABLE(_data, _pub_data);
+  TLS_TRAITS(tls::vector_trait<2>, tls::vector_trait<2>);
 
 private:
-  tls::opaque<2> _data;
-  tls::opaque<2> _pub_data;
+  bytes _data;
+  bytes _pub_data;
 
-  HPKEPrivateKey(CipherSuite suite, bytes data);
+  HPKEPrivateKey(CipherSuite suite, const bytes& data);
 };
 
 // Signature Keys
@@ -131,7 +134,7 @@ class SignaturePublicKey
 {
 public:
   SignaturePublicKey();
-  SignaturePublicKey(SignatureScheme scheme, bytes data);
+  SignaturePublicKey(SignatureScheme scheme, const bytes& data);
 
   void set_signature_scheme(SignatureScheme scheme);
   SignatureScheme signature_scheme() const;
@@ -139,10 +142,11 @@ public:
   bytes to_bytes() const;
 
   TLS_SERIALIZABLE(_data);
+  TLS_TRAITS(tls::vector_trait<2>);
 
 private:
   SignatureScheme _scheme;
-  tls::opaque<2> _data;
+  bytes _data;
 };
 
 class SignaturePrivateKey
@@ -159,13 +163,14 @@ public:
   SignaturePublicKey public_key() const;
 
   TLS_SERIALIZABLE(_scheme, _data, _pub_data);
+  TLS_TRAITS(tls::pass, tls::vector_trait<2>, tls::vector_trait<2>);
 
 private:
   SignatureScheme _scheme;
-  tls::opaque<2> _data;
-  tls::opaque<2> _pub_data;
+  bytes _data;
+  bytes _pub_data;
 
-  SignaturePrivateKey(SignatureScheme scheme, bytes data);
+  SignaturePrivateKey(SignatureScheme scheme, const bytes& data);
 };
 
 } // namespace mls

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -92,7 +92,7 @@ struct HPKECiphertext
   bytes ciphertext;
 
   TLS_SERIALIZABLE(kem_output, ciphertext);
-  TLS_TRAITS(tls::vector_trait<2>, tls::vector_trait<4>);
+  TLS_TRAITS(tls::vector<2>, tls::vector<4>);
 };
 
 struct HPKEPublicKey
@@ -106,7 +106,7 @@ struct HPKEPublicKey
   bytes to_bytes() const;
 
   TLS_SERIALIZABLE(data);
-  TLS_TRAITS(tls::vector_trait<2>);
+  TLS_TRAITS(tls::vector<2>);
 };
 
 class HPKEPrivateKey
@@ -120,7 +120,7 @@ public:
   HPKEPublicKey public_key() const;
 
   TLS_SERIALIZABLE(_data, _pub_data);
-  TLS_TRAITS(tls::vector_trait<2>, tls::vector_trait<2>);
+  TLS_TRAITS(tls::vector<2>, tls::vector<2>);
 
 private:
   bytes _data;
@@ -142,7 +142,7 @@ public:
   bytes to_bytes() const;
 
   TLS_SERIALIZABLE(_data);
-  TLS_TRAITS(tls::vector_trait<2>);
+  TLS_TRAITS(tls::vector<2>);
 
 private:
   SignatureScheme _scheme;
@@ -163,7 +163,7 @@ public:
   SignaturePublicKey public_key() const;
 
   TLS_SERIALIZABLE(_scheme, _data, _pub_data);
-  TLS_TRAITS(tls::pass, tls::vector_trait<2>, tls::vector_trait<2>);
+  TLS_TRAITS(tls::pass, tls::vector<2>, tls::vector<2>);
 
 private:
   SignatureScheme _scheme;

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -91,8 +91,8 @@ struct HPKECiphertext
   bytes kem_output;
   bytes ciphertext;
 
-  TLS_SERIALIZABLE(kem_output, ciphertext);
-  TLS_TRAITS(tls::vector<2>, tls::vector<4>);
+  TLS_SERIALIZABLE(kem_output, ciphertext)
+  TLS_TRAITS(tls::vector<2>, tls::vector<4>)
 };
 
 struct HPKEPublicKey
@@ -105,8 +105,8 @@ struct HPKEPublicKey
   HPKECiphertext encrypt(CipherSuite suite, const bytes& aad, const bytes& pt) const;
   bytes to_bytes() const;
 
-  TLS_SERIALIZABLE(data);
-  TLS_TRAITS(tls::vector<2>);
+  TLS_SERIALIZABLE(data)
+  TLS_TRAITS(tls::vector<2>)
 };
 
 class HPKEPrivateKey
@@ -119,8 +119,8 @@ public:
   bytes decrypt(CipherSuite suite, const bytes& aad, const HPKECiphertext& ct) const;
   HPKEPublicKey public_key() const;
 
-  TLS_SERIALIZABLE(_data, _pub_data);
-  TLS_TRAITS(tls::vector<2>, tls::vector<2>);
+  TLS_SERIALIZABLE(_data, _pub_data)
+  TLS_TRAITS(tls::vector<2>, tls::vector<2>)
 
 private:
   bytes _data;
@@ -141,8 +141,8 @@ public:
   bool verify(const bytes& message, const bytes& signature) const;
   bytes to_bytes() const;
 
-  TLS_SERIALIZABLE(_data);
-  TLS_TRAITS(tls::vector<2>);
+  TLS_SERIALIZABLE(_data)
+  TLS_TRAITS(tls::vector<2>)
 
 private:
   SignatureScheme _scheme;
@@ -162,8 +162,8 @@ public:
   bytes sign(const bytes& message) const;
   SignaturePublicKey public_key() const;
 
-  TLS_SERIALIZABLE(_scheme, _data, _pub_data);
-  TLS_TRAITS(tls::pass, tls::vector<2>, tls::vector<2>);
+  TLS_SERIALIZABLE(_scheme, _data, _pub_data)
+  TLS_TRAITS(tls::pass, tls::vector<2>, tls::vector<2>)
 
 private:
   SignatureScheme _scheme;

--- a/include/messages.h
+++ b/include/messages.h
@@ -204,16 +204,22 @@ enum struct ProposalType : uint8_t {
 
 struct Add {
   KeyPackage key_package;
+
+  static const ProposalType type;
   TLS_SERIALIZABLE(key_package)
 };
 
 struct Update {
   HPKEPublicKey leaf_key;
+
+  static const ProposalType type;
   TLS_SERIALIZABLE(leaf_key)
 };
 
 struct Remove {
   LeafIndex removed;
+
+  static const ProposalType type;
   TLS_SERIALIZABLE(removed)
 };
 
@@ -234,6 +240,8 @@ enum struct ContentType : uint8_t
 struct Proposal
 {
   std::variant<Add, Update, Remove> content;
+
+  static const ContentType type;
   TLS_SERIALIZABLE(content)
   TLS_TRAITS(tls::variant<ProposalType>)
 };
@@ -287,6 +295,7 @@ struct ApplicationData
 {
   bytes data;
 
+  static const ContentType type;
   TLS_SERIALIZABLE(data)
   TLS_TRAITS(tls::vector<4>)
 };
@@ -296,6 +305,7 @@ struct CommitData
   Commit commit;
   bytes confirmation;
 
+  static const ContentType type;
   TLS_SERIALIZABLE(commit, confirmation)
   TLS_TRAITS(tls::pass, tls::vector<1>)
 };

--- a/include/messages.h
+++ b/include/messages.h
@@ -204,22 +204,16 @@ enum struct ProposalType : uint8_t {
 
 struct Add {
   KeyPackage key_package;
-
-  static const ProposalType type;
   TLS_SERIALIZABLE(key_package)
 };
 
 struct Update {
   HPKEPublicKey leaf_key;
-
-  static const ProposalType type;
   TLS_SERIALIZABLE(leaf_key)
 };
 
 struct Remove {
   LeafIndex removed;
-
-  static const ProposalType type;
   TLS_SERIALIZABLE(removed)
 };
 
@@ -237,12 +231,11 @@ enum struct ContentType : uint8_t
   commit = 3,
 };
 
-struct Proposal : public tls::variant<ProposalType, Add, Update, Remove>
+struct Proposal
 {
-  using parent = tls::variant<ProposalType, Add, Update, Remove>;
-  using parent::parent;
-
-  static const ContentType type;
+  std::variant<Add, Update, Remove> content;
+  TLS_SERIALIZABLE(content);
+  TLS_TRAITS(tls::variant<ProposalType>);
 };
 
 struct ProposalID {
@@ -296,8 +289,6 @@ struct ApplicationData
 
   TLS_SERIALIZABLE(data);
   TLS_TRAITS(tls::vector<4>);
-
-  static const ContentType type;
 };
 
 struct CommitData
@@ -305,7 +296,6 @@ struct CommitData
   Commit commit;
   bytes confirmation;
 
-  static const ContentType type;
   TLS_SERIALIZABLE(commit, confirmation);
   TLS_TRAITS(tls::pass, tls::vector<1>);
 };
@@ -318,7 +308,7 @@ struct MLSPlaintext
   epoch_t epoch;
   LeafIndex sender;
   bytes authenticated_data;
-  tls::variant<ContentType, ApplicationData, Proposal, CommitData> content;
+  std::variant<ApplicationData, Proposal, CommitData> content;
   bytes signature;
 
   // Constructor for unmarshaling directly
@@ -360,7 +350,7 @@ struct MLSPlaintext
              tls::pass,
              tls::pass,
              tls::vector<4>,
-             tls::pass,
+             tls::variant<ContentType>,
              tls::vector<2>)
 };
 

--- a/include/messages.h
+++ b/include/messages.h
@@ -28,7 +28,7 @@ struct RatchetNode
   std::vector<HPKECiphertext> node_secrets;
 
   TLS_SERIALIZABLE(public_key, node_secrets);
-  TLS_TRAITS(tls::pass, tls::vector_trait<2>);
+  TLS_TRAITS(tls::pass, tls::vector<2>);
 };
 
 // struct {
@@ -39,7 +39,7 @@ struct DirectPath
   std::vector<RatchetNode> nodes;
 
   TLS_SERIALIZABLE(nodes);
-  TLS_TRAITS(tls::vector_trait<2>);
+  TLS_TRAITS(tls::vector<2>);
 };
 
 // struct {
@@ -69,7 +69,7 @@ struct KeyPackage
   bool verify() const;
 
   TLS_SERIALIZABLE(version, cipher_suite, init_key, credential, signature);
-  TLS_TRAITS(tls::pass, tls::pass, tls::pass, tls::pass, tls::vector_trait<2>);
+  TLS_TRAITS(tls::pass, tls::pass, tls::pass, tls::pass, tls::vector<2>);
 
   private:
   bytes to_be_signed() const;
@@ -127,16 +127,16 @@ struct GroupInfo {
                    confirmation,
                    signer_index,
                    signature);
-  TLS_TRAITS(tls::vector_trait<1>,
+  TLS_TRAITS(tls::vector<1>,
              tls::pass,
              tls::pass,
-             tls::vector_trait<1>,
-             tls::vector_trait<1>,
-             tls::vector_trait<1>,
+             tls::vector<1>,
+             tls::vector<1>,
+             tls::vector<1>,
              tls::pass,
-             tls::vector_trait<1>,
+             tls::vector<1>,
              tls::pass,
-             tls::vector_trait<2>);
+             tls::vector<2>);
 };
 
 // struct {
@@ -148,7 +148,7 @@ struct GroupSecrets {
   bytes init_secret;
 
   TLS_SERIALIZABLE(init_secret);
-  TLS_TRAITS(tls::vector_trait<1>);
+  TLS_TRAITS(tls::vector<1>);
 };
 
 // struct {
@@ -160,7 +160,7 @@ struct EncryptedGroupSecrets {
   HPKECiphertext encrypted_group_secrets;
 
   TLS_SERIALIZABLE(key_package_hash, encrypted_group_secrets);
-  TLS_TRAITS(tls::vector_trait<1>, tls::pass);
+  TLS_TRAITS(tls::vector<1>, tls::pass);
 };
 
 
@@ -185,7 +185,7 @@ struct Welcome {
   std::optional<int> find(const KeyPackage& kp) const;
 
   TLS_SERIALIZABLE(version, cipher_suite, secrets, encrypted_group_info);
-  TLS_TRAITS(tls::pass, tls::pass, tls::vector_trait<4>, tls::vector_trait<4>);
+  TLS_TRAITS(tls::pass, tls::pass, tls::vector<4>, tls::vector<4>);
 
   private:
   bytes _init_secret;
@@ -248,7 +248,7 @@ struct Proposal : public tls::variant<ProposalType, Add, Update, Remove>
 struct ProposalID {
   bytes id;
   TLS_SERIALIZABLE(id);
-  TLS_TRAITS(tls::vector_trait<1>);
+  TLS_TRAITS(tls::vector<1>);
 };
 
 // struct {
@@ -266,10 +266,10 @@ struct Commit {
   DirectPath path;
 
   TLS_SERIALIZABLE(updates, removes, adds, ignored, path);
-  TLS_TRAITS(tls::vector_trait<2>,
-             tls::vector_trait<2>,
-             tls::vector_trait<2>,
-             tls::vector_trait<2>,
+  TLS_TRAITS(tls::vector<2>,
+             tls::vector<2>,
+             tls::vector<2>,
+             tls::vector<2>,
              tls::pass);
 };
 
@@ -295,7 +295,7 @@ struct ApplicationData
   bytes data;
 
   TLS_SERIALIZABLE(data);
-  TLS_TRAITS(tls::vector_trait<4>);
+  TLS_TRAITS(tls::vector<4>);
 
   static const ContentType type;
 };
@@ -307,7 +307,7 @@ struct CommitData
 
   static const ContentType type;
   TLS_SERIALIZABLE(commit, confirmation);
-  TLS_TRAITS(tls::pass, tls::vector_trait<1>);
+  TLS_TRAITS(tls::pass, tls::vector<1>);
 };
 
 struct GroupContext;
@@ -356,12 +356,12 @@ struct MLSPlaintext
   bytes commit_auth_data() const;
 
   TLS_SERIALIZABLE(group_id, epoch, sender, authenticated_data, content, signature);
-  TLS_TRAITS(tls::vector_trait<1>,
+  TLS_TRAITS(tls::vector<1>,
              tls::pass,
              tls::pass,
-             tls::vector_trait<4>,
+             tls::vector<4>,
              tls::pass,
-             tls::vector_trait<2>)
+             tls::vector<2>)
 };
 
 // struct {
@@ -384,13 +384,13 @@ struct MLSCiphertext
 
   TLS_SERIALIZABLE(group_id, epoch, content_type, sender_data_nonce,
                    encrypted_sender_data, authenticated_data, ciphertext);
-  TLS_TRAITS(tls::vector_trait<1>,
+  TLS_TRAITS(tls::vector<1>,
              tls::pass,
              tls::pass,
-             tls::vector_trait<1>,
-             tls::vector_trait<1>,
-             tls::vector_trait<4>,
-             tls::vector_trait<4>);
+             tls::vector<1>,
+             tls::vector<1>,
+             tls::vector<4>,
+             tls::vector<4>);
 };
 
 } // namespace mls

--- a/include/messages.h
+++ b/include/messages.h
@@ -263,7 +263,7 @@ struct Commit {
              tls::vector<2>,
              tls::vector<2>,
              tls::vector<2>,
-             tls::pass);
+             tls::pass)
 };
 
 // struct {
@@ -380,7 +380,7 @@ struct MLSCiphertext
              tls::vector<1>,
              tls::vector<1>,
              tls::vector<4>,
-             tls::vector<4>);
+             tls::vector<4>)
 };
 
 } // namespace mls

--- a/include/messages.h
+++ b/include/messages.h
@@ -27,8 +27,8 @@ struct RatchetNode
   HPKEPublicKey public_key;
   std::vector<HPKECiphertext> node_secrets;
 
-  TLS_SERIALIZABLE(public_key, node_secrets);
-  TLS_TRAITS(tls::pass, tls::vector<2>);
+  TLS_SERIALIZABLE(public_key, node_secrets)
+  TLS_TRAITS(tls::pass, tls::vector<2>)
 };
 
 // struct {
@@ -38,8 +38,8 @@ struct DirectPath
 {
   std::vector<RatchetNode> nodes;
 
-  TLS_SERIALIZABLE(nodes);
-  TLS_TRAITS(tls::vector<2>);
+  TLS_SERIALIZABLE(nodes)
+  TLS_TRAITS(tls::vector<2>)
 };
 
 // struct {
@@ -68,8 +68,8 @@ struct KeyPackage
   bytes hash() const;
   bool verify() const;
 
-  TLS_SERIALIZABLE(version, cipher_suite, init_key, credential, signature);
-  TLS_TRAITS(tls::pass, tls::pass, tls::pass, tls::pass, tls::vector<2>);
+  TLS_SERIALIZABLE(version, cipher_suite, init_key, credential, signature)
+  TLS_TRAITS(tls::pass, tls::pass, tls::pass, tls::pass, tls::vector<2>)
 
   private:
   bytes to_be_signed() const;
@@ -126,7 +126,7 @@ struct GroupInfo {
                    path,
                    confirmation,
                    signer_index,
-                   signature);
+                   signature)
   TLS_TRAITS(tls::vector<1>,
              tls::pass,
              tls::pass,
@@ -136,7 +136,7 @@ struct GroupInfo {
              tls::pass,
              tls::vector<1>,
              tls::pass,
-             tls::vector<2>);
+             tls::vector<2>)
 };
 
 // struct {
@@ -147,8 +147,8 @@ struct GroupInfo {
 struct GroupSecrets {
   bytes init_secret;
 
-  TLS_SERIALIZABLE(init_secret);
-  TLS_TRAITS(tls::vector<1>);
+  TLS_SERIALIZABLE(init_secret)
+  TLS_TRAITS(tls::vector<1>)
 };
 
 // struct {
@@ -159,8 +159,8 @@ struct EncryptedGroupSecrets {
   bytes key_package_hash;
   HPKECiphertext encrypted_group_secrets;
 
-  TLS_SERIALIZABLE(key_package_hash, encrypted_group_secrets);
-  TLS_TRAITS(tls::vector<1>, tls::pass);
+  TLS_SERIALIZABLE(key_package_hash, encrypted_group_secrets)
+  TLS_TRAITS(tls::vector<1>, tls::pass)
 };
 
 
@@ -184,8 +184,8 @@ struct Welcome {
   void encrypt(const KeyPackage& kp);
   std::optional<int> find(const KeyPackage& kp) const;
 
-  TLS_SERIALIZABLE(version, cipher_suite, secrets, encrypted_group_info);
-  TLS_TRAITS(tls::pass, tls::pass, tls::vector<4>, tls::vector<4>);
+  TLS_SERIALIZABLE(version, cipher_suite, secrets, encrypted_group_info)
+  TLS_TRAITS(tls::pass, tls::pass, tls::vector<4>, tls::vector<4>)
 
   private:
   bytes _init_secret;
@@ -234,14 +234,14 @@ enum struct ContentType : uint8_t
 struct Proposal
 {
   std::variant<Add, Update, Remove> content;
-  TLS_SERIALIZABLE(content);
-  TLS_TRAITS(tls::variant<ProposalType>);
+  TLS_SERIALIZABLE(content)
+  TLS_TRAITS(tls::variant<ProposalType>)
 };
 
 struct ProposalID {
   bytes id;
-  TLS_SERIALIZABLE(id);
-  TLS_TRAITS(tls::vector<1>);
+  TLS_SERIALIZABLE(id)
+  TLS_TRAITS(tls::vector<1>)
 };
 
 // struct {
@@ -258,7 +258,7 @@ struct Commit {
   std::vector<ProposalID> ignored;
   DirectPath path;
 
-  TLS_SERIALIZABLE(updates, removes, adds, ignored, path);
+  TLS_SERIALIZABLE(updates, removes, adds, ignored, path)
   TLS_TRAITS(tls::vector<2>,
              tls::vector<2>,
              tls::vector<2>,
@@ -287,8 +287,8 @@ struct ApplicationData
 {
   bytes data;
 
-  TLS_SERIALIZABLE(data);
-  TLS_TRAITS(tls::vector<4>);
+  TLS_SERIALIZABLE(data)
+  TLS_TRAITS(tls::vector<4>)
 };
 
 struct CommitData
@@ -296,8 +296,8 @@ struct CommitData
   Commit commit;
   bytes confirmation;
 
-  TLS_SERIALIZABLE(commit, confirmation);
-  TLS_TRAITS(tls::pass, tls::vector<1>);
+  TLS_SERIALIZABLE(commit, confirmation)
+  TLS_TRAITS(tls::pass, tls::vector<1>)
 };
 
 struct GroupContext;
@@ -345,7 +345,7 @@ struct MLSPlaintext
   bytes commit_content() const;
   bytes commit_auth_data() const;
 
-  TLS_SERIALIZABLE(group_id, epoch, sender, authenticated_data, content, signature);
+  TLS_SERIALIZABLE(group_id, epoch, sender, authenticated_data, content, signature)
   TLS_TRAITS(tls::vector<1>,
              tls::pass,
              tls::pass,

--- a/include/messages.h
+++ b/include/messages.h
@@ -145,7 +145,7 @@ struct GroupInfo {
 //   opaque path_secret<1..255>;
 // } GroupSecrets;
 struct GroupSecrets {
-  tls::opaque<1> init_secret;
+  bytes init_secret;
 
   TLS_SERIALIZABLE(init_secret);
   TLS_TRAITS(tls::vector_trait<1>);
@@ -245,6 +245,12 @@ struct Proposal : public tls::variant<ProposalType, Add, Update, Remove>
   static const ContentType type;
 };
 
+struct ProposalID {
+  bytes id;
+  TLS_SERIALIZABLE(id);
+  TLS_TRAITS(tls::vector_trait<1>);
+};
+
 // struct {
 //     ProposalID updates<0..2^16-1>;
 //     ProposalID removes<0..2^16-1>;
@@ -252,7 +258,6 @@ struct Proposal : public tls::variant<ProposalType, Add, Update, Remove>
 //     ProposalID ignored<0..2^16-1>;
 //     DirectPath path;
 // } Commit;
-using ProposalID = tls::opaque<1>;
 struct Commit {
   std::vector<ProposalID> updates;
   std::vector<ProposalID> removes;
@@ -285,10 +290,12 @@ struct Commit {
 //
 //     opaque signature<0..2^16-1>;
 // } MLSPlaintext;
-struct ApplicationData : tls::opaque<4>
+struct ApplicationData
 {
-  using parent = tls::opaque<4>;
-  using parent::parent;
+  bytes data;
+
+  TLS_SERIALIZABLE(data);
+  TLS_TRAITS(tls::vector_trait<4>);
 
   static const ContentType type;
 };

--- a/include/messages.h
+++ b/include/messages.h
@@ -28,7 +28,7 @@ struct RatchetNode
   std::vector<HPKECiphertext> node_secrets;
 
   TLS_SERIALIZABLE(public_key, node_secrets);
-  TLS_TRAITS(tls::pass{}, tls::vector_trait<2>{});
+  TLS_TRAITS(tls::pass, tls::vector_trait<2>);
 };
 
 // struct {
@@ -39,7 +39,7 @@ struct DirectPath
   std::vector<RatchetNode> nodes;
 
   TLS_SERIALIZABLE(nodes);
-  TLS_TRAITS(tls::vector_trait<2>{});
+  TLS_TRAITS(tls::vector_trait<2>);
 };
 
 // struct {
@@ -69,7 +69,7 @@ struct KeyPackage
   bool verify() const;
 
   TLS_SERIALIZABLE(version, cipher_suite, init_key, credential, signature);
-  TLS_TRAITS(tls::pass{}, tls::pass{}, tls::pass{}, tls::pass{}, tls::vector_trait<2>{});
+  TLS_TRAITS(tls::pass, tls::pass, tls::pass, tls::pass, tls::vector_trait<2>);
 
   private:
   bytes to_be_signed() const;
@@ -127,16 +127,16 @@ struct GroupInfo {
                    confirmation,
                    signer_index,
                    signature);
-  TLS_TRAITS(tls::vector_trait<1>{},
-             tls::pass{},
-             tls::pass{},
-             tls::vector_trait<1>{},
-             tls::vector_trait<1>{},
-             tls::vector_trait<1>{},
-             tls::pass{},
-             tls::vector_trait<1>{},
-             tls::pass{},
-             tls::vector_trait<2>{});
+  TLS_TRAITS(tls::vector_trait<1>,
+             tls::pass,
+             tls::pass,
+             tls::vector_trait<1>,
+             tls::vector_trait<1>,
+             tls::vector_trait<1>,
+             tls::pass,
+             tls::vector_trait<1>,
+             tls::pass,
+             tls::vector_trait<2>);
 };
 
 // struct {
@@ -148,7 +148,7 @@ struct GroupSecrets {
   tls::opaque<1> init_secret;
 
   TLS_SERIALIZABLE(init_secret);
-  TLS_TRAITS(tls::vector_trait<1>{});
+  TLS_TRAITS(tls::vector_trait<1>);
 };
 
 // struct {
@@ -160,7 +160,7 @@ struct EncryptedGroupSecrets {
   HPKECiphertext encrypted_group_secrets;
 
   TLS_SERIALIZABLE(key_package_hash, encrypted_group_secrets);
-  TLS_TRAITS(tls::vector_trait<1>{}, tls::pass{});
+  TLS_TRAITS(tls::vector_trait<1>, tls::pass);
 };
 
 
@@ -185,7 +185,7 @@ struct Welcome {
   std::optional<int> find(const KeyPackage& kp) const;
 
   TLS_SERIALIZABLE(version, cipher_suite, secrets, encrypted_group_info);
-  TLS_TRAITS(tls::pass{}, tls::pass{}, tls::vector_trait<4>{}, tls::vector_trait<4>{});
+  TLS_TRAITS(tls::pass, tls::pass, tls::vector_trait<4>, tls::vector_trait<4>);
 
   private:
   bytes _init_secret;
@@ -261,11 +261,11 @@ struct Commit {
   DirectPath path;
 
   TLS_SERIALIZABLE(updates, removes, adds, ignored, path);
-  TLS_TRAITS(tls::vector_trait<2>{},
-             tls::vector_trait<2>{},
-             tls::vector_trait<2>{},
-             tls::vector_trait<2>{},
-             tls::pass{});
+  TLS_TRAITS(tls::vector_trait<2>,
+             tls::vector_trait<2>,
+             tls::vector_trait<2>,
+             tls::vector_trait<2>,
+             tls::pass);
 };
 
 // struct {
@@ -300,7 +300,7 @@ struct CommitData
 
   static const ContentType type;
   TLS_SERIALIZABLE(commit, confirmation);
-  TLS_TRAITS(tls::pass{}, tls::vector_trait<1>{});
+  TLS_TRAITS(tls::pass, tls::vector_trait<1>);
 };
 
 struct GroupContext;
@@ -349,12 +349,12 @@ struct MLSPlaintext
   bytes commit_auth_data() const;
 
   TLS_SERIALIZABLE(group_id, epoch, sender, authenticated_data, content, signature);
-  TLS_TRAITS(tls::vector_trait<1>{},
-             tls::pass{},
-             tls::pass{},
-             tls::vector_trait<4>{},
-             tls::pass{},
-             tls::vector_trait<2>{})
+  TLS_TRAITS(tls::vector_trait<1>,
+             tls::pass,
+             tls::pass,
+             tls::vector_trait<4>,
+             tls::pass,
+             tls::vector_trait<2>)
 };
 
 // struct {
@@ -377,13 +377,13 @@ struct MLSCiphertext
 
   TLS_SERIALIZABLE(group_id, epoch, content_type, sender_data_nonce,
                    encrypted_sender_data, authenticated_data, ciphertext);
-  TLS_TRAITS(tls::vector_trait<1>{},
-             tls::pass{},
-             tls::pass{},
-             tls::vector_trait<1>{},
-             tls::vector_trait<1>{},
-             tls::vector_trait<4>{},
-             tls::vector_trait<4>{});
+  TLS_TRAITS(tls::vector_trait<1>,
+             tls::pass,
+             tls::pass,
+             tls::vector_trait<1>,
+             tls::vector_trait<1>,
+             tls::vector_trait<4>,
+             tls::vector_trait<4>);
 };
 
 } // namespace mls

--- a/include/ratchet_tree.h
+++ b/include/ratchet_tree.h
@@ -32,8 +32,8 @@ public:
   void set_cipher_suite();
   void add_unmerged(LeafIndex index);
 
-  TLS_SERIALIZABLE(_pub, _unmerged_leaves, _cred);
-  TLS_TRAITS(tls::pass, tls::vector<4>, tls::pass);
+  TLS_SERIALIZABLE(_pub, _unmerged_leaves, _cred)
+  TLS_TRAITS(tls::pass, tls::vector<4>, tls::pass)
 
 private:
   std::optional<HPKEPrivateKey> _priv;

--- a/include/ratchet_tree.h
+++ b/include/ratchet_tree.h
@@ -43,16 +43,16 @@ private:
   std::vector<LeafIndex> _unmerged_leaves;
 
   // A credential is populated iff this is a leaf node
-  tls::optional<Credential> _cred;
+  std::optional<Credential> _cred;
 };
 
 // XXX(rlb@ipv.sx): We have to subclass optional<T> in order to
 // ensure that nodes are populated with blank values on unmarshal.
 // Otherwise, `*opt` will access uninitialized memory.
 struct OptionalRatchetTreeNode
-  : public tls::optional<RatchetTreeNode>
+  : public std::optional<RatchetTreeNode>
 {
-  using parent = tls::optional<RatchetTreeNode>;
+  using parent = std::optional<RatchetTreeNode>;
   using parent::parent;
 
   bool has_private() const;

--- a/include/ratchet_tree.h
+++ b/include/ratchet_tree.h
@@ -33,7 +33,7 @@ public:
   void add_unmerged(LeafIndex index);
 
   TLS_SERIALIZABLE(_pub, _unmerged_leaves, _cred);
-  TLS_TRAITS(tls::pass, tls::vector_trait<4>, tls::pass);
+  TLS_TRAITS(tls::pass, tls::vector<4>, tls::pass);
 
 private:
   std::optional<HPKEPrivateKey> _priv;

--- a/include/ratchet_tree.h
+++ b/include/ratchet_tree.h
@@ -33,7 +33,7 @@ public:
   void add_unmerged(LeafIndex index);
 
   TLS_SERIALIZABLE(_pub, _unmerged_leaves, _cred);
-  TLS_TRAITS(tls::pass{}, tls::vector_trait<4>{}, tls::pass{});
+  TLS_TRAITS(tls::pass, tls::vector_trait<4>, tls::pass);
 
 private:
   std::optional<HPKEPrivateKey> _priv;

--- a/include/ratchet_tree.h
+++ b/include/ratchet_tree.h
@@ -18,8 +18,8 @@ class RatchetTreeNode
 public:
   RatchetTreeNode() = default;
   RatchetTreeNode(CipherSuite suite, const bytes& secret);
-  RatchetTreeNode(HPKEPrivateKey priv);
-  RatchetTreeNode(HPKEPublicKey pub);
+  RatchetTreeNode(const HPKEPrivateKey& priv);
+  RatchetTreeNode(const HPKEPublicKey& pub);
 
   bool public_equal(const RatchetTreeNode& other) const;
   const std::optional<HPKEPrivateKey>& private_key() const;

--- a/include/ratchet_tree.h
+++ b/include/ratchet_tree.h
@@ -33,13 +33,14 @@ public:
   void add_unmerged(LeafIndex index);
 
   TLS_SERIALIZABLE(_pub, _unmerged_leaves, _cred);
+  TLS_TRAITS(tls::pass{}, tls::vector_trait<4>{}, tls::pass{});
 
 private:
   std::optional<HPKEPrivateKey> _priv;
   HPKEPublicKey _pub;
 
   // Unmerged leaves to be included in resolution
-  tls::vector<LeafIndex, 4> _unmerged_leaves;
+  std::vector<LeafIndex> _unmerged_leaves;
 
   // A credential is populated iff this is a leaf node
   tls::optional<Credential> _cred;
@@ -68,9 +69,9 @@ private:
 };
 
 struct RatchetTreeNodeVector
-  : public tls::vector<OptionalRatchetTreeNode, 4>
+  : public std::vector<OptionalRatchetTreeNode>
 {
-  using parent = tls::vector<OptionalRatchetTreeNode, 4>;
+  using parent = std::vector<OptionalRatchetTreeNode>;
   using parent::parent;
   using parent::operator[];
 

--- a/include/state.h
+++ b/include/state.h
@@ -25,7 +25,7 @@ struct GroupContext
   bytes confirmed_transcript_hash;
 
   TLS_SERIALIZABLE(group_id, epoch, tree_hash, confirmed_transcript_hash);
-  TLS_TRAITS(tls::vector_trait<1>, tls::pass, tls::vector_trait<1>, tls::vector_trait<1>);
+  TLS_TRAITS(tls::vector<1>, tls::pass, tls::vector<1>, tls::vector<1>);
 };
 
 class State

--- a/include/state.h
+++ b/include/state.h
@@ -24,8 +24,8 @@ struct GroupContext
   bytes tree_hash;
   bytes confirmed_transcript_hash;
 
-  TLS_SERIALIZABLE(group_id, epoch, tree_hash, confirmed_transcript_hash);
-  TLS_TRAITS(tls::vector<1>, tls::pass, tls::vector<1>, tls::vector<1>);
+  TLS_SERIALIZABLE(group_id, epoch, tree_hash, confirmed_transcript_hash)
+  TLS_TRAITS(tls::vector<1>, tls::pass, tls::vector<1>, tls::vector<1>)
 };
 
 class State

--- a/include/state.h
+++ b/include/state.h
@@ -19,12 +19,13 @@ namespace mls {
 // } GroupContext;
 struct GroupContext
 {
-  tls::opaque<1> group_id;
+  bytes group_id;
   epoch_t epoch;
-  tls::opaque<1> tree_hash;
-  tls::opaque<1> confirmed_transcript_hash;
+  bytes tree_hash;
+  bytes confirmed_transcript_hash;
 
-  TLS_SERIALIZABLE(group_id, epoch, tree_hash, confirmed_transcript_hash)
+  TLS_SERIALIZABLE(group_id, epoch, tree_hash, confirmed_transcript_hash);
+  TLS_TRAITS(tls::vector_trait<1>, tls::pass, tls::vector_trait<1>, tls::vector_trait<1>);
 };
 
 class State
@@ -103,7 +104,7 @@ protected:
 
   // Cache of Proposals and update secrets
   std::list<MLSPlaintext> _pending_proposals;
-  std::map<ProposalID, bytes> _update_secrets;
+  std::map<bytes, bytes> _update_secrets;
 
   // Assemble a group context for this state
   GroupContext group_context() const;
@@ -125,7 +126,7 @@ protected:
   void apply(const Commit& commit);
 
   // Compute a proposal ID
-  bytes proposal_id(const MLSPlaintext& pt) const;
+  ProposalID proposal_id(const MLSPlaintext& pt) const;
 
   // Extract a proposal from the cache
   std::optional<MLSPlaintext> find_proposal(const ProposalID& id);

--- a/include/tls_syntax.h
+++ b/include/tls_syntax.h
@@ -70,62 +70,6 @@ class variant_variant : public variant<Te, Tp...>
   Tc _context;
 };
 
-template<typename T>
-class optional_base : public std::optional<T>
-{
-public:
-  using parent = std::optional<T>;
-  using parent::parent;
-  virtual ~optional_base() = default;
-
-  virtual T& emplace_new() = 0;
-};
-
-template<typename T>
-class optional : public optional_base<T>
-{
-public:
-  using parent = optional_base<T>;
-  using parent::parent;
-
-  virtual T& emplace_new() { return this->emplace(); }
-};
-
-template<typename T>
-bool
-operator==(const optional<T>& lhs, const optional<T>& rhs)
-{
-  auto both_blank = (!lhs.has_value() && !rhs.has_value());
-  auto both_occupied = (lhs.has_value() && rhs.has_value());
-  return (both_blank || (both_occupied && (lhs.value() == rhs.value())));
-}
-
-template<typename T, typename C>
-class variant_optional : public optional_base<T>
-{
-public:
-  using parent = optional_base<T>;
-  using parent::parent;
-
-  variant_optional(C ctor_arg)
-    : _ctor_arg(ctor_arg)
-  {}
-
-  virtual T& emplace_new() { return this->emplace(_ctor_arg); }
-
-private:
-  C _ctor_arg;
-};
-
-template<typename T, typename C>
-bool
-operator==(const variant_optional<T, C>& lhs, const variant_optional<T, C>& rhs)
-{
-  auto both_blank = (!lhs.has_value() && !rhs.has_value());
-  auto both_occupied = (lhs.has_value() && rhs.has_value());
-  return (both_blank || (both_occupied && (lhs.value() == rhs.value())));
-}
-
 ///
 /// ostream
 ///
@@ -172,7 +116,7 @@ operator<<(ostream& out, const std::array<T, N>& data)
 // Optional writer
 template<typename T>
 tls::ostream&
-operator<<(tls::ostream& out, const optional_base<T>& opt)
+operator<<(tls::ostream& out, const std::optional<T>& opt)
 {
   if (!opt.has_value()) {
     return out << uint8_t(0);
@@ -269,7 +213,7 @@ operator>>(istream& in, std::array<T, N>& data)
 // Optional reader
 template<typename T>
 tls::istream&
-operator>>(tls::istream& in, optional_base<T>& opt)
+operator>>(tls::istream& in, std::optional<T>& opt)
 {
   uint8_t present = 0;
   in >> present;
@@ -280,7 +224,7 @@ operator>>(tls::istream& in, optional_base<T>& opt)
       return in;
 
     case 1:
-      opt.emplace_new();
+      opt.emplace();
       return in >> opt.value();
 
     default:

--- a/include/tls_syntax.h
+++ b/include/tls_syntax.h
@@ -391,7 +391,7 @@ struct variant {
   {
     using Tc = std::variant_alternative_t<I, std::variant<Tp...>>;
     if (std::holds_alternative<Tc>(v)) {
-      str << variant_value<Te, Tc> << std::get<I>(v);
+      str << Tc::type << std::get<I>(v);
       return;
     }
 
@@ -416,7 +416,7 @@ struct variant {
   read_variant(tls::istream& str, Te target_type, std::variant<Tp...>& v)
   {
     using Tc = std::variant_alternative_t<I, std::variant<Tp...>>;
-    if (variant_value<Te, Tc> == target_type) {
+    if (Tc::type == target_type) {
       str >> v.template emplace<I>();
       return;
     }

--- a/include/tls_syntax.h
+++ b/include/tls_syntax.h
@@ -153,7 +153,7 @@ private:
   friend ostream& operator<<(ostream& out, const std::array<T, N>& data);
 
   template<size_t head, size_t min, size_t max>
-  friend struct vector_trait;
+  friend struct vector;
 };
 
 // Primitive writers defined in .cpp file
@@ -250,7 +250,7 @@ private:
   friend istream& operator>>(istream& in, std::array<T, N>& data);
 
   template<size_t head, size_t min, size_t max>
-  friend struct vector_trait;
+  friend struct vector;
 };
 
 // Primitive type readers defined in .cpp file
@@ -435,7 +435,7 @@ struct pass {
 
 // Vector encoding
 template<size_t head, size_t min=none, size_t max=none>
-struct vector_trait {
+struct vector {
   template<typename T>
   static ostream& encode(ostream& str, const std::vector<T>& data) {
     // Vectors with no header are written directly

--- a/include/tree_math.h
+++ b/include/tree_math.h
@@ -46,7 +46,7 @@ struct UInt32
     : val(val_in)
   {}
 
-  TLS_SERIALIZABLE(val);
+  TLS_SERIALIZABLE(val)
 };
 
 struct NodeCount;

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -12,15 +12,16 @@ const CredentialType BasicCredential::type = CredentialType::basic;
 tls::ostream&
 operator<<(tls::ostream& str, const BasicCredential& obj)
 {
-  return str << obj.identity << obj.public_key.signature_scheme()
-             << obj.public_key;
+  tls::vector_trait<2>::encode(str, obj.identity);
+  return str << obj.public_key.signature_scheme() << obj.public_key;
 }
 
 tls::istream&
 operator>>(tls::istream& str, BasicCredential& obj)
 {
   SignatureScheme scheme;
-  str >> obj.identity >> scheme >> obj.public_key;
+  tls::vector_trait<2>::decode(str, obj.identity);
+  str >> scheme >> obj.public_key;
   obj.public_key.set_signature_scheme(scheme);
   return str;
 }

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -1,24 +1,13 @@
 #include "credential.h"
 #include "tls_syntax.h"
 
-namespace tls {
-
-///
-/// CredentialType
-///
-
-template<>
-inline mls::CredentialType
-  variant_value<mls::CredentialType, mls::BasicCredential> =
-    mls::CredentialType::basic;
-
-} // namespace tls
-
 namespace mls {
 
 ///
 /// BasicCredential
 ///
+
+const CredentialType BasicCredential::type = CredentialType::basic;
 
 tls::ostream&
 operator<<(tls::ostream& str, const BasicCredential& obj)

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -1,13 +1,25 @@
 #include "credential.h"
 #include "tls_syntax.h"
 
+namespace tls {
+
+///
+/// CredentialType
+///
+
+using namespace mls;
+
+template<>
+CredentialType variant_value<CredentialType, BasicCredential> =
+  CredentialType::basic;
+
+} // namespace tls
+
 namespace mls {
 
 ///
 /// BasicCredential
 ///
-
-const CredentialType BasicCredential::type = CredentialType::basic;
 
 tls::ostream&
 operator<<(tls::ostream& str, const BasicCredential& obj)

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -12,7 +12,7 @@ const CredentialType BasicCredential::type = CredentialType::basic;
 tls::ostream&
 operator<<(tls::ostream& str, const BasicCredential& obj)
 {
-  tls::vector_trait<2>::encode(str, obj.identity);
+  tls::vector<2>::encode(str, obj.identity);
   return str << obj.public_key.signature_scheme() << obj.public_key;
 }
 
@@ -20,7 +20,7 @@ tls::istream&
 operator>>(tls::istream& str, BasicCredential& obj)
 {
   SignatureScheme scheme;
-  tls::vector_trait<2>::decode(str, obj.identity);
+  tls::vector<2>::decode(str, obj.identity);
   str >> scheme >> obj.public_key;
   obj.public_key.set_signature_scheme(scheme);
   return str;

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -8,8 +8,9 @@ namespace tls {
 ///
 
 template<>
-mls::CredentialType variant_value<mls::CredentialType, mls::BasicCredential> =
-  mls::CredentialType::basic;
+inline mls::CredentialType
+  variant_value<mls::CredentialType, mls::BasicCredential> =
+    mls::CredentialType::basic;
 
 } // namespace tls
 

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -7,11 +7,9 @@ namespace tls {
 /// CredentialType
 ///
 
-using namespace mls;
-
 template<>
-CredentialType variant_value<CredentialType, BasicCredential> =
-  CredentialType::basic;
+mls::CredentialType variant_value<mls::CredentialType, mls::BasicCredential> =
+  mls::CredentialType::basic;
 
 } // namespace tls
 

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -146,7 +146,7 @@ struct HKDFLabel
   bytes context;
 
   TLS_SERIALIZABLE(length, label, context);
-  TLS_TRAITS(tls::pass, tls::vector_trait<1>, tls::vector_trait<4>);
+  TLS_TRAITS(tls::pass, tls::vector<1>, tls::vector<4>);
 };
 
 bytes
@@ -286,11 +286,11 @@ struct HPKEContext
              tls::pass,
              tls::pass,
              tls::pass,
-             tls::vector_trait<0>,
-             tls::vector_trait<0>,
-             tls::vector_trait<0>,
-             tls::vector_trait<0>,
-             tls::vector_trait<0>);
+             tls::vector<0>,
+             tls::vector<0>,
+             tls::vector<0>,
+             tls::vector<0>,
+             tls::vector<0>);
 };
 
 static std::tuple<bytes, bytes>

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -290,7 +290,7 @@ struct HPKEContext
              tls::vector<0>,
              tls::vector<0>,
              tls::vector<0>,
-             tls::vector<0>);
+             tls::vector<0>)
 };
 
 static std::tuple<bytes, bytes>

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -142,10 +142,11 @@ hkdf_expand(CipherSuite suite,
 struct HKDFLabel
 {
   uint16_t length;
-  tls::opaque<1> label;
-  tls::opaque<4> context;
+  bytes label;
+  bytes context;
 
   TLS_SERIALIZABLE(length, label, context);
+  TLS_TRAITS(tls::pass, tls::vector_trait<1>, tls::vector_trait<4>);
 };
 
 bytes
@@ -266,11 +267,11 @@ struct HPKEContext
   HPKEKEMID kem;
   HPKEKDFID kdf;
   HPKEAEADID aead;
-  tls::opaque<0> enc;
-  tls::opaque<0> pkRm;
-  tls::opaque<0> pkIm;
-  tls::opaque<0> psk_id_hash;
-  tls::opaque<0> info_hash;
+  bytes enc;
+  bytes pkRm;
+  bytes pkIm;
+  bytes psk_id_hash;
+  bytes info_hash;
 
   TLS_SERIALIZABLE(mode,
                    kem,
@@ -280,7 +281,16 @@ struct HPKEContext
                    pkRm,
                    pkIm,
                    psk_id_hash,
-                   info_hash)
+                   info_hash);
+  TLS_TRAITS(tls::pass,
+             tls::pass,
+             tls::pass,
+             tls::pass,
+             tls::vector_trait<0>,
+             tls::vector_trait<0>,
+             tls::vector_trait<0>,
+             tls::vector_trait<0>,
+             tls::vector_trait<0>);
 };
 
 static std::tuple<bytes, bytes>
@@ -393,9 +403,9 @@ HPKEPrivateKey::public_key() const
   return HPKEPublicKey(_pub_data);
 }
 
-HPKEPrivateKey::HPKEPrivateKey(CipherSuite suite, bytes data)
-  : _data(std::move(data))
-  , _pub_data(primitive::priv_to_pub(suite, data))
+HPKEPrivateKey::HPKEPrivateKey(CipherSuite suite, const bytes& data)
+  : _data(data)
+  , _pub_data(primitive::priv_to_pub(suite, _data))
 {}
 
 ///
@@ -406,9 +416,10 @@ SignaturePublicKey::SignaturePublicKey()
   : _scheme(SignatureScheme::unknown)
 {}
 
-SignaturePublicKey::SignaturePublicKey(SignatureScheme scheme, bytes data)
+SignaturePublicKey::SignaturePublicKey(SignatureScheme scheme,
+                                       const bytes& data)
   : _scheme(scheme)
-  , _data(std::move(data))
+  , _data(data)
 {}
 
 void
@@ -469,9 +480,10 @@ SignaturePrivateKey::public_key() const
   return SignaturePublicKey(_scheme, _pub_data);
 }
 
-SignaturePrivateKey::SignaturePrivateKey(SignatureScheme scheme, bytes data)
+SignaturePrivateKey::SignaturePrivateKey(SignatureScheme scheme,
+                                         const bytes& data)
   : _scheme(scheme)
-  , _data(std::move(data))
+  , _data(data)
   , _pub_data(primitive::priv_to_pub(scheme, data))
 {}
 

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -145,8 +145,8 @@ struct HKDFLabel
   bytes label;
   bytes context;
 
-  TLS_SERIALIZABLE(length, label, context);
-  TLS_TRAITS(tls::pass, tls::vector<1>, tls::vector<4>);
+  TLS_SERIALIZABLE(length, label, context)
+  TLS_TRAITS(tls::pass, tls::vector<1>, tls::vector<4>)
 };
 
 bytes

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -38,7 +38,7 @@ struct ApplicationContext
     , generation(generation_in)
   {}
 
-  TLS_SERIALIZABLE(node, generation);
+  TLS_SERIALIZABLE(node, generation)
 };
 
 bytes

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -2,37 +2,6 @@
 #include "key_schedule.h"
 #include "state.h"
 
-// Variant type selectors in the `tls` namespace
-namespace tls {
-
-// ProposalType
-template<>
-inline mls::ProposalType variant_value<mls::ProposalType, mls::Add> =
-  mls::ProposalType::add;
-
-template<>
-inline mls::ProposalType variant_value<mls::ProposalType, mls::Update> =
-  mls::ProposalType::update;
-
-template<>
-inline mls::ProposalType variant_value<mls::ProposalType, mls::Remove> =
-  mls::ProposalType::remove;
-
-// ContentType
-template<>
-inline mls::ContentType variant_value<mls::ContentType, mls::ApplicationData> =
-  mls::ContentType::application;
-
-template<>
-inline mls::ContentType variant_value<mls::ContentType, mls::Proposal> =
-  mls::ContentType::proposal;
-
-template<>
-inline mls::ContentType variant_value<mls::ContentType, mls::CommitData> =
-  mls::ContentType::commit;
-
-} // namespace tls
-
 namespace mls {
 
 // KeyPackage
@@ -182,6 +151,14 @@ Welcome::find(const KeyPackage& kp) const
 }
 
 // MLSPlaintext
+
+const ProposalType Add::type = ProposalType::add;
+const ProposalType Update::type = ProposalType::update;
+const ProposalType Remove::type = ProposalType::remove;
+
+const ContentType Proposal::type = ContentType::proposal;
+const ContentType CommitData::type = ContentType::commit;
+const ContentType ApplicationData::type = ContentType::application;
 
 MLSPlaintext::MLSPlaintext(bytes group_id_in,
                            epoch_t epoch_in,

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -7,28 +7,28 @@ namespace tls {
 
 // ProposalType
 template<>
-mls::ProposalType variant_value<mls::ProposalType, mls::Add> =
+inline mls::ProposalType variant_value<mls::ProposalType, mls::Add> =
   mls::ProposalType::add;
 
 template<>
-mls::ProposalType variant_value<mls::ProposalType, mls::Update> =
+inline mls::ProposalType variant_value<mls::ProposalType, mls::Update> =
   mls::ProposalType::update;
 
 template<>
-mls::ProposalType variant_value<mls::ProposalType, mls::Remove> =
+inline mls::ProposalType variant_value<mls::ProposalType, mls::Remove> =
   mls::ProposalType::remove;
 
 // ContentType
 template<>
-mls::ContentType variant_value<mls::ContentType, mls::ApplicationData> =
+inline mls::ContentType variant_value<mls::ContentType, mls::ApplicationData> =
   mls::ContentType::application;
 
 template<>
-mls::ContentType variant_value<mls::ContentType, mls::Proposal> =
+inline mls::ContentType variant_value<mls::ContentType, mls::Proposal> =
   mls::ContentType::proposal;
 
 template<>
-mls::ContentType variant_value<mls::ContentType, mls::CommitData> =
+inline mls::ContentType variant_value<mls::ContentType, mls::CommitData> =
   mls::ContentType::commit;
 
 } // namespace tls

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -4,28 +4,32 @@
 
 // Variant type selectors in the `tls` namespace
 namespace tls {
-using namespace mls;
 
 // ProposalType
 template<>
-ProposalType variant_value<ProposalType, Add> = ProposalType::add;
+mls::ProposalType variant_value<mls::ProposalType, mls::Add> =
+  mls::ProposalType::add;
 
 template<>
-ProposalType variant_value<ProposalType, Update> = ProposalType::update;
+mls::ProposalType variant_value<mls::ProposalType, mls::Update> =
+  mls::ProposalType::update;
 
 template<>
-ProposalType variant_value<ProposalType, Remove> = ProposalType::remove;
+mls::ProposalType variant_value<mls::ProposalType, mls::Remove> =
+  mls::ProposalType::remove;
 
 // ContentType
 template<>
-ContentType variant_value<ContentType, ApplicationData> =
-  ContentType::application;
+mls::ContentType variant_value<mls::ContentType, mls::ApplicationData> =
+  mls::ContentType::application;
 
 template<>
-ContentType variant_value<ContentType, Proposal> = ContentType::proposal;
+mls::ContentType variant_value<mls::ContentType, mls::Proposal> =
+  mls::ContentType::proposal;
 
 template<>
-ContentType variant_value<ContentType, CommitData> = ContentType::commit;
+mls::ContentType variant_value<mls::ContentType, mls::CommitData> =
+  mls::ContentType::commit;
 
 } // namespace tls
 
@@ -104,12 +108,12 @@ bytes
 GroupInfo::to_be_signed() const
 {
   tls::ostream w;
-  tls::vector<1>{}.encode(w, group_id);
+  tls::vector<1>::encode(w, group_id);
   w << epoch << tree;
-  tls::vector<1>{}.encode(w, confirmed_transcript_hash);
-  tls::vector<1>{}.encode(w, interim_transcript_hash);
+  tls::vector<1>::encode(w, confirmed_transcript_hash);
+  tls::vector<1>::encode(w, interim_transcript_hash);
   w << path;
-  tls::vector<1>{}.encode(w, confirmation);
+  tls::vector<1>::encode(w, confirmation);
   w << signer_index;
   return w.bytes();
 }
@@ -272,8 +276,8 @@ MLSPlaintext::marshal_content(size_t padding_size) const
   }
 
   bytes padding(padding_size, 0);
-  tls::vector<2>{}.encode(w, signature);
-  tls::vector<2>{}.encode(w, padding);
+  tls::vector<2>::encode(w, signature);
+  tls::vector<2>::encode(w, padding);
   return w.bytes();
 }
 
@@ -282,7 +286,7 @@ MLSPlaintext::commit_content() const
 {
   auto& commit_data = std::get<CommitData>(content);
   tls::ostream w;
-  tls::vector<1>{}.encode(w, group_id);
+  tls::vector<1>::encode(w, group_id);
   w << epoch << sender << commit_data.commit;
   return w.bytes();
 }
@@ -296,8 +300,8 @@ MLSPlaintext::commit_auth_data() const
 {
   auto& commit_data = std::get<CommitData>(content);
   tls::ostream w;
-  tls::vector<1>{}.encode(w, commit_data.confirmation);
-  tls::vector<2>{}.encode(w, signature);
+  tls::vector<1>::encode(w, commit_data.confirmation);
+  tls::vector<2>::encode(w, signature);
   return w.bytes();
 }
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -220,8 +220,8 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
   }
 
   bytes padding;
-  tls::vector<2>{}.decode(r, signature);
-  tls::vector<2>{}.decode(r, padding);
+  tls::vector<2>::decode(r, signature);
+  tls::vector<2>::decode(r, padding);
 }
 
 MLSPlaintext::MLSPlaintext(bytes group_id_in,

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -77,12 +77,12 @@ bytes
 GroupInfo::to_be_signed() const
 {
   tls::ostream w;
-  tls::vector_trait<1>{}.encode(w, group_id);
+  tls::vector<1>{}.encode(w, group_id);
   w << epoch << tree;
-  tls::vector_trait<1>{}.encode(w, confirmed_transcript_hash);
-  tls::vector_trait<1>{}.encode(w, interim_transcript_hash);
+  tls::vector<1>{}.encode(w, confirmed_transcript_hash);
+  tls::vector<1>{}.encode(w, interim_transcript_hash);
   w << path;
-  tls::vector_trait<1>{}.encode(w, confirmation);
+  tls::vector<1>{}.encode(w, confirmation);
   w << signer_index;
   return w.bytes();
 }
@@ -199,8 +199,8 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
   }
 
   bytes padding;
-  tls::vector_trait<2>{}.decode(r, signature);
-  tls::vector_trait<2>{}.decode(r, padding);
+  tls::vector<2>{}.decode(r, signature);
+  tls::vector<2>{}.decode(r, padding);
 }
 
 MLSPlaintext::MLSPlaintext(bytes group_id_in,
@@ -262,8 +262,8 @@ MLSPlaintext::marshal_content(size_t padding_size) const
   }
 
   bytes padding(padding_size, 0);
-  tls::vector_trait<2>{}.encode(w, signature);
-  tls::vector_trait<2>{}.encode(w, padding);
+  tls::vector<2>{}.encode(w, signature);
+  tls::vector<2>{}.encode(w, padding);
   return w.bytes();
 }
 
@@ -272,7 +272,7 @@ MLSPlaintext::commit_content() const
 {
   auto& commit_data = std::get<CommitData>(content);
   tls::ostream w;
-  tls::vector_trait<1>{}.encode(w, group_id);
+  tls::vector<1>{}.encode(w, group_id);
   w << epoch << sender << commit_data.commit;
   return w.bytes();
 }
@@ -286,8 +286,8 @@ MLSPlaintext::commit_auth_data() const
 {
   auto& commit_data = std::get<CommitData>(content);
   tls::ostream w;
-  tls::vector_trait<1>{}.encode(w, commit_data.confirmation);
-  tls::vector_trait<2>{}.encode(w, signature);
+  tls::vector<1>{}.encode(w, commit_data.confirmation);
+  tls::vector<2>{}.encode(w, signature);
   return w.bytes();
 }
 
@@ -296,9 +296,9 @@ MLSPlaintext::to_be_signed(const GroupContext& context) const
 {
   tls::ostream w;
   w << context;
-  tls::vector_trait<1>{}.encode(w, group_id);
+  tls::vector<1>{}.encode(w, group_id);
   w << epoch << sender;
-  tls::vector_trait<4>{}.encode(w, authenticated_data);
+  tls::vector<4>{}.encode(w, authenticated_data);
   w << content;
   return w.bytes();
 }

--- a/src/ratchet_tree.cpp
+++ b/src/ratchet_tree.cpp
@@ -152,7 +152,7 @@ struct ParentNodeInfo
   std::vector<LeafIndex> unmerged_leaves;
 
   TLS_SERIALIZABLE(public_key, unmerged_leaves);
-  TLS_TRAITS(tls::pass{}, tls::vector_trait<4>{});
+  TLS_TRAITS(tls::pass, tls::vector_trait<4>);
 };
 
 struct ParentNodeHashInput
@@ -659,13 +659,13 @@ operator<<(std::ostream& out, const RatchetTree& obj)
 tls::ostream&
 operator<<(tls::ostream& out, const RatchetTree& obj)
 {
-  return tls::vector_trait<4>{}.encode(out, obj._nodes);
+  return tls::vector_trait<4>::encode(out, obj._nodes);
 }
 
 tls::istream&
 operator>>(tls::istream& in, RatchetTree& obj)
 {
-  tls::vector_trait<4>{}.decode(in, obj._nodes);
+  tls::vector_trait<4>::decode(in, obj._nodes);
   obj.set_hash_all(obj.root_index());
   return in;
 }

--- a/src/ratchet_tree.cpp
+++ b/src/ratchet_tree.cpp
@@ -152,7 +152,7 @@ struct ParentNodeInfo
   std::vector<LeafIndex> unmerged_leaves;
 
   TLS_SERIALIZABLE(public_key, unmerged_leaves);
-  TLS_TRAITS(tls::pass, tls::vector_trait<4>);
+  TLS_TRAITS(tls::pass, tls::vector<4>);
 };
 
 struct ParentNodeHashInput
@@ -163,7 +163,7 @@ struct ParentNodeHashInput
   bytes right_hash;
 
   TLS_SERIALIZABLE(hash_type, info, left_hash, right_hash);
-  TLS_TRAITS(tls::pass, tls::pass, tls::vector_trait<1>, tls::vector_trait<1>);
+  TLS_TRAITS(tls::pass, tls::pass, tls::vector<1>, tls::vector<1>);
 };
 
 void
@@ -660,13 +660,13 @@ operator<<(std::ostream& out, const RatchetTree& obj)
 tls::ostream&
 operator<<(tls::ostream& out, const RatchetTree& obj)
 {
-  return tls::vector_trait<4>::encode(out, obj._nodes);
+  return tls::vector<4>::encode(out, obj._nodes);
 }
 
 tls::istream&
 operator>>(tls::istream& in, RatchetTree& obj)
 {
-  tls::vector_trait<4>::decode(in, obj._nodes);
+  tls::vector<4>::decode(in, obj._nodes);
   obj.set_hash_all(obj.root_index());
   return in;
 }

--- a/src/ratchet_tree.cpp
+++ b/src/ratchet_tree.cpp
@@ -149,9 +149,10 @@ OptionalRatchetTreeNode::set_leaf_hash(CipherSuite suite)
 struct ParentNodeInfo
 {
   HPKEPublicKey public_key;
-  tls::vector<LeafIndex, 4> unmerged_leaves;
+  std::vector<LeafIndex> unmerged_leaves;
 
   TLS_SERIALIZABLE(public_key, unmerged_leaves);
+  TLS_TRAITS(tls::pass{}, tls::vector_trait<4>{});
 };
 
 struct ParentNodeHashInput
@@ -658,14 +659,13 @@ operator<<(std::ostream& out, const RatchetTree& obj)
 tls::ostream&
 operator<<(tls::ostream& out, const RatchetTree& obj)
 {
-  return out << obj._nodes;
+  return tls::vector_trait<4>{}.encode(out, obj._nodes);
 }
 
 tls::istream&
 operator>>(tls::istream& in, RatchetTree& obj)
 {
-  in >> obj._nodes;
-
+  tls::vector_trait<4>{}.decode(in, obj._nodes);
   obj.set_hash_all(obj.root_index());
   return in;
 }

--- a/src/ratchet_tree.cpp
+++ b/src/ratchet_tree.cpp
@@ -122,7 +122,7 @@ struct LeafNodeInfo
 struct LeafNodeHashInput
 {
   const uint8_t hash_type = 0;
-  tls::optional<LeafNodeInfo> info;
+  std::optional<LeafNodeInfo> info;
 
   TLS_SERIALIZABLE(hash_type, info);
 };
@@ -158,7 +158,7 @@ struct ParentNodeInfo
 struct ParentNodeHashInput
 {
   const uint8_t hash_type = 1;
-  tls::optional<ParentNodeInfo> info;
+  std::optional<ParentNodeInfo> info;
   bytes left_hash;
   bytes right_hash;
 

--- a/src/ratchet_tree.cpp
+++ b/src/ratchet_tree.cpp
@@ -14,14 +14,14 @@ RatchetTreeNode::RatchetTreeNode(CipherSuite suite, const bytes& secret)
   _pub = _priv.value().public_key();
 }
 
-RatchetTreeNode::RatchetTreeNode(HPKEPrivateKey priv)
-  : _priv(std::move(priv))
+RatchetTreeNode::RatchetTreeNode(const HPKEPrivateKey& priv)
+  : _priv(priv)
   , _pub(priv.public_key())
 {}
 
-RatchetTreeNode::RatchetTreeNode(HPKEPublicKey pub)
+RatchetTreeNode::RatchetTreeNode(const HPKEPublicKey& pub)
   : _priv(std::nullopt)
-  , _pub(std::move(pub))
+  , _pub(pub)
 {}
 
 bool
@@ -159,10 +159,11 @@ struct ParentNodeHashInput
 {
   const uint8_t hash_type = 1;
   tls::optional<ParentNodeInfo> info;
-  tls::opaque<1> left_hash;
-  tls::opaque<1> right_hash;
+  bytes left_hash;
+  bytes right_hash;
 
   TLS_SERIALIZABLE(hash_type, info, left_hash, right_hash);
+  TLS_TRAITS(tls::pass, tls::pass, tls::vector_trait<1>, tls::vector_trait<1>);
 };
 
 void

--- a/src/ratchet_tree.cpp
+++ b/src/ratchet_tree.cpp
@@ -116,7 +116,7 @@ struct LeafNodeInfo
   HPKEPublicKey public_key;
   Credential credential;
 
-  TLS_SERIALIZABLE(public_key, credential);
+  TLS_SERIALIZABLE(public_key, credential)
 };
 
 struct LeafNodeHashInput
@@ -124,7 +124,7 @@ struct LeafNodeHashInput
   const uint8_t hash_type = 0;
   std::optional<LeafNodeInfo> info;
 
-  TLS_SERIALIZABLE(hash_type, info);
+  TLS_SERIALIZABLE(hash_type, info)
 };
 
 void
@@ -151,8 +151,8 @@ struct ParentNodeInfo
   HPKEPublicKey public_key;
   std::vector<LeafIndex> unmerged_leaves;
 
-  TLS_SERIALIZABLE(public_key, unmerged_leaves);
-  TLS_TRAITS(tls::pass, tls::vector<4>);
+  TLS_SERIALIZABLE(public_key, unmerged_leaves)
+  TLS_TRAITS(tls::pass, tls::vector<4>)
 };
 
 struct ParentNodeHashInput
@@ -162,8 +162,8 @@ struct ParentNodeHashInput
   bytes left_hash;
   bytes right_hash;
 
-  TLS_SERIALIZABLE(hash_type, info, left_hash, right_hash);
-  TLS_TRAITS(tls::pass, tls::pass, tls::vector<1>, tls::vector<1>);
+  TLS_SERIALIZABLE(hash_type, info, left_hash, right_hash)
+  TLS_TRAITS(tls::pass, tls::pass, tls::vector<1>, tls::vector<1>)
 };
 
 void

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -500,11 +500,11 @@ content_aad(const bytes& group_id,
             const bytes& encrypted_sender_data)
 {
   tls::ostream w;
-  tls::vector_trait<1>::encode(w, group_id);
+  tls::vector<1>::encode(w, group_id);
   w << epoch << content_type;
-  tls::vector_trait<4>::encode(w, authenticated_data);
-  tls::vector_trait<1>::encode(w, sender_data_nonce);
-  tls::vector_trait<1>::encode(w, encrypted_sender_data);
+  tls::vector<4>::encode(w, authenticated_data);
+  tls::vector<1>::encode(w, sender_data_nonce);
+  tls::vector<1>::encode(w, encrypted_sender_data);
   return w.bytes();
 }
 
@@ -521,9 +521,9 @@ sender_data_aad(const bytes& group_id,
                 const bytes& sender_data_nonce)
 {
   tls::ostream w;
-  tls::vector_trait<1>::encode(w, group_id);
+  tls::vector<1>::encode(w, group_id);
   w << epoch << content_type;
-  tls::vector_trait<1>::encode(w, sender_data_nonce);
+  tls::vector<1>::encode(w, sender_data_nonce);
   return w.bytes();
 }
 

--- a/test/key_schedule_test.cpp
+++ b/test/key_schedule_test.cpp
@@ -21,11 +21,11 @@ TEST_F(HashRatchetTest, Interop)
     ASSERT_EQ(tc.key_sequences.size(), tv.n_members);
     for (uint32_t j = 0; j < tv.n_members; ++j) {
       HashRatchet ratchet{ suite, NodeIndex{ LeafIndex{ j } }, tv.base_secret };
-      ASSERT_EQ(tc.key_sequences[j].size(), tv.n_generations);
+      ASSERT_EQ(tc.key_sequences[j].steps.size(), tv.n_generations);
       for (uint32_t k = 0; k < tv.n_generations; ++k) {
         auto kn = ratchet.get(k);
-        ASSERT_EQ(tc.key_sequences[j][k].key, kn.key);
-        ASSERT_EQ(tc.key_sequences[j][k].nonce, kn.nonce);
+        ASSERT_EQ(tc.key_sequences[j].steps[k].key, kn.key);
+        ASSERT_EQ(tc.key_sequences[j].steps[k].nonce, kn.nonce);
       }
     }
   }

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -14,6 +14,8 @@ tls_round_trip(const bytes& vector,
 {
   auto marshaled = tls::marshal(constructed);
   if (reproducible) {
+    std::cout << "vec " << vector << std::endl;
+    std::cout << "mar " << marshaled << std::endl;
     ASSERT_EQ(vector, marshaled);
   }
 

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -107,10 +107,10 @@ TEST_F(MessagesTest, Interop)
 
     // Commit
     auto commit = Commit{
-      { tv.random, tv.random },
-      { tv.random, tv.random },
-      { tv.random, tv.random },
-      { tv.random, tv.random },
+      { { tv.random }, { tv.random } },
+      { { tv.random }, { tv.random } },
+      { { tv.random }, { tv.random } },
+      { { tv.random }, { tv.random } },
       direct_path,
     };
     tls_round_trip(tc.commit, commit, true);

--- a/test/ratchet_tree_test.cpp
+++ b/test/ratchet_tree_test.cpp
@@ -69,13 +69,14 @@ protected:
                       const TestRatchetTree& tree)
   {
     auto& nodes = tree.nodes();
-    ASSERT_EQ(vec.size(), nodes.size());
+    ASSERT_EQ(vec.nodes.size(), nodes.size());
 
-    for (size_t j = 0; j < vec.size(); ++j) {
-      ASSERT_EQ(vec[j].hash, nodes[j].hash());
-      ASSERT_EQ(vec[j].public_key.has_value(), nodes[j].has_value());
+    for (size_t j = 0; j < vec.nodes.size(); ++j) {
+      ASSERT_EQ(vec.nodes[j].hash, nodes[j].hash());
+      ASSERT_EQ(vec.nodes[j].public_key.has_value(), nodes[j].has_value());
       if (nodes[j].has_value()) {
-        ASSERT_EQ(vec[j].public_key.value(), nodes[j]->public_key().to_bytes());
+        ASSERT_EQ(vec.nodes[j].public_key.value().data,
+                  nodes[j]->public_key().to_bytes());
       }
     }
   }
@@ -89,9 +90,10 @@ TEST_F(RatchetTreeTest, Interop)
     // Add the leaves
     int tci = 0;
     for (uint32_t i = 0; i < tv.leaf_secrets.size(); ++i, ++tci) {
-      auto priv = HPKEPrivateKey::derive(tc.cipher_suite, tv.leaf_secrets[i]);
+      auto priv =
+        HPKEPrivateKey::derive(tc.cipher_suite, tv.leaf_secrets[i].data);
       tree.add_leaf(LeafIndex{ i }, priv.public_key(), tc.credentials[i]);
-      tree.encap(LeafIndex{ i }, {}, tv.leaf_secrets[i]);
+      tree.encap(LeafIndex{ i }, {}, tv.leaf_secrets[i].data);
       assert_tree_eq(tc.trees[tci], tree);
     }
 

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -311,7 +311,7 @@ struct TreeTestVectors
 
   struct TreeNode
   {
-    tls::optional<Bytes1> public_key;
+    std::optional<Bytes1> public_key;
     bytes hash;
 
     TLS_SERIALIZABLE(public_key, hash);
@@ -487,7 +487,7 @@ struct SessionTestVectors
 {
   struct Epoch
   {
-    tls::optional<Welcome> welcome;
+    std::optional<Welcome> welcome;
     bytes handshake;
     bytes commit_secret;
 
@@ -499,7 +499,7 @@ struct SessionTestVectors
 
     Epoch() = default;
 
-    Epoch(const tls::optional<Welcome>& welcome_in,
+    Epoch(const std::optional<Welcome>& welcome_in,
           const bytes& handshake_in,
           const bytes& commit_secret_in,
           const TestSession& session)

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -17,8 +17,8 @@ struct TreeMathTestVectors
   struct NodeVector
   {
     std::vector<NodeIndex> nodes;
-    TLS_SERIALIZABLE(nodes);
-    TLS_TRAITS(tls::vector<4>);
+    TLS_SERIALIZABLE(nodes)
+    TLS_TRAITS(tls::vector<4>)
   };
 
   LeafCount n_leaves{ 255 };
@@ -82,7 +82,7 @@ struct CryptoTestVectors
                      hkdf_extract_out,
                      derive_key_pair_pub,
                      hpke_out)
-    TLS_TRAITS(tls::pass, tls::vector<1>, tls::pass, tls::pass);
+    TLS_TRAITS(tls::pass, tls::vector<1>, tls::pass, tls::pass)
   };
 
   std::vector<TestCase> cases;
@@ -112,15 +112,15 @@ struct HashRatchetTestVectors
     bytes key;
     bytes nonce;
 
-    TLS_SERIALIZABLE(key, nonce);
-    TLS_TRAITS(tls::vector<1>, tls::vector<1>);
+    TLS_SERIALIZABLE(key, nonce)
+    TLS_TRAITS(tls::vector<1>, tls::vector<1>)
   };
 
   struct KeySequence
   {
     std::vector<Step> steps;
-    TLS_SERIALIZABLE(steps);
-    TLS_TRAITS(tls::vector<4>);
+    TLS_SERIALIZABLE(steps)
+    TLS_TRAITS(tls::vector<4>)
   };
 
   struct TestCase
@@ -128,8 +128,8 @@ struct HashRatchetTestVectors
     CipherSuite cipher_suite;
     std::vector<KeySequence> key_sequences;
 
-    TLS_SERIALIZABLE(cipher_suite, key_sequences);
-    TLS_TRAITS(tls::pass, tls::vector<4>);
+    TLS_SERIALIZABLE(cipher_suite, key_sequences)
+    TLS_TRAITS(tls::pass, tls::vector<4>)
   };
 
   uint32_t n_members;
@@ -138,8 +138,8 @@ struct HashRatchetTestVectors
 
   std::vector<TestCase> cases;
 
-  TLS_SERIALIZABLE(n_members, n_generations, base_secret, cases);
-  TLS_TRAITS(tls::pass, tls::pass, tls::vector<1>, tls::vector<4>);
+  TLS_SERIALIZABLE(n_members, n_generations, base_secret, cases)
+  TLS_TRAITS(tls::pass, tls::pass, tls::vector<1>, tls::vector<4>)
 };
 
 /////
@@ -153,8 +153,8 @@ struct KeyScheduleTestVectors
     bytes key;
     bytes nonce;
 
-    TLS_SERIALIZABLE(key, nonce);
-    TLS_TRAITS(tls::vector<1>, tls::vector<1>);
+    TLS_SERIALIZABLE(key, nonce)
+    TLS_TRAITS(tls::vector<1>, tls::vector<1>)
   };
 
   struct Epoch
@@ -205,8 +205,8 @@ struct KeyScheduleTestVectors
     CipherSuite cipher_suite;
     std::vector<Epoch> epochs;
 
-    TLS_SERIALIZABLE(cipher_suite, epochs);
-    TLS_TRAITS(tls::pass, tls::vector<2>);
+    TLS_SERIALIZABLE(cipher_suite, epochs)
+    TLS_TRAITS(tls::pass, tls::vector<2>)
   };
 
   uint32_t n_epochs;
@@ -305,8 +305,8 @@ struct TreeTestVectors
   struct Bytes1
   {
     bytes data;
-    TLS_SERIALIZABLE(data);
-    TLS_TRAITS(tls::vector<1>);
+    TLS_SERIALIZABLE(data)
+    TLS_TRAITS(tls::vector<1>)
   };
 
   struct TreeNode
@@ -314,15 +314,15 @@ struct TreeTestVectors
     std::optional<Bytes1> public_key;
     bytes hash;
 
-    TLS_SERIALIZABLE(public_key, hash);
-    TLS_TRAITS(tls::pass, tls::vector<1>);
+    TLS_SERIALIZABLE(public_key, hash)
+    TLS_TRAITS(tls::pass, tls::vector<1>)
   };
 
   struct TreeCase
   {
     std::vector<TreeNode> nodes;
-    TLS_SERIALIZABLE(nodes);
-    TLS_TRAITS(tls::vector<4>);
+    TLS_SERIALIZABLE(nodes)
+    TLS_TRAITS(tls::vector<4>)
   };
 
   struct TestCase
@@ -332,7 +332,7 @@ struct TreeTestVectors
     std::vector<Credential> credentials;
     std::vector<TreeCase> trees;
 
-    TLS_SERIALIZABLE(cipher_suite, signature_scheme, credentials, trees);
+    TLS_SERIALIZABLE(cipher_suite, signature_scheme, credentials, trees)
     TLS_TRAITS(tls::pass, tls::pass, tls::vector<4>, tls::vector<4>)
   };
 
@@ -340,8 +340,8 @@ struct TreeTestVectors
   std::vector<Credential> credentials;
   std::vector<TestCase> cases;
 
-  TLS_SERIALIZABLE(leaf_secrets, credentials, cases);
-  TLS_TRAITS(tls::vector<4>, tls::vector<4>, tls::vector<4>);
+  TLS_SERIALIZABLE(leaf_secrets, credentials, cases)
+  TLS_TRAITS(tls::vector<4>, tls::vector<4>, tls::vector<4>)
 };
 
 /////
@@ -544,7 +544,7 @@ struct SessionTestVectors
                      encrypt,
                      key_packages,
                      transcript);
-    TLS_TRAITS(tls::pass, tls::pass, tls::pass, tls::vector<4>, tls::vector<4>);
+    TLS_TRAITS(tls::pass, tls::pass, tls::pass, tls::vector<4>, tls::vector<4>)
   };
 
   uint32_t group_size;
@@ -552,8 +552,8 @@ struct SessionTestVectors
 
   std::vector<TestCase> cases;
 
-  TLS_SERIALIZABLE(group_size, group_id, cases);
-  TLS_TRAITS(tls::pass, tls::vector<1>, tls::vector<4>);
+  TLS_SERIALIZABLE(group_size, group_id, cases)
+  TLS_TRAITS(tls::pass, tls::vector<1>, tls::vector<4>)
 };
 
 struct BasicSessionTestVectors : SessionTestVectors

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -15,14 +15,14 @@ struct TreeMathTestVectors
   static const std::string file_name;
 
   LeafCount n_leaves{ 255 };
-  tls::vector<NodeIndex, 4> root;
-  tls::vector<NodeIndex, 4> left;
-  tls::vector<NodeIndex, 4> right;
-  tls::vector<NodeIndex, 4> parent;
-  tls::vector<NodeIndex, 4> sibling;
-  tls::vector<tls::vector<NodeIndex, 4>, 4> dirpath;
-  tls::vector<tls::vector<NodeIndex, 4>, 4> copath;
-  tls::vector<tls::vector<NodeIndex, 4>, 4> ancestor;
+  std::vector<NodeIndex> root;
+  std::vector<NodeIndex> left;
+  std::vector<NodeIndex> right;
+  std::vector<NodeIndex> parent;
+  std::vector<NodeIndex> sibling;
+  std::vector<tls::vector<NodeIndex, 4>> dirpath;
+  std::vector<tls::vector<NodeIndex, 4>> copath;
+  std::vector<tls::vector<NodeIndex, 4>> ancestor;
 
   TLS_SERIALIZABLE(n_leaves,
                    root,
@@ -33,6 +33,15 @@ struct TreeMathTestVectors
                    dirpath,
                    copath,
                    ancestor)
+  TLS_TRAITS(tls::pass{},
+             tls::vector_trait<4>{},
+             tls::vector_trait<4>{},
+             tls::vector_trait<4>{},
+             tls::vector_trait<4>{},
+             tls::vector_trait<4>{},
+             tls::vector_trait<4>{},
+             tls::vector_trait<4>{},
+             tls::vector_trait<4>{});
 };
 
 /////
@@ -41,20 +50,20 @@ struct CryptoTestVectors
 {
   static const std::string file_name;
 
-  tls::opaque<1> hkdf_extract_salt;
-  tls::opaque<1> hkdf_extract_ikm;
+  bytes hkdf_extract_salt;
+  bytes hkdf_extract_ikm;
 
-  tls::opaque<1> derive_key_pair_seed;
+  bytes derive_key_pair_seed;
 
-  tls::opaque<1> hpke_aad;
-  tls::opaque<1> hpke_plaintext;
+  bytes hpke_aad;
+  bytes hpke_plaintext;
 
   struct TestCase
   {
     CipherSuite cipher_suite;
 
     // HKDF-Extract
-    tls::opaque<1> hkdf_extract_out;
+    bytes hkdf_extract_out;
 
     // Derive-Key-Pair
     HPKEPublicKey derive_key_pair_pub;
@@ -66,9 +75,10 @@ struct CryptoTestVectors
                      hkdf_extract_out,
                      derive_key_pair_pub,
                      hpke_out)
+    TLS_TRAITS(tls::pass{}, tls::vector_trait<1>{}, tls::pass{}, tls::pass{});
   };
 
-  tls::vector<TestCase, 4> cases;
+  std::vector<TestCase> cases;
 
   TLS_SERIALIZABLE(hkdf_extract_salt,
                    hkdf_extract_ikm,
@@ -76,6 +86,12 @@ struct CryptoTestVectors
                    hpke_aad,
                    hpke_plaintext,
                    cases)
+  TLS_TRAITS(tls::vector_trait<1>{},
+             tls::vector_trait<1>{},
+             tls::vector_trait<1>{},
+             tls::vector_trait<1>{},
+             tls::vector_trait<1>{},
+             tls::vector_trait<4>{});
 };
 
 /////
@@ -86,10 +102,11 @@ struct HashRatchetTestVectors
 
   struct Step
   {
-    tls::opaque<1> key;
-    tls::opaque<1> nonce;
+    bytes key;
+    bytes nonce;
 
     TLS_SERIALIZABLE(key, nonce);
+    TLS_TRAITS(tls::vector_trait<1>{}, tls::vector_trait<1>{});
   };
 
   typedef tls::vector<Step, 4> KeySequence;
@@ -97,18 +114,23 @@ struct HashRatchetTestVectors
   struct TestCase
   {
     CipherSuite cipher_suite;
-    tls::vector<KeySequence, 4> key_sequences;
+    std::vector<KeySequence> key_sequences;
 
     TLS_SERIALIZABLE(cipher_suite, key_sequences);
+    TLS_TRAITS(tls::pass{}, tls::vector_trait<4>{});
   };
 
   uint32_t n_members;
   uint32_t n_generations;
-  tls::opaque<1> base_secret;
+  bytes base_secret;
 
-  tls::vector<TestCase, 4> cases;
+  std::vector<TestCase> cases;
 
   TLS_SERIALIZABLE(n_members, n_generations, base_secret, cases);
+  TLS_TRAITS(tls::pass{},
+             tls::pass{},
+             tls::vector_trait<1>{},
+             tls::vector_trait<4>{});
 };
 
 /////
@@ -119,30 +141,31 @@ struct KeyScheduleTestVectors
 
   struct KeyAndNonce
   {
-    tls::opaque<1> key;
-    tls::opaque<1> nonce;
+    bytes key;
+    bytes nonce;
 
     TLS_SERIALIZABLE(key, nonce);
+    TLS_TRAITS(tls::vector_trait<1>{}, tls::vector_trait<1>{});
   };
 
   struct Epoch
   {
     LeafCount n_members;
-    tls::opaque<1> update_secret;
+    bytes update_secret;
 
-    tls::opaque<1> epoch_secret;
+    bytes epoch_secret;
 
-    tls::opaque<1> sender_data_secret;
-    tls::opaque<1> sender_data_key;
+    bytes sender_data_secret;
+    bytes sender_data_key;
 
-    tls::opaque<1> handshake_secret;
-    tls::vector<KeyAndNonce, 4> handshake_keys;
+    bytes handshake_secret;
+    std::vector<KeyAndNonce> handshake_keys;
 
-    tls::opaque<1> application_secret;
-    tls::vector<KeyAndNonce, 4> application_keys;
+    bytes application_secret;
+    std::vector<KeyAndNonce> application_keys;
 
-    tls::opaque<1> confirmation_key;
-    tls::opaque<1> init_secret;
+    bytes confirmation_key;
+    bytes init_secret;
 
     TLS_SERIALIZABLE(n_members,
                      update_secret,
@@ -155,28 +178,45 @@ struct KeyScheduleTestVectors
                      application_keys,
                      confirmation_key,
                      init_secret);
+    TLS_TRAITS(tls::pass{},
+               tls::vector_trait<1>{},
+               tls::vector_trait<1>{},
+               tls::vector_trait<1>{},
+               tls::vector_trait<1>{},
+               tls::vector_trait<1>{},
+               tls::vector_trait<4>{},
+               tls::vector_trait<1>{},
+               tls::vector_trait<4>{},
+               tls::vector_trait<1>{},
+               tls::vector_trait<1>{});
   };
 
   struct TestCase
   {
     CipherSuite cipher_suite;
-    tls::vector<Epoch, 2> epochs;
+    std::vector<Epoch> epochs;
 
     TLS_SERIALIZABLE(cipher_suite, epochs);
+    TLS_TRAITS(tls::pass{}, tls::vector_trait<2>{});
   };
 
   uint32_t n_epochs;
   uint32_t target_generation;
-  tls::opaque<1> base_init_secret;
-  tls::opaque<4> base_group_context;
+  bytes base_init_secret;
+  bytes base_group_context;
 
-  tls::vector<TestCase, 4> cases;
+  std::vector<TestCase> cases;
 
   TLS_SERIALIZABLE(n_epochs,
                    target_generation,
                    base_init_secret,
                    base_group_context,
                    cases);
+  TLS_TRAITS(tls::pass{},
+             tls::pass{},
+             tls::vector_trait<1>{},
+             tls::vector_trait<4>{},
+             tls::vector_trait<4>{});
 };
 
 /////
@@ -256,9 +296,10 @@ struct TreeTestVectors
   struct TreeNode
   {
     tls::optional<tls::opaque<1>> public_key;
-    tls::opaque<1> hash;
+    bytes hash;
 
     TLS_SERIALIZABLE(public_key, hash);
+    TLS_TRAITS(tls::pass{}, tls::vector_trait<1>{});
   };
 
   typedef tls::vector<TreeNode, 4> TreeCase;
@@ -267,17 +308,24 @@ struct TreeTestVectors
   {
     CipherSuite cipher_suite;
     SignatureScheme signature_scheme;
-    tls::vector<Credential, 4> credentials;
-    tls::vector<TreeCase, 4> trees;
+    std::vector<Credential> credentials;
+    std::vector<TreeCase> trees;
 
     TLS_SERIALIZABLE(cipher_suite, signature_scheme, credentials, trees);
+    TLS_TRAITS(tls::pass{},
+               tls::pass{},
+               tls::vector_trait<4>{},
+               tls::vector_trait<4>{})
   };
 
-  tls::vector<tls::opaque<1>, 4> leaf_secrets;
-  tls::vector<Credential, 4> credentials;
-  tls::vector<TestCase, 4> cases;
+  std::vector<tls::opaque<1>> leaf_secrets;
+  std::vector<Credential> credentials;
+  std::vector<TestCase> cases;
 
   TLS_SERIALIZABLE(leaf_secrets, credentials, cases);
+  TLS_TRAITS(tls::vector_trait<4>{},
+             tls::vector_trait<4>{},
+             tls::vector_trait<4>{});
 };
 
 /////
@@ -294,16 +342,16 @@ struct MessagesTestVectors
     CipherSuite cipher_suite;
     SignatureScheme signature_scheme;
 
-    tls::opaque<4> key_package;
-    tls::opaque<4> group_info;
-    tls::opaque<4> group_secrets;
-    tls::opaque<4> encrypted_group_secrets;
-    tls::opaque<4> welcome;
-    tls::opaque<4> add_proposal;
-    tls::opaque<4> update_proposal;
-    tls::opaque<4> remove_proposal;
-    tls::opaque<4> commit;
-    tls::opaque<4> ciphertext;
+    bytes key_package;
+    bytes group_info;
+    bytes group_secrets;
+    bytes encrypted_group_secrets;
+    bytes welcome;
+    bytes add_proposal;
+    bytes update_proposal;
+    bytes remove_proposal;
+    bytes commit;
+    bytes ciphertext;
 
     TLS_SERIALIZABLE(cipher_suite,
                      signature_scheme,
@@ -317,19 +365,31 @@ struct MessagesTestVectors
                      remove_proposal,
                      commit,
                      ciphertext);
+    TLS_TRAITS(tls::pass{},
+               tls::pass{},
+               tls::vector_trait<4>{},
+               tls::vector_trait<4>{},
+               tls::vector_trait<4>{},
+               tls::vector_trait<4>{},
+               tls::vector_trait<4>{},
+               tls::vector_trait<4>{},
+               tls::vector_trait<4>{},
+               tls::vector_trait<4>{},
+               tls::vector_trait<4>{},
+               tls::vector_trait<4>{});
   };
 
   epoch_t epoch;
   LeafIndex signer_index;
   LeafIndex removed;
-  tls::opaque<1> user_id;
-  tls::opaque<1> group_id;
-  tls::opaque<1> key_package_id;
-  tls::opaque<1> dh_seed;
-  tls::opaque<1> sig_seed;
-  tls::opaque<1> random;
+  bytes user_id;
+  bytes group_id;
+  bytes key_package_id;
+  bytes dh_seed;
+  bytes sig_seed;
+  bytes random;
 
-  tls::vector<TestCase, 4> cases;
+  std::vector<TestCase> cases;
 
   TLS_SERIALIZABLE(epoch,
                    signer_index,
@@ -341,6 +401,16 @@ struct MessagesTestVectors
                    sig_seed,
                    random,
                    cases);
+  TLS_TRAITS(tls::pass{},
+             tls::pass{},
+             tls::pass{},
+             tls::vector_trait<1>{},
+             tls::vector_trait<1>{},
+             tls::vector_trait<1>{},
+             tls::vector_trait<1>{},
+             tls::vector_trait<1>{},
+             tls::vector_trait<1>{},
+             tls::vector_trait<4>{});
 };
 
 /////
@@ -402,14 +472,14 @@ struct SessionTestVectors
   struct Epoch
   {
     tls::optional<Welcome> welcome;
-    tls::opaque<4> handshake;
-    tls::opaque<1> commit_secret;
+    bytes handshake;
+    bytes commit_secret;
 
     epoch_t epoch;
-    tls::opaque<1> epoch_secret;
-    tls::opaque<1> application_secret;
-    tls::opaque<1> confirmation_key;
-    tls::opaque<1> init_secret;
+    bytes epoch_secret;
+    bytes application_secret;
+    bytes confirmation_key;
+    bytes init_secret;
 
     Epoch() = default;
 
@@ -435,6 +505,14 @@ struct SessionTestVectors
                      application_secret,
                      confirmation_key,
                      init_secret);
+    TLS_TRAITS(tls::pass{},
+               tls::vector_trait<4>{},
+               tls::vector_trait<1>{},
+               tls::pass{},
+               tls::vector_trait<1>{},
+               tls::vector_trait<1>{},
+               tls::vector_trait<1>{},
+               tls::vector_trait<1>{});
   };
 
   struct TestCase
@@ -442,22 +520,28 @@ struct SessionTestVectors
     CipherSuite cipher_suite;
     SignatureScheme signature_scheme;
     bool encrypt;
-    tls::vector<KeyPackage, 4> key_packages;
-    tls::vector<Epoch, 4> transcript;
+    std::vector<KeyPackage> key_packages;
+    std::vector<Epoch> transcript;
 
     TLS_SERIALIZABLE(cipher_suite,
                      signature_scheme,
                      encrypt,
                      key_packages,
                      transcript);
+    TLS_TRAITS(tls::pass{},
+               tls::pass{},
+               tls::pass{},
+               tls::vector_trait<4>{},
+               tls::vector_trait<4>{});
   };
 
   uint32_t group_size;
-  tls::opaque<1> group_id;
+  bytes group_id;
 
-  tls::vector<TestCase, 4> cases;
+  std::vector<TestCase> cases;
 
   TLS_SERIALIZABLE(group_size, group_id, cases);
+  TLS_TRAITS(tls::pass{}, tls::vector_trait<1>{}, tls::vector_trait<4>{});
 };
 
 struct BasicSessionTestVectors : SessionTestVectors

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -14,15 +14,22 @@ struct TreeMathTestVectors
 {
   static const std::string file_name;
 
+  struct NodeVector
+  {
+    std::vector<NodeIndex> nodes;
+    TLS_SERIALIZABLE(nodes);
+    TLS_TRAITS(tls::vector_trait<4>);
+  };
+
   LeafCount n_leaves{ 255 };
   std::vector<NodeIndex> root;
   std::vector<NodeIndex> left;
   std::vector<NodeIndex> right;
   std::vector<NodeIndex> parent;
   std::vector<NodeIndex> sibling;
-  std::vector<tls::vector<NodeIndex, 4>> dirpath;
-  std::vector<tls::vector<NodeIndex, 4>> copath;
-  std::vector<tls::vector<NodeIndex, 4>> ancestor;
+  std::vector<NodeVector> dirpath;
+  std::vector<NodeVector> copath;
+  std::vector<NodeVector> ancestor;
 
   TLS_SERIALIZABLE(n_leaves,
                    root,
@@ -109,7 +116,12 @@ struct HashRatchetTestVectors
     TLS_TRAITS(tls::vector_trait<1>, tls::vector_trait<1>);
   };
 
-  typedef tls::vector<Step, 4> KeySequence;
+  struct KeySequence
+  {
+    std::vector<Step> steps;
+    TLS_SERIALIZABLE(steps);
+    TLS_TRAITS(tls::vector_trait<4>);
+  };
 
   struct TestCase
   {
@@ -290,16 +302,28 @@ struct TreeTestVectors
 {
   static const std::string file_name;
 
+  struct Bytes1
+  {
+    bytes data;
+    TLS_SERIALIZABLE(data);
+    TLS_TRAITS(tls::vector_trait<1>);
+  };
+
   struct TreeNode
   {
-    tls::optional<tls::opaque<1>> public_key;
+    tls::optional<Bytes1> public_key;
     bytes hash;
 
     TLS_SERIALIZABLE(public_key, hash);
     TLS_TRAITS(tls::pass, tls::vector_trait<1>);
   };
 
-  typedef tls::vector<TreeNode, 4> TreeCase;
+  struct TreeCase
+  {
+    std::vector<TreeNode> nodes;
+    TLS_SERIALIZABLE(nodes);
+    TLS_TRAITS(tls::vector_trait<4>);
+  };
 
   struct TestCase
   {
@@ -312,7 +336,7 @@ struct TreeTestVectors
     TLS_TRAITS(tls::pass, tls::pass, tls::vector_trait<4>, tls::vector_trait<4>)
   };
 
-  std::vector<tls::opaque<1>> leaf_secrets;
+  std::vector<Bytes1> leaf_secrets;
   std::vector<Credential> credentials;
   std::vector<TestCase> cases;
 

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -48,7 +48,7 @@ struct TreeMathTestVectors
              tls::vector<4>,
              tls::vector<4>,
              tls::vector<4>,
-             tls::vector<4>);
+             tls::vector<4>)
 };
 
 /////
@@ -98,7 +98,7 @@ struct CryptoTestVectors
              tls::vector<1>,
              tls::vector<1>,
              tls::vector<1>,
-             tls::vector<4>);
+             tls::vector<4>)
 };
 
 /////
@@ -197,7 +197,7 @@ struct KeyScheduleTestVectors
                tls::vector<1>,
                tls::vector<4>,
                tls::vector<1>,
-               tls::vector<1>);
+               tls::vector<1>)
   };
 
   struct TestCase
@@ -225,7 +225,7 @@ struct KeyScheduleTestVectors
              tls::pass,
              tls::vector<1>,
              tls::vector<4>,
-             tls::vector<4>);
+             tls::vector<4>)
 };
 
 /////
@@ -392,7 +392,7 @@ struct MessagesTestVectors
                tls::vector<4>,
                tls::vector<4>,
                tls::vector<4>,
-               tls::vector<4>);
+               tls::vector<4>)
   };
 
   epoch_t epoch;
@@ -426,7 +426,7 @@ struct MessagesTestVectors
              tls::vector<1>,
              tls::vector<1>,
              tls::vector<1>,
-             tls::vector<4>);
+             tls::vector<4>)
 };
 
 /////
@@ -528,7 +528,7 @@ struct SessionTestVectors
                tls::vector<1>,
                tls::vector<1>,
                tls::vector<1>,
-               tls::vector<1>);
+               tls::vector<1>)
   };
 
   struct TestCase

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -18,7 +18,7 @@ struct TreeMathTestVectors
   {
     std::vector<NodeIndex> nodes;
     TLS_SERIALIZABLE(nodes);
-    TLS_TRAITS(tls::vector_trait<4>);
+    TLS_TRAITS(tls::vector<4>);
   };
 
   LeafCount n_leaves{ 255 };
@@ -41,14 +41,14 @@ struct TreeMathTestVectors
                    copath,
                    ancestor)
   TLS_TRAITS(tls::pass,
-             tls::vector_trait<4>,
-             tls::vector_trait<4>,
-             tls::vector_trait<4>,
-             tls::vector_trait<4>,
-             tls::vector_trait<4>,
-             tls::vector_trait<4>,
-             tls::vector_trait<4>,
-             tls::vector_trait<4>);
+             tls::vector<4>,
+             tls::vector<4>,
+             tls::vector<4>,
+             tls::vector<4>,
+             tls::vector<4>,
+             tls::vector<4>,
+             tls::vector<4>,
+             tls::vector<4>);
 };
 
 /////
@@ -82,7 +82,7 @@ struct CryptoTestVectors
                      hkdf_extract_out,
                      derive_key_pair_pub,
                      hpke_out)
-    TLS_TRAITS(tls::pass, tls::vector_trait<1>, tls::pass, tls::pass);
+    TLS_TRAITS(tls::pass, tls::vector<1>, tls::pass, tls::pass);
   };
 
   std::vector<TestCase> cases;
@@ -93,12 +93,12 @@ struct CryptoTestVectors
                    hpke_aad,
                    hpke_plaintext,
                    cases)
-  TLS_TRAITS(tls::vector_trait<1>,
-             tls::vector_trait<1>,
-             tls::vector_trait<1>,
-             tls::vector_trait<1>,
-             tls::vector_trait<1>,
-             tls::vector_trait<4>);
+  TLS_TRAITS(tls::vector<1>,
+             tls::vector<1>,
+             tls::vector<1>,
+             tls::vector<1>,
+             tls::vector<1>,
+             tls::vector<4>);
 };
 
 /////
@@ -113,14 +113,14 @@ struct HashRatchetTestVectors
     bytes nonce;
 
     TLS_SERIALIZABLE(key, nonce);
-    TLS_TRAITS(tls::vector_trait<1>, tls::vector_trait<1>);
+    TLS_TRAITS(tls::vector<1>, tls::vector<1>);
   };
 
   struct KeySequence
   {
     std::vector<Step> steps;
     TLS_SERIALIZABLE(steps);
-    TLS_TRAITS(tls::vector_trait<4>);
+    TLS_TRAITS(tls::vector<4>);
   };
 
   struct TestCase
@@ -129,7 +129,7 @@ struct HashRatchetTestVectors
     std::vector<KeySequence> key_sequences;
 
     TLS_SERIALIZABLE(cipher_suite, key_sequences);
-    TLS_TRAITS(tls::pass, tls::vector_trait<4>);
+    TLS_TRAITS(tls::pass, tls::vector<4>);
   };
 
   uint32_t n_members;
@@ -139,7 +139,7 @@ struct HashRatchetTestVectors
   std::vector<TestCase> cases;
 
   TLS_SERIALIZABLE(n_members, n_generations, base_secret, cases);
-  TLS_TRAITS(tls::pass, tls::pass, tls::vector_trait<1>, tls::vector_trait<4>);
+  TLS_TRAITS(tls::pass, tls::pass, tls::vector<1>, tls::vector<4>);
 };
 
 /////
@@ -154,7 +154,7 @@ struct KeyScheduleTestVectors
     bytes nonce;
 
     TLS_SERIALIZABLE(key, nonce);
-    TLS_TRAITS(tls::vector_trait<1>, tls::vector_trait<1>);
+    TLS_TRAITS(tls::vector<1>, tls::vector<1>);
   };
 
   struct Epoch
@@ -188,16 +188,16 @@ struct KeyScheduleTestVectors
                      confirmation_key,
                      init_secret);
     TLS_TRAITS(tls::pass,
-               tls::vector_trait<1>,
-               tls::vector_trait<1>,
-               tls::vector_trait<1>,
-               tls::vector_trait<1>,
-               tls::vector_trait<1>,
-               tls::vector_trait<4>,
-               tls::vector_trait<1>,
-               tls::vector_trait<4>,
-               tls::vector_trait<1>,
-               tls::vector_trait<1>);
+               tls::vector<1>,
+               tls::vector<1>,
+               tls::vector<1>,
+               tls::vector<1>,
+               tls::vector<1>,
+               tls::vector<4>,
+               tls::vector<1>,
+               tls::vector<4>,
+               tls::vector<1>,
+               tls::vector<1>);
   };
 
   struct TestCase
@@ -206,7 +206,7 @@ struct KeyScheduleTestVectors
     std::vector<Epoch> epochs;
 
     TLS_SERIALIZABLE(cipher_suite, epochs);
-    TLS_TRAITS(tls::pass, tls::vector_trait<2>);
+    TLS_TRAITS(tls::pass, tls::vector<2>);
   };
 
   uint32_t n_epochs;
@@ -223,9 +223,9 @@ struct KeyScheduleTestVectors
                    cases);
   TLS_TRAITS(tls::pass,
              tls::pass,
-             tls::vector_trait<1>,
-             tls::vector_trait<4>,
-             tls::vector_trait<4>);
+             tls::vector<1>,
+             tls::vector<4>,
+             tls::vector<4>);
 };
 
 /////
@@ -306,7 +306,7 @@ struct TreeTestVectors
   {
     bytes data;
     TLS_SERIALIZABLE(data);
-    TLS_TRAITS(tls::vector_trait<1>);
+    TLS_TRAITS(tls::vector<1>);
   };
 
   struct TreeNode
@@ -315,14 +315,14 @@ struct TreeTestVectors
     bytes hash;
 
     TLS_SERIALIZABLE(public_key, hash);
-    TLS_TRAITS(tls::pass, tls::vector_trait<1>);
+    TLS_TRAITS(tls::pass, tls::vector<1>);
   };
 
   struct TreeCase
   {
     std::vector<TreeNode> nodes;
     TLS_SERIALIZABLE(nodes);
-    TLS_TRAITS(tls::vector_trait<4>);
+    TLS_TRAITS(tls::vector<4>);
   };
 
   struct TestCase
@@ -333,7 +333,7 @@ struct TreeTestVectors
     std::vector<TreeCase> trees;
 
     TLS_SERIALIZABLE(cipher_suite, signature_scheme, credentials, trees);
-    TLS_TRAITS(tls::pass, tls::pass, tls::vector_trait<4>, tls::vector_trait<4>)
+    TLS_TRAITS(tls::pass, tls::pass, tls::vector<4>, tls::vector<4>)
   };
 
   std::vector<Bytes1> leaf_secrets;
@@ -341,7 +341,7 @@ struct TreeTestVectors
   std::vector<TestCase> cases;
 
   TLS_SERIALIZABLE(leaf_secrets, credentials, cases);
-  TLS_TRAITS(tls::vector_trait<4>, tls::vector_trait<4>, tls::vector_trait<4>);
+  TLS_TRAITS(tls::vector<4>, tls::vector<4>, tls::vector<4>);
 };
 
 /////
@@ -383,16 +383,16 @@ struct MessagesTestVectors
                      ciphertext);
     TLS_TRAITS(tls::pass,
                tls::pass,
-               tls::vector_trait<4>,
-               tls::vector_trait<4>,
-               tls::vector_trait<4>,
-               tls::vector_trait<4>,
-               tls::vector_trait<4>,
-               tls::vector_trait<4>,
-               tls::vector_trait<4>,
-               tls::vector_trait<4>,
-               tls::vector_trait<4>,
-               tls::vector_trait<4>);
+               tls::vector<4>,
+               tls::vector<4>,
+               tls::vector<4>,
+               tls::vector<4>,
+               tls::vector<4>,
+               tls::vector<4>,
+               tls::vector<4>,
+               tls::vector<4>,
+               tls::vector<4>,
+               tls::vector<4>);
   };
 
   epoch_t epoch;
@@ -420,13 +420,13 @@ struct MessagesTestVectors
   TLS_TRAITS(tls::pass,
              tls::pass,
              tls::pass,
-             tls::vector_trait<1>,
-             tls::vector_trait<1>,
-             tls::vector_trait<1>,
-             tls::vector_trait<1>,
-             tls::vector_trait<1>,
-             tls::vector_trait<1>,
-             tls::vector_trait<4>);
+             tls::vector<1>,
+             tls::vector<1>,
+             tls::vector<1>,
+             tls::vector<1>,
+             tls::vector<1>,
+             tls::vector<1>,
+             tls::vector<4>);
 };
 
 /////
@@ -522,13 +522,13 @@ struct SessionTestVectors
                      confirmation_key,
                      init_secret);
     TLS_TRAITS(tls::pass,
-               tls::vector_trait<4>,
-               tls::vector_trait<1>,
+               tls::vector<4>,
+               tls::vector<1>,
                tls::pass,
-               tls::vector_trait<1>,
-               tls::vector_trait<1>,
-               tls::vector_trait<1>,
-               tls::vector_trait<1>);
+               tls::vector<1>,
+               tls::vector<1>,
+               tls::vector<1>,
+               tls::vector<1>);
   };
 
   struct TestCase
@@ -544,11 +544,7 @@ struct SessionTestVectors
                      encrypt,
                      key_packages,
                      transcript);
-    TLS_TRAITS(tls::pass,
-               tls::pass,
-               tls::pass,
-               tls::vector_trait<4>,
-               tls::vector_trait<4>);
+    TLS_TRAITS(tls::pass, tls::pass, tls::pass, tls::vector<4>, tls::vector<4>);
   };
 
   uint32_t group_size;
@@ -557,7 +553,7 @@ struct SessionTestVectors
   std::vector<TestCase> cases;
 
   TLS_SERIALIZABLE(group_size, group_id, cases);
-  TLS_TRAITS(tls::pass, tls::vector_trait<1>, tls::vector_trait<4>);
+  TLS_TRAITS(tls::pass, tls::vector<1>, tls::vector<4>);
 };
 
 struct BasicSessionTestVectors : SessionTestVectors

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -33,15 +33,15 @@ struct TreeMathTestVectors
                    dirpath,
                    copath,
                    ancestor)
-  TLS_TRAITS(tls::pass{},
-             tls::vector_trait<4>{},
-             tls::vector_trait<4>{},
-             tls::vector_trait<4>{},
-             tls::vector_trait<4>{},
-             tls::vector_trait<4>{},
-             tls::vector_trait<4>{},
-             tls::vector_trait<4>{},
-             tls::vector_trait<4>{});
+  TLS_TRAITS(tls::pass,
+             tls::vector_trait<4>,
+             tls::vector_trait<4>,
+             tls::vector_trait<4>,
+             tls::vector_trait<4>,
+             tls::vector_trait<4>,
+             tls::vector_trait<4>,
+             tls::vector_trait<4>,
+             tls::vector_trait<4>);
 };
 
 /////
@@ -75,7 +75,7 @@ struct CryptoTestVectors
                      hkdf_extract_out,
                      derive_key_pair_pub,
                      hpke_out)
-    TLS_TRAITS(tls::pass{}, tls::vector_trait<1>{}, tls::pass{}, tls::pass{});
+    TLS_TRAITS(tls::pass, tls::vector_trait<1>, tls::pass, tls::pass);
   };
 
   std::vector<TestCase> cases;
@@ -86,12 +86,12 @@ struct CryptoTestVectors
                    hpke_aad,
                    hpke_plaintext,
                    cases)
-  TLS_TRAITS(tls::vector_trait<1>{},
-             tls::vector_trait<1>{},
-             tls::vector_trait<1>{},
-             tls::vector_trait<1>{},
-             tls::vector_trait<1>{},
-             tls::vector_trait<4>{});
+  TLS_TRAITS(tls::vector_trait<1>,
+             tls::vector_trait<1>,
+             tls::vector_trait<1>,
+             tls::vector_trait<1>,
+             tls::vector_trait<1>,
+             tls::vector_trait<4>);
 };
 
 /////
@@ -106,7 +106,7 @@ struct HashRatchetTestVectors
     bytes nonce;
 
     TLS_SERIALIZABLE(key, nonce);
-    TLS_TRAITS(tls::vector_trait<1>{}, tls::vector_trait<1>{});
+    TLS_TRAITS(tls::vector_trait<1>, tls::vector_trait<1>);
   };
 
   typedef tls::vector<Step, 4> KeySequence;
@@ -117,7 +117,7 @@ struct HashRatchetTestVectors
     std::vector<KeySequence> key_sequences;
 
     TLS_SERIALIZABLE(cipher_suite, key_sequences);
-    TLS_TRAITS(tls::pass{}, tls::vector_trait<4>{});
+    TLS_TRAITS(tls::pass, tls::vector_trait<4>);
   };
 
   uint32_t n_members;
@@ -127,10 +127,7 @@ struct HashRatchetTestVectors
   std::vector<TestCase> cases;
 
   TLS_SERIALIZABLE(n_members, n_generations, base_secret, cases);
-  TLS_TRAITS(tls::pass{},
-             tls::pass{},
-             tls::vector_trait<1>{},
-             tls::vector_trait<4>{});
+  TLS_TRAITS(tls::pass, tls::pass, tls::vector_trait<1>, tls::vector_trait<4>);
 };
 
 /////
@@ -145,7 +142,7 @@ struct KeyScheduleTestVectors
     bytes nonce;
 
     TLS_SERIALIZABLE(key, nonce);
-    TLS_TRAITS(tls::vector_trait<1>{}, tls::vector_trait<1>{});
+    TLS_TRAITS(tls::vector_trait<1>, tls::vector_trait<1>);
   };
 
   struct Epoch
@@ -178,17 +175,17 @@ struct KeyScheduleTestVectors
                      application_keys,
                      confirmation_key,
                      init_secret);
-    TLS_TRAITS(tls::pass{},
-               tls::vector_trait<1>{},
-               tls::vector_trait<1>{},
-               tls::vector_trait<1>{},
-               tls::vector_trait<1>{},
-               tls::vector_trait<1>{},
-               tls::vector_trait<4>{},
-               tls::vector_trait<1>{},
-               tls::vector_trait<4>{},
-               tls::vector_trait<1>{},
-               tls::vector_trait<1>{});
+    TLS_TRAITS(tls::pass,
+               tls::vector_trait<1>,
+               tls::vector_trait<1>,
+               tls::vector_trait<1>,
+               tls::vector_trait<1>,
+               tls::vector_trait<1>,
+               tls::vector_trait<4>,
+               tls::vector_trait<1>,
+               tls::vector_trait<4>,
+               tls::vector_trait<1>,
+               tls::vector_trait<1>);
   };
 
   struct TestCase
@@ -197,7 +194,7 @@ struct KeyScheduleTestVectors
     std::vector<Epoch> epochs;
 
     TLS_SERIALIZABLE(cipher_suite, epochs);
-    TLS_TRAITS(tls::pass{}, tls::vector_trait<2>{});
+    TLS_TRAITS(tls::pass, tls::vector_trait<2>);
   };
 
   uint32_t n_epochs;
@@ -212,11 +209,11 @@ struct KeyScheduleTestVectors
                    base_init_secret,
                    base_group_context,
                    cases);
-  TLS_TRAITS(tls::pass{},
-             tls::pass{},
-             tls::vector_trait<1>{},
-             tls::vector_trait<4>{},
-             tls::vector_trait<4>{});
+  TLS_TRAITS(tls::pass,
+             tls::pass,
+             tls::vector_trait<1>,
+             tls::vector_trait<4>,
+             tls::vector_trait<4>);
 };
 
 /////
@@ -299,7 +296,7 @@ struct TreeTestVectors
     bytes hash;
 
     TLS_SERIALIZABLE(public_key, hash);
-    TLS_TRAITS(tls::pass{}, tls::vector_trait<1>{});
+    TLS_TRAITS(tls::pass, tls::vector_trait<1>);
   };
 
   typedef tls::vector<TreeNode, 4> TreeCase;
@@ -312,10 +309,7 @@ struct TreeTestVectors
     std::vector<TreeCase> trees;
 
     TLS_SERIALIZABLE(cipher_suite, signature_scheme, credentials, trees);
-    TLS_TRAITS(tls::pass{},
-               tls::pass{},
-               tls::vector_trait<4>{},
-               tls::vector_trait<4>{})
+    TLS_TRAITS(tls::pass, tls::pass, tls::vector_trait<4>, tls::vector_trait<4>)
   };
 
   std::vector<tls::opaque<1>> leaf_secrets;
@@ -323,9 +317,7 @@ struct TreeTestVectors
   std::vector<TestCase> cases;
 
   TLS_SERIALIZABLE(leaf_secrets, credentials, cases);
-  TLS_TRAITS(tls::vector_trait<4>{},
-             tls::vector_trait<4>{},
-             tls::vector_trait<4>{});
+  TLS_TRAITS(tls::vector_trait<4>, tls::vector_trait<4>, tls::vector_trait<4>);
 };
 
 /////
@@ -365,18 +357,18 @@ struct MessagesTestVectors
                      remove_proposal,
                      commit,
                      ciphertext);
-    TLS_TRAITS(tls::pass{},
-               tls::pass{},
-               tls::vector_trait<4>{},
-               tls::vector_trait<4>{},
-               tls::vector_trait<4>{},
-               tls::vector_trait<4>{},
-               tls::vector_trait<4>{},
-               tls::vector_trait<4>{},
-               tls::vector_trait<4>{},
-               tls::vector_trait<4>{},
-               tls::vector_trait<4>{},
-               tls::vector_trait<4>{});
+    TLS_TRAITS(tls::pass,
+               tls::pass,
+               tls::vector_trait<4>,
+               tls::vector_trait<4>,
+               tls::vector_trait<4>,
+               tls::vector_trait<4>,
+               tls::vector_trait<4>,
+               tls::vector_trait<4>,
+               tls::vector_trait<4>,
+               tls::vector_trait<4>,
+               tls::vector_trait<4>,
+               tls::vector_trait<4>);
   };
 
   epoch_t epoch;
@@ -401,16 +393,16 @@ struct MessagesTestVectors
                    sig_seed,
                    random,
                    cases);
-  TLS_TRAITS(tls::pass{},
-             tls::pass{},
-             tls::pass{},
-             tls::vector_trait<1>{},
-             tls::vector_trait<1>{},
-             tls::vector_trait<1>{},
-             tls::vector_trait<1>{},
-             tls::vector_trait<1>{},
-             tls::vector_trait<1>{},
-             tls::vector_trait<4>{});
+  TLS_TRAITS(tls::pass,
+             tls::pass,
+             tls::pass,
+             tls::vector_trait<1>,
+             tls::vector_trait<1>,
+             tls::vector_trait<1>,
+             tls::vector_trait<1>,
+             tls::vector_trait<1>,
+             tls::vector_trait<1>,
+             tls::vector_trait<4>);
 };
 
 /////
@@ -505,14 +497,14 @@ struct SessionTestVectors
                      application_secret,
                      confirmation_key,
                      init_secret);
-    TLS_TRAITS(tls::pass{},
-               tls::vector_trait<4>{},
-               tls::vector_trait<1>{},
-               tls::pass{},
-               tls::vector_trait<1>{},
-               tls::vector_trait<1>{},
-               tls::vector_trait<1>{},
-               tls::vector_trait<1>{});
+    TLS_TRAITS(tls::pass,
+               tls::vector_trait<4>,
+               tls::vector_trait<1>,
+               tls::pass,
+               tls::vector_trait<1>,
+               tls::vector_trait<1>,
+               tls::vector_trait<1>,
+               tls::vector_trait<1>);
   };
 
   struct TestCase
@@ -528,11 +520,11 @@ struct SessionTestVectors
                      encrypt,
                      key_packages,
                      transcript);
-    TLS_TRAITS(tls::pass{},
-               tls::pass{},
-               tls::pass{},
-               tls::vector_trait<4>{},
-               tls::vector_trait<4>{});
+    TLS_TRAITS(tls::pass,
+               tls::pass,
+               tls::pass,
+               tls::vector_trait<4>,
+               tls::vector_trait<4>);
   };
 
   uint32_t group_size;
@@ -541,7 +533,7 @@ struct SessionTestVectors
   std::vector<TestCase> cases;
 
   TLS_SERIALIZABLE(group_size, group_id, cases);
-  TLS_TRAITS(tls::pass{}, tls::vector_trait<1>{}, tls::vector_trait<4>{});
+  TLS_TRAITS(tls::pass, tls::vector_trait<1>, tls::vector_trait<4>);
 };
 
 struct BasicSessionTestVectors : SessionTestVectors

--- a/test/tls_syntax_test.cpp
+++ b/test/tls_syntax_test.cpp
@@ -36,7 +36,7 @@ struct StructWithTraits
   std::vector<uint8_t> b;
 
   TLS_SERIALIZABLE(a, b);
-  TLS_TRAITS(tls::pass{}, tls::vector_trait<2>{});
+  TLS_TRAITS(tls::pass, tls::vector_trait<2>);
 };
 
 bool

--- a/test/tls_syntax_test.cpp
+++ b/test/tls_syntax_test.cpp
@@ -101,19 +101,15 @@ protected:
   const bytes enc_struct =
     from_hex("11110002222233333333444444445555555566666666");
 
-  const tls::optional<ExampleStruct> val_optional{ val_struct };
+  const std::optional<ExampleStruct> val_optional{ val_struct };
   const bytes enc_optional = from_hex("01") + enc_struct;
 
-  const tls::optional<ExampleStruct> val_optional_null = std::nullopt;
+  const std::optional<ExampleStruct> val_optional_null = std::nullopt;
   const bytes enc_optional_null = from_hex("00");
 
   const uint8_t variant_param = 0xff;
-  typedef tls::variant_optional<MustInitialize, uint8_t> test_var_optional;
   typedef tls::variant_variant<TypeSelector, uint8_t, MustInitialize>
     test_var_variant;
-
-  test_var_optional val_var_optional;
-  const bytes enc_var_optional = from_hex("01f0");
 
   const TypeSelector val_enum = TypeSelector::example_struct;
   const bytes enc_enum = from_hex("a0a0");
@@ -123,12 +119,6 @@ protected:
 
   const test_var_variant val_var_variant{ 0xff, MustInitialize{ 0xff, 0x0f } };
   const bytes enc_var_variant = from_hex("B0B0f0");
-
-  TLSSyntaxTest()
-    : val_var_optional(variant_param)
-  {
-    val_var_optional = MustInitialize{ 0xff, 0x0f };
-  }
 };
 
 template<typename T>
@@ -156,7 +146,6 @@ TEST_F(TLSSyntaxTest, OStream)
   ostream_test(val_struct, enc_struct);
   ostream_test(val_optional, enc_optional);
   ostream_test(val_optional_null, enc_optional_null);
-  ostream_test(val_var_optional, enc_var_optional);
   ostream_test(val_enum, enc_enum);
   ostream_test(val_variant, enc_variant);
   ostream_test(val_var_variant, enc_var_variant);
@@ -194,14 +183,11 @@ TEST_F(TLSSyntaxTest, IStream)
   ExampleStruct data_struct;
   istream_test(val_struct, data_struct, enc_struct);
 
-  tls::optional<ExampleStruct> data_optional;
+  std::optional<ExampleStruct> data_optional;
   istream_test(val_optional, data_optional, enc_optional);
 
-  tls::optional<ExampleStruct> data_optional_null;
+  std::optional<ExampleStruct> data_optional_null;
   istream_test(val_optional_null, data_optional_null, enc_optional_null);
-
-  test_var_optional data_var_optional(variant_param);
-  istream_test(val_var_optional, data_var_optional, enc_var_optional);
 
   TypeSelector data_enum;
   istream_test(val_enum, data_enum, enc_enum);

--- a/test/tls_syntax_test.cpp
+++ b/test/tls_syntax_test.cpp
@@ -30,6 +30,21 @@ operator==(const ExampleStruct& lhs, const ExampleStruct& rhs)
   return (lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c);
 }
 
+struct StructWithTraits
+{
+  uint16_t a;
+  std::vector<uint8_t> b;
+
+  TLS_SERIALIZABLE(a, b);
+  TLS_TRAITS(tls::pass{}, tls::vector_trait<2>{});
+};
+
+bool
+operator==(const StructWithTraits& lhs, const StructWithTraits& rhs)
+{
+  return (lhs.a == rhs.a) && (lhs.b == rhs.b);
+}
+
 struct MustInitialize
 {
   uint8_t offset;
@@ -106,6 +121,12 @@ protected:
   const bytes enc_struct =
     from_hex("11110002222233333333444444445555555566666666");
 
+  const StructWithTraits val_struct_traits{
+    0x1111,
+    { 0x02, 0x03, 0x04 },
+  };
+  const bytes enc_struct_traits = from_hex("11110003020304");
+
   const tls::optional<ExampleStruct> val_optional{ val_struct };
   const bytes enc_optional = from_hex("01") + enc_struct;
 
@@ -168,6 +189,7 @@ TEST_F(TLSSyntaxTest, OStream)
   ostream_test(val_vector, enc_vector);
   ostream_test(val_vector_raw, enc_vector_raw);
   ostream_test(val_struct, enc_struct);
+  ostream_test(val_struct_traits, enc_struct_traits);
   ostream_test(val_optional, enc_optional);
   ostream_test(val_optional_null, enc_optional_null);
   ostream_test(val_var_vector, enc_var_vector);
@@ -214,6 +236,9 @@ TEST_F(TLSSyntaxTest, IStream)
 
   ExampleStruct data_struct;
   istream_test(val_struct, data_struct, enc_struct);
+
+  StructWithTraits data_struct_traits;
+  istream_test(val_struct_traits, data_struct_traits, enc_struct_traits);
 
   tls::optional<ExampleStruct> data_optional;
   istream_test(val_optional, data_optional, enc_optional);

--- a/test/tls_syntax_test.cpp
+++ b/test/tls_syntax_test.cpp
@@ -26,12 +26,12 @@ struct ExampleStruct
   std::vector<uint8_t> d;
   std::variant<uint8_t, uint16_t> e;
 
-  TLS_SERIALIZABLE(a, b, c, d, e);
+  TLS_SERIALIZABLE(a, b, c, d, e)
   TLS_TRAITS(tls::pass,
              tls::pass,
              tls::pass,
              tls::vector<2>,
-             tls::variant<IntSelector>);
+             tls::variant<IntSelector>)
 };
 
 bool

--- a/test/tls_syntax_test.cpp
+++ b/test/tls_syntax_test.cpp
@@ -11,11 +11,23 @@ enum struct IntSelector : uint16_t
   uint16 = 0xBBBB,
 };
 
-template<>
-IntSelector tls::variant_value<IntSelector, uint8_t> = IntSelector::uint8;
+struct Uint8
+{
+  uint8_t value;
+  static const IntSelector type;
+  TLS_SERIALIZABLE(value);
+};
 
-template<>
-IntSelector tls::variant_value<IntSelector, uint16_t> = IntSelector::uint16;
+const IntSelector Uint8::type = IntSelector::uint8;
+
+struct Uint16
+{
+  uint16_t value;
+  static const IntSelector type;
+  TLS_SERIALIZABLE(value);
+};
+
+const IntSelector Uint16::type = IntSelector::uint16;
 
 // A struct to test struct encoding and traits
 struct ExampleStruct
@@ -24,7 +36,7 @@ struct ExampleStruct
   std::array<uint32_t, 4> b;
   std::optional<uint8_t> c;
   std::vector<uint8_t> d;
-  std::variant<uint8_t, uint16_t> e;
+  std::variant<Uint8, Uint16> e;
 
   TLS_SERIALIZABLE(a, b, c, d, e)
   TLS_TRAITS(tls::pass,
@@ -67,7 +79,7 @@ protected:
     { 0x22222222, 0x33333333, 0x44444444, 0x55555555 },
     { 0x66 },
     { 0x77, 0x88 },
-    { uint16_t(0x9999) },
+    { Uint16{ 0x9999 } },
   };
   const bytes enc_struct =
     from_hex("111122222222333333334444444455555555016600027788BBBB9999");

--- a/test/tls_syntax_test.cpp
+++ b/test/tls_syntax_test.cpp
@@ -20,7 +20,7 @@ struct ExampleStruct
 
   static const TypeSelector type;
   TLS_SERIALIZABLE(a, b, c);
-  TLS_TRAITS(tls::pass, tls::vector_trait<2>, tls::pass);
+  TLS_TRAITS(tls::pass, tls::vector<2>, tls::pass);
 };
 
 const TypeSelector ExampleStruct::type = TypeSelector::example_struct;

--- a/test/tree_math_test.cpp
+++ b/test/tree_math_test.cpp
@@ -36,6 +36,14 @@ protected:
       ASSERT_EQ(function(NodeIndex{ i }), answers[i]);
     }
   }
+
+  template<typename F, typename A>
+  void matrix_test(F function, A answers)
+  {
+    for (uint32_t i = 0; i < width.val; ++i) {
+      ASSERT_EQ(function(NodeIndex{ i }), answers[i].nodes);
+    }
+  }
 };
 
 TEST_F(TreeMathTest, Root)
@@ -68,12 +76,12 @@ TEST_F(TreeMathTest, Sibling)
 
 TEST_F(TreeMathTest, Dirpath)
 {
-  vector_test(size_scope(tree_math::dirpath), tv.dirpath);
+  matrix_test(size_scope(tree_math::dirpath), tv.dirpath);
 }
 
 TEST_F(TreeMathTest, Copath)
 {
-  vector_test(size_scope(tree_math::copath), tv.copath);
+  matrix_test(size_scope(tree_math::copath), tv.copath);
 }
 
 TEST_F(TreeMathTest, Ancestor)
@@ -83,6 +91,6 @@ TEST_F(TreeMathTest, Ancestor)
     for (uint32_t r = l + 1; r < tv.n_leaves.val; ++r) {
       ancestors.push_back(tree_math::ancestor(LeafIndex(l), LeafIndex(r)));
     }
-    ASSERT_EQ(ancestors, tv.ancestor[l]);
+    ASSERT_EQ(ancestors, tv.ancestor[l].nodes);
   }
 }


### PR DESCRIPTION
The current TLS syntax serialization code relies on subclassing STL container types, which is [not safe](https://stackoverflow.com/questions/4353203/thou-shalt-not-inherit-from-stdvector).  This has led to some odd errors in the development of #87, and I suspect it is responsible for some memory leakage that has been observe elsewhere (due to vectors not being properly cleaned up).

This PR replaces custom types with external type traits for type members.  These traits are specified using a `TLS_TRAITS` macro, parallel to the `TLS_SERIALIZABLE` macro.  For example:

```
// BEFORE
struct Foo {
  uint16_t a;
  Baz b;
  tls::vector<Bar, 3> c;

  TLS_SERIALIZABLE(a, b, c);
};

// AFTER

struct Foo {
  uint16_t a;
  Baz b;
  std::vector<Bar> c;

  TLS_SERIALIZABLE(a, b, c);
  TLS_TRAITS( tls::pass{}, tls::pass{}, tls::vector_trait<3>{} );
};
```

Together with the fact that several of the specialized types are not used, we should be able to use this construct to move basically all of the non-trivial serialization logic to traits.

The remaining things to do here are:

- [x] Remove unused specialized types
- [x] Create a trait to handle variant
- [x] Create a trait to handle optional (if necessary)
- [x] Migrate existing structs to use traits as required