### PR TITLE
Add support for extensions

### DIFF
--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -313,8 +313,8 @@ generate_messages()
     key_package.signature = tv.random;
 
     // Construct Welcome
-    auto group_info =
-      GroupInfo{ tv.group_id, tv.epoch, tree, tv.random, tv.random, ext_list, tv.random };
+    auto group_info = GroupInfo{ tv.group_id, tv.epoch, tree,     tv.random,
+                                 tv.random,   ext_list, tv.random };
     group_info.signer_index = LeafIndex(tv.sender.sender);
     group_info.signature = tv.random;
 

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -578,8 +578,6 @@ main()
   verify_reproducible(generate_tree_math);
   verify_reproducible(generate_hash_ratchet);
   verify_reproducible(generate_key_schedule);
-  verify_reproducible(generate_messages);
-  verify_session_repro(generate_basic_session);
 
   // Verify that the test vectors load
   try {

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -319,13 +319,16 @@ generate_messages()
     direct_path.leaf_key_package.signature = tv.random;
 
     // Construct CIK
+    auto ext_list =
+      ExtensionList{ { { ExtensionType::lifetime, bytes(8, 0) } } };
     auto key_package =
       KeyPackage{ suite, dh_priv.public_key(), cred, sig_priv };
+    key_package.extensions = ext_list;
     key_package.signature = tv.random;
 
     // Construct Welcome
-    auto group_info =
-      GroupInfo{ tv.group_id, tv.epoch, tree, tv.random, tv.random, tv.random };
+    auto group_info = GroupInfo{ tv.group_id, tv.epoch, tree,     tv.random,
+                                 tv.random,   ext_list, tv.random };
     group_info.signer_index = tv.signer_index;
     group_info.signature = tv.random;
 

--- a/include/common.h
+++ b/include/common.h
@@ -38,6 +38,12 @@ operator<<(std::ostream& out, const bytes& data);
 using epoch_t = uint64_t;
 
 ///
+/// Get the current system clock time in the format MLS expects
+///
+
+uint64_t seconds_since_epoch();
+
+///
 /// Auto-generate equality and inequality operators for TLS-serializable things
 ///
 

--- a/include/core_types.h
+++ b/include/core_types.h
@@ -28,8 +28,8 @@ struct Extension {
   ExtensionType type;
   bytes data;
 
-  TLS_SERIALIZABLE(type, data);
-  TLS_TRAITS(tls::pass, tls::vector<2>);
+  TLS_SERIALIZABLE(type, data)
+  TLS_TRAITS(tls::pass, tls::vector<2>)
 };
 
 struct ExtensionList {
@@ -65,24 +65,24 @@ struct ExtensionList {
 
   bool has(ExtensionType type) const;
 
-  TLS_SERIALIZABLE(extensions);
-  TLS_TRAITS(tls::vector<2>);
+  TLS_SERIALIZABLE(extensions)
+  TLS_TRAITS(tls::vector<2>)
 };
 
 struct SupportedVersionsExtension {
   std::vector<ProtocolVersion> versions;
 
   static const ExtensionType type;
-  TLS_SERIALIZABLE(versions);
-  TLS_TRAITS(tls::vector<1>);
+  TLS_SERIALIZABLE(versions)
+  TLS_TRAITS(tls::vector<1>)
 };
 
 struct SupportedCipherSuitesExtension {
   std::vector<CipherSuite> cipher_suites;
 
   static const ExtensionType type;
-  TLS_SERIALIZABLE(cipher_suites);
-  TLS_TRAITS(tls::vector<1>);
+  TLS_SERIALIZABLE(cipher_suites)
+  TLS_TRAITS(tls::vector<1>)
 };
 
 struct LifetimeExtension {
@@ -90,23 +90,23 @@ struct LifetimeExtension {
   uint64_t not_after;
 
   static const ExtensionType type;
-  TLS_SERIALIZABLE(not_before, not_after);
+  TLS_SERIALIZABLE(not_before, not_after)
 };
 
 struct KeyIDExtension {
   bytes key_id;
 
   static const ExtensionType type;
-  TLS_SERIALIZABLE(key_id);
-  TLS_TRAITS(tls::vector<2>);
+  TLS_SERIALIZABLE(key_id)
+  TLS_TRAITS(tls::vector<2>)
 };
 
 struct ParentHashExtension {
   bytes parent_hash;
 
   static const ExtensionType type;
-  TLS_SERIALIZABLE(parent_hash);
-  TLS_TRAITS(tls::vector<1>);
+  TLS_SERIALIZABLE(parent_hash)
+  TLS_TRAITS(tls::vector<1>)
 };
 
 ///
@@ -160,9 +160,7 @@ struct KeyPackage
   void sign(const SignaturePrivateKey& sig_priv,
             const std::optional<KeyPackageOpts>& opts);
 
-  bool verify_basic_extensions(ProtocolVersion version,
-                               CipherSuite suite,
-                               uint64_t now) const;
+  bool verify_expiry(uint64_t now) const;
   bool verify_extension_support(const ExtensionList& ext_list) const;
   bool verify() const;
 

--- a/include/core_types.h
+++ b/include/core_types.h
@@ -134,7 +134,7 @@ struct KeyPackage
   CipherSuite cipher_suite;
   HPKEPublicKey init_key;
   Credential credential;
-  // TODO Extensions
+  ExtensionList extensions;
   bytes signature;
 
   KeyPackage();
@@ -150,8 +150,8 @@ struct KeyPackage
   bool verify() const;
 
   static const NodeType type;
-  TLS_SERIALIZABLE(version, cipher_suite, init_key, credential, signature)
-  TLS_TRAITS(tls::pass, tls::pass, tls::pass, tls::pass, tls::vector<2>)
+  TLS_SERIALIZABLE(version, cipher_suite, init_key, credential, extensions, signature)
+  TLS_TRAITS(tls::pass, tls::pass, tls::pass, tls::pass, tls::pass, tls::vector<2>)
 
   private:
   bytes to_be_signed() const;

--- a/include/messages.h
+++ b/include/messages.h
@@ -12,18 +12,15 @@
 namespace mls {
 
 // struct {
-//   // GroupContext inputs
 //   opaque group_id<0..255>;
-//   uint32 epoch;
-//   optional<RatchetNode> tree<1..2^32-1>;
+//   uint64 epoch;
+//   optional<Node> tree<1..2^32-1>;
 //   opaque confirmed_transcript_hash<0..255>;
-//
-//   // Inputs to the next round of the key schedule
 //   opaque interim_transcript_hash<0..255>;
-//   opaque epoch_secret<0..255>;
-//
+//   Extension extensions<0..2^16-1>;
+//   opaque confirmation<0..255>
 //   uint32 signer_index;
-//   opaque signature<0..255>;
+//   opaque signature<0..2^16-1>;
 // } GroupInfo;
 struct GroupInfo {
   bytes group_id;
@@ -32,8 +29,9 @@ struct GroupInfo {
 
   bytes confirmed_transcript_hash;
   bytes interim_transcript_hash;
-  bytes confirmation;
+  ExtensionList extensions;
 
+  bytes confirmation;
   LeafIndex signer_index;
   bytes signature;
 
@@ -43,6 +41,7 @@ struct GroupInfo {
             TreeKEMPublicKey tree_in,
             bytes confirmed_transcript_hash_in,
             bytes interim_transcript_hash_in,
+            ExtensionList extensions_in,
             bytes confirmation_in);
 
   bytes to_be_signed() const;
@@ -54,6 +53,7 @@ struct GroupInfo {
                    tree,
                    confirmed_transcript_hash,
                    interim_transcript_hash,
+                   extensions,
                    confirmation,
                    signer_index,
                    signature)
@@ -62,6 +62,7 @@ struct GroupInfo {
              tls::pass,
              tls::vector<1>,
              tls::vector<1>,
+             tls::pass,
              tls::vector<1>,
              tls::pass,
              tls::vector<2>)

--- a/include/state.h
+++ b/include/state.h
@@ -12,10 +12,11 @@
 namespace mls {
 
 // struct {
-//   opaque group_id<0..255>;
-//   uint32 epoch;
-//   opaque tree_hash<0..255>;
-//   opaque transcript_hash<0..255>;
+//     opaque group_id<0..255>;
+//     uint64 epoch;
+//     opaque tree_hash<0..255>;
+//     opaque confirmed_transcript_hash<0..255>;
+//     Extension extensions<0..2^16-1>;
 // } GroupContext;
 struct GroupContext
 {
@@ -23,9 +24,10 @@ struct GroupContext
   epoch_t epoch;
   bytes tree_hash;
   bytes confirmed_transcript_hash;
+  ExtensionList extensions;
 
-  TLS_SERIALIZABLE(group_id, epoch, tree_hash, confirmed_transcript_hash)
-  TLS_TRAITS(tls::vector<1>, tls::pass, tls::vector<1>, tls::vector<1>)
+  TLS_SERIALIZABLE(group_id, epoch, tree_hash, confirmed_transcript_hash, extensions)
+  TLS_TRAITS(tls::vector<1>, tls::pass, tls::vector<1>, tls::vector<1>, tls::pass)
 };
 
 class State
@@ -92,6 +94,7 @@ protected:
   TreeKEMPrivateKey _tree_priv;
   bytes _confirmed_transcript_hash;
   bytes _interim_transcript_hash;
+  ExtensionList _extensions;
 
   // Shared secret state
   KeyScheduleEpoch _keys;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -67,6 +67,14 @@ operator^(const bytes& lhs, const bytes& rhs)
   return out;
 }
 
+uint64_t
+seconds_since_epoch()
+{
+  auto since_epoch = std::chrono::system_clock::now().time_since_epoch();
+  auto secs = std::chrono::duration_cast<std::chrono::seconds>(since_epoch);
+  return secs.count();
+}
+
 std::ostream&
 operator<<(std::ostream& out, const bytes& data)
 {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -70,9 +70,9 @@ operator^(const bytes& lhs, const bytes& rhs)
 uint64_t
 seconds_since_epoch()
 {
-  auto since_epoch = std::chrono::system_clock::now().time_since_epoch();
-  auto secs = std::chrono::duration_cast<std::chrono::seconds>(since_epoch);
-  return secs.count();
+  // TODO(RLB) This should use std::chrono, but that seems not to be available
+  // on some platforms.
+  return std::time(nullptr);
 }
 
 std::ostream&

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -88,11 +88,7 @@ KeyPackage::verify_expiry(uint64_t now) const
   }
 
   auto& lt = maybe_lt.value();
-  if (now < lt.not_before || now > lt.not_after) {
-    return false;
-  }
-
-  return true;
+  return lt.not_before <= now && now <= lt.not_after;
 }
 
 bool

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -2,6 +2,22 @@
 
 namespace mls {
 
+///
+/// Extensions
+///
+
+const ExtensionType SupportedVersionsExtension::type =
+  ExtensionType::supported_versions;
+const ExtensionType SupportedCipherSuitesExtension::type =
+  ExtensionType::supported_ciphersuites;
+const ExtensionType LifetimeExtension::type = ExtensionType::lifetime;
+const ExtensionType KeyIDExtension::type = ExtensionType::key_id;
+const ExtensionType ParentHashExtension::type = ExtensionType::parent_hash;
+
+///
+/// NodeType, ParentNode, and KeyPackage
+///
+
 const NodeType KeyPackage::type = NodeType::leaf;
 
 KeyPackage::KeyPackage()
@@ -64,7 +80,9 @@ operator==(const KeyPackage& lhs, const KeyPackage& rhs)
   return tbs && (ver || same);
 }
 
-// DirectPath
+///
+/// DirectPath
+///
 
 void
 DirectPath::sign(CipherSuite suite,

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -80,33 +80,8 @@ KeyPackage::sign(const SignaturePrivateKey& sig_priv,
 }
 
 bool
-KeyPackage::verify_basic_extensions(ProtocolVersion version,
-                                    CipherSuite suite,
-                                    uint64_t now) const
+KeyPackage::verify_expiry(uint64_t now) const
 {
-  // Verify version support
-  auto maybe_sv = extensions.find<SupportedVersionsExtension>();
-  if (!maybe_sv.has_value()) {
-    return false;
-  }
-
-  auto& sv = maybe_sv.value().versions;
-  if (std::find(sv.begin(), sv.end(), version) == sv.end()) {
-    return false;
-  }
-
-  // Verify ciphersuite support
-  auto maybe_sc = extensions.find<SupportedCipherSuitesExtension>();
-  if (!maybe_sc.has_value()) {
-    return false;
-  }
-
-  auto& sc = maybe_sc.value().cipher_suites;
-  if (std::find(sc.begin(), sc.end(), suite) == sc.end()) {
-    return false;
-  }
-
-  // Verify expiry
   auto maybe_lt = extensions.find<LifetimeExtension>();
   if (!maybe_lt.has_value()) {
     return false;

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -17,12 +17,14 @@ GroupInfo::GroupInfo(bytes group_id_in,
                      TreeKEMPublicKey tree_in,
                      bytes confirmed_transcript_hash_in,
                      bytes interim_transcript_hash_in,
+                     ExtensionList extensions_in,
                      bytes confirmation_in)
   : group_id(std::move(group_id_in))
   , epoch(epoch_in)
   , tree(std::move(tree_in))
   , confirmed_transcript_hash(std::move(confirmed_transcript_hash_in))
   , interim_transcript_hash(std::move(interim_transcript_hash_in))
+  , extensions(std::move(extensions_in))
   , confirmation(std::move(confirmation_in))
 {}
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -114,6 +114,24 @@ State::sign(const Proposal& proposal) const
 MLSPlaintext
 State::add(const KeyPackage& key_package) const
 {
+  // Check that the key package is validly signed
+  if (!key_package.verify()) {
+    throw InvalidParameterError("Invalid signature on key package");
+  }
+
+  // Check that the group's basic properties are supported
+  auto version = ProtocolVersion::mls10;
+  auto now = seconds_since_epoch();
+  if (!key_package.verify_basic_extensions(version, _suite, now)) {
+    throw InvalidParameterError("Basic extensions invalid");
+  }
+
+  // Check that the group's extensions are supported
+  if (!key_package.verify_extension_support(_extensions)) {
+    throw InvalidParameterError(
+      "Key package does not support group's extensions");
+  }
+
   return sign({ Add{ key_package } });
 }
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -191,6 +191,7 @@ State::commit(const bytes& leaf_secret) const
     next._tree,
     next._confirmed_transcript_hash,
     next._interim_transcript_hash,
+    next._extensions,
     std::get<CommitData>(pt.content).confirmation,
   };
   group_info.sign(_index, _identity_priv);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -120,10 +120,9 @@ State::add(const KeyPackage& key_package) const
   }
 
   // Check that the group's basic properties are supported
-  auto version = ProtocolVersion::mls10;
   auto now = seconds_since_epoch();
-  if (!key_package.verify_basic_extensions(version, _suite, now)) {
-    throw InvalidParameterError("Basic extensions invalid");
+  if (!key_package.verify_expiry(now)) {
+    throw InvalidParameterError("Expired key package");
   }
 
   // Check that the group's extensions are supported

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -99,8 +99,8 @@ TEST_F(MessagesTest, Interop)
     tls_round_trip(tc.key_package, key_package, reproducible);
 
     // GroupInfo, GroupSecrets, EncryptedGroupSecrets, and Welcome
-    auto group_info =
-      GroupInfo{ tv.group_id, tv.epoch, tree, tv.random, tv.random, ext_list, tv.random };
+    auto group_info = GroupInfo{ tv.group_id, tv.epoch, tree,     tv.random,
+                                 tv.random,   ext_list, tv.random };
     group_info.signer_index = LeafIndex(tv.sender.sender);
     group_info.signature = tv.random;
     tls_round_trip(tc.group_info, group_info, true, tc.cipher_suite);

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -92,15 +92,17 @@ TEST_F(MessagesTest, Interop)
     direct_path.leaf_key_package.signature = tv.random;
 
     // KeyPackage
-    KeyPackage key_package{
-      tc.cipher_suite, dh_priv.public_key(), cred, sig_priv
-    };
+    auto ext_list =
+      ExtensionList{ { { ExtensionType::lifetime, bytes(8, 0) } } };
+    auto key_package =
+      KeyPackage{ tc.cipher_suite, dh_priv.public_key(), cred, sig_priv };
+    key_package.extensions = ext_list;
     key_package.signature = tv.random;
     tls_round_trip(tc.key_package, key_package, reproducible);
 
     // GroupInfo, GroupSecrets, EncryptedGroupSecrets, and Welcome
-    auto group_info =
-      GroupInfo{ tv.group_id, tv.epoch, tree, tv.random, tv.random, tv.random };
+    auto group_info = GroupInfo{ tv.group_id, tv.epoch, tree,     tv.random,
+                                 tv.random,   ext_list, tv.random };
     group_info.signer_index = tv.signer_index;
     group_info.signature = tv.random;
     tls_round_trip(tc.group_info, group_info, true, tc.cipher_suite);

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -38,8 +38,8 @@ TEST_F(MessagesTest, Extensions)
 {
   auto sv0 = SupportedVersionsExtension{ { ProtocolVersion::mls10 } };
   auto sc0 = SupportedCipherSuitesExtension{ {
-    CipherSuite::P256_SHA256_AES128GCM,
-    CipherSuite::X25519_SHA256_AES128GCM,
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   } };
   auto lt0 = LifetimeExtension{ 0xA0A0A0A0A0A0A0A0, 0xB0B0B0B0B0B0B0B0 };
   auto kid0 = KeyIDExtension{ { 0, 1, 2, 3 } };
@@ -52,11 +52,11 @@ TEST_F(MessagesTest, Extensions)
   exts.add(kid0);
   exts.add(ph0);
 
-  auto sv1 = exts.get<SupportedVersionsExtension>();
-  auto sc1 = exts.get<SupportedCipherSuitesExtension>();
-  auto lt1 = exts.get<LifetimeExtension>();
-  auto kid1 = exts.get<KeyIDExtension>();
-  auto ph1 = exts.get<ParentHashExtension>();
+  auto sv1 = exts.find<SupportedVersionsExtension>();
+  auto sc1 = exts.find<SupportedCipherSuitesExtension>();
+  auto lt1 = exts.find<LifetimeExtension>();
+  auto kid1 = exts.find<KeyIDExtension>();
+  auto ph1 = exts.find<ParentHashExtension>();
 
   ASSERT_EQ(sv0, sv1);
   ASSERT_EQ(sc0, sc1);

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -34,6 +34,37 @@ protected:
   {}
 };
 
+TEST_F(MessagesTest, Extensions)
+{
+  auto sv0 = SupportedVersionsExtension{ { ProtocolVersion::mls10 } };
+  auto sc0 = SupportedCipherSuitesExtension{ {
+    CipherSuite::P256_SHA256_AES128GCM,
+    CipherSuite::X25519_SHA256_AES128GCM,
+  } };
+  auto lt0 = LifetimeExtension{ 0xA0A0A0A0A0A0A0A0, 0xB0B0B0B0B0B0B0B0 };
+  auto kid0 = KeyIDExtension{ { 0, 1, 2, 3 } };
+  auto ph0 = ParentHashExtension{ { 4, 5, 6, 7 } };
+
+  ExtensionList exts;
+  exts.add(sv0);
+  exts.add(sc0);
+  exts.add(lt0);
+  exts.add(kid0);
+  exts.add(ph0);
+
+  auto sv1 = exts.get<SupportedVersionsExtension>();
+  auto sc1 = exts.get<SupportedCipherSuitesExtension>();
+  auto lt1 = exts.get<LifetimeExtension>();
+  auto kid1 = exts.get<KeyIDExtension>();
+  auto ph1 = exts.get<ParentHashExtension>();
+
+  ASSERT_EQ(sv0, sv1);
+  ASSERT_EQ(sc0, sc1);
+  ASSERT_EQ(lt0, lt1);
+  ASSERT_EQ(kid0, kid1);
+  ASSERT_EQ(ph0, ph1);
+}
+
 TEST_F(MessagesTest, Interop)
 {
   for (const auto& tc : tv.cases) {


### PR DESCRIPTION
This PR adds basic support for extensions in all of the places currently defined: KeyPackage, GroupState, and Groupinfo.  API is available for setting extensions on KeyPackage objects, but not for setting extensions on groups.

Depends on #90.