### PR TITLE
Change to the ninja cmake generator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
       - cmake
       - clang-format
       - libssl-dev
+      - ninja-build
 
 script:
   - MLSPP_LINT=ON make

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # This is just a convenience Makefile to avoid having to remember
 # all the CMake commands and their arguments.
 
+# choose: Ninja, Unix Makefiles, Xcode
+GENERATOR=Ninja
 BUILD_DIR=build
 CLANG_FORMAT=clang-format -i -style=mozilla
 
@@ -17,7 +19,7 @@ ${TEST_VECTOR_DIR}:
 	mkdir -p ${TEST_VECTOR_DIR}
 
 ${BUILD_DIR}: CMakeLists.txt test/CMakeLists.txt cmd/CMakeLists.txt
-	cmake -H. -B${BUILD_DIR} -DMLSPP_LINT=${MLSPP_LINT} -DCMAKE_BUILD_TYPE=Debug
+	cmake -H. -G "${GENERATOR}" -B${BUILD_DIR} -DMLSPP_LINT=${MLSPP_LINT} -DCMAKE_BUILD_TYPE=Debug
 
 lint:
 	cmake -H. -B${BUILD_DIR} -DMLSPP_LINT=ON -DCMAKE_BUILD_TYPE=Debug

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ example: all
 	./build/cmd/api_example/api_example
 
 clean:
-	cd ${BUILD_DIR} && make clean
+	cd ${BUILD_DIR} && ninja clean
 
 cclean:
 	rm -rf ${BUILD_DIR}


### PR DESCRIPTION
Someone suggested we use the `ninja` generator for CMake, so I tried it, and indeed it is a bit faster than the default, serial Makefile generator, especially on cold start.

```
                                    make      ninja     make -j4
make                                67.853s   31.694s   28.967s
make                                 1.743s    1.087s    1.205s
touch src/state.cpp && make          5.949s    4.519s    4.358s
touch include/tls_syntax.h && make  57.205s   27.691s   29.325s
make gen                             8.427s    8.832s    8.881s
make test                            9.580s    9.993s    9.708s
```

It's not faster when compared to `cmake -j4` with the Makefile generator.  But Ninja will automatically choose the level of parallelism appropriately, and produces more pleasant terminal output, so I'm inclined to make the change.