### PR TITLE
Support Chacha20-Poly1305

### DIFF
--- a/cmd/api_example/main.cpp
+++ b/cmd/api_example/main.cpp
@@ -10,14 +10,13 @@
 using namespace mls;
 
 const auto suite = CipherSuite::X25519_AES128GCM_SHA256_Ed25519;
-const auto scheme = SignatureScheme::Ed25519;
 
 class User
 {
 public:
   User(const std::string& name)
   {
-    _identity_priv = SignaturePrivateKey::generate(scheme);
+    _identity_priv = SignaturePrivateKey::generate(suite);
     auto id = bytes(name.begin(), name.end());
     _cred = Credential::basic(id, _identity_priv.public_key());
   }

--- a/cmd/api_example/main.cpp
+++ b/cmd/api_example/main.cpp
@@ -9,7 +9,7 @@
 
 using namespace mls;
 
-const auto suite = CipherSuite::X25519_SHA256_AES128GCM;
+const auto suite = CipherSuite::X25519_AES128GCM_SHA256_Ed25519;
 const auto scheme = SignatureScheme::Ed25519;
 
 class User

--- a/cmd/simulator/main.cpp
+++ b/cmd/simulator/main.cpp
@@ -225,7 +225,7 @@ public:
 int
 main(int argc, char** argv)
 {
-  const auto suite = mls::CipherSuite::X25519_SHA256_AES128GCM;
+  const auto suite = mls::CipherSuite::X25519_AES128GCM_SHA256_Ed25519;
   const auto scheme = mls::SignatureScheme::Ed25519;
 
   if (argc < 2) {

--- a/cmd/simulator/main.cpp
+++ b/cmd/simulator/main.cpp
@@ -122,13 +122,11 @@ class Simulation
 {
 private:
   mls::CipherSuite suite;
-  mls::SignatureScheme scheme;
   std::vector<std::optional<mls::Session>> sessions;
 
 public:
-  Simulation(mls::CipherSuite suite_in, mls::SignatureScheme scheme_in)
+  Simulation(mls::CipherSuite suite_in)
     : suite(suite_in)
-    , scheme(scheme_in)
   {}
 
   mls::bytes random() const { return mls::random_bytes(32); }
@@ -137,7 +135,7 @@ public:
   {
     auto secret = mls::random_bytes(32);
     auto init = mls::HPKEPrivateKey::derive(suite, secret);
-    auto priv = mls::SignaturePrivateKey::generate(scheme);
+    auto priv = mls::SignaturePrivateKey::generate(suite);
     auto id = random();
     auto cred = mls::Credential::basic(id, priv.public_key());
     auto kp = mls::KeyPackage{ suite, init.public_key(), cred, priv };
@@ -226,7 +224,6 @@ int
 main(int argc, char** argv)
 {
   const auto suite = mls::CipherSuite::X25519_AES128GCM_SHA256_Ed25519;
-  const auto scheme = mls::SignatureScheme::Ed25519;
 
   if (argc < 2) {
     std::cout << "Usage: simulator <script.json>" << std::endl;
@@ -237,7 +234,7 @@ main(int argc, char** argv)
   auto script = json::parse(script_json).get<Script>();
 
   // Initialize a set of sessions
-  Simulation sim(suite, scheme);
+  Simulation sim(suite);
   sim.init(script.initial_size);
 
   // Follow the steps in the script

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -215,11 +215,6 @@ generate_treekem()
     CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
-  std::vector<SignatureScheme> schemes{
-    SignatureScheme::P256_SHA256,
-    SignatureScheme::Ed25519,
-  };
-
   size_t n_leaves = 10;
   tv.init_secrets.resize(n_leaves);
   tv.leaf_secrets.resize(n_leaves);
@@ -230,11 +225,9 @@ generate_treekem()
 
   for (size_t i = 0; i < suites.size(); ++i) {
     auto suite = suites[i];
-    auto scheme = schemes[i];
 
     TreeKEMTestVectors::TestCase tc;
     tc.cipher_suite = suite;
-    tc.signature_scheme = scheme;
 
     TreeKEMPublicKey tree{ suite };
 
@@ -243,7 +236,7 @@ generate_treekem()
       auto context = bytes{ uint8_t(i), uint8_t(j) };
       auto init_priv = HPKEPrivateKey::derive(suite, tv.init_secrets[j].data);
       auto sig_priv =
-        SignaturePrivateKey::derive(scheme, tv.init_secrets[j].data);
+        SignaturePrivateKey::derive(suite, tv.init_secrets[j].data);
       auto cred = Credential::basic(context, sig_priv.public_key());
       auto kp = KeyPackage{ suite, init_priv.public_key(), cred, sig_priv };
 
@@ -276,11 +269,6 @@ generate_messages()
     CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
-  std::vector<SignatureScheme> schemes{
-    SignatureScheme::P256_SHA256,
-    SignatureScheme::Ed25519,
-  };
-
   // Set the inputs
   tv.epoch = 0xA0A1A2A3;
   tv.signer_index = LeafIndex{ 0xB0B1B2B3 };
@@ -296,18 +284,16 @@ generate_messages()
   DeterministicHPKE lock;
   for (size_t i = 0; i < suites.size(); ++i) {
     auto suite = suites[i];
-    auto scheme = schemes[i];
 
     // Miscellaneous data items we need to construct messages
     auto dh_priv = HPKEPrivateKey::derive(suite, tv.dh_seed);
     auto dh_key = dh_priv.public_key();
-    auto sig_priv = SignaturePrivateKey::derive(scheme, tv.sig_seed);
+    auto sig_priv = SignaturePrivateKey::derive(suite, tv.sig_seed);
     auto sig_key = sig_priv.public_key();
     auto cred = Credential::basic(tv.user_id, sig_priv.public_key());
 
     auto tree = TestTreeKEMPublicKey{
       suite,
-      scheme,
       { tv.random, tv.random, tv.random, tv.random },
     };
     tree.blank_path(LeafIndex{ 2 });
@@ -371,7 +357,6 @@ generate_messages()
     };
 
     tv.cases.push_back({ suite,
-                         scheme,
                          tls::marshal(key_package),
                          tls::marshal(group_info),
                          tls::marshal(group_secrets),
@@ -406,13 +391,6 @@ generate_basic_session()
     CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
-  std::vector<SignatureScheme> schemes{
-    SignatureScheme::P256_SHA256,
-    SignatureScheme::P256_SHA256,
-    SignatureScheme::Ed25519,
-    SignatureScheme::Ed25519,
-  };
-
   std::vector<bool> encrypts{ false, true, false, true };
 
   tv.group_size = 5;
@@ -421,7 +399,6 @@ generate_basic_session()
   DeterministicHPKE lock;
   for (size_t i = 0; i < suites.size(); ++i) {
     auto suite = suites[i];
-    auto scheme = schemes[i];
     auto encrypt = encrypts[i];
     const bytes key_package_id = { 0, 1, 2, 3 };
     const bytes group_init_secret = { 4, 5, 6, 7 };
@@ -435,7 +412,7 @@ generate_basic_session()
     auto ciphersuites = std::vector<CipherSuite>{ suite };
     for (size_t j = 0; j < tv.group_size; ++j) {
       auto init_secret = bytes{ uint8_t(j), 0 };
-      auto identity_priv = SignaturePrivateKey::derive(scheme, init_secret);
+      auto identity_priv = SignaturePrivateKey::derive(suite, init_secret);
       auto cred = Credential::basic(init_secret, identity_priv.public_key());
       auto init = HPKEPrivateKey::derive(suite, init_secret);
       auto kp = KeyPackage{ suite, init.public_key(), cred, identity_priv };
@@ -501,7 +478,7 @@ generate_basic_session()
     }
 
     // Construct the test case
-    tv.cases.push_back({ suite, scheme, encrypt, key_packages, transcript });
+    tv.cases.push_back({ suite, encrypt, key_packages, transcript });
   }
 
   return tv;
@@ -552,7 +529,7 @@ verify_session_repro(const F& generator)
 
   for (size_t i = 0; i < v0.cases.size(); ++i) {
     // Randomized signatures break reproducibility
-    if (!deterministic_signature_scheme(v0.cases[i].signature_scheme)) {
+    if (!deterministic_signature_scheme(v0.cases[i].cipher_suite)) {
       continue;
     }
 

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -56,8 +56,8 @@ generate_crypto()
   CryptoTestVectors tv;
 
   std::vector<CipherSuite> suites{
-    CipherSuite::P256_SHA256_AES128GCM,
-    CipherSuite::X25519_SHA256_AES128GCM,
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
   tv.hkdf_extract_salt = { 0, 1, 2, 3 };
@@ -95,8 +95,8 @@ generate_hash_ratchet()
   HashRatchetTestVectors tv;
 
   std::vector<CipherSuite> suites{
-    CipherSuite::P256_SHA256_AES128GCM,
-    CipherSuite::X25519_SHA256_AES128GCM,
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
   tv.n_members = 16;
@@ -129,8 +129,8 @@ generate_key_schedule()
   KeyScheduleTestVectors tv;
 
   std::vector<CipherSuite> suites{
-    CipherSuite::P256_SHA256_AES128GCM,
-    CipherSuite::X25519_SHA256_AES128GCM,
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
   GroupContext base_group_context{
@@ -211,8 +211,8 @@ generate_treekem()
   TreeKEMTestVectors tv;
 
   std::vector<CipherSuite> suites{
-    CipherSuite::P256_SHA256_AES128GCM,
-    CipherSuite::X25519_SHA256_AES128GCM,
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
   std::vector<SignatureScheme> schemes{
@@ -272,8 +272,8 @@ generate_messages()
   MessagesTestVectors tv;
 
   std::vector<CipherSuite> suites{
-    CipherSuite::P256_SHA256_AES128GCM,
-    CipherSuite::X25519_SHA256_AES128GCM,
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
   std::vector<SignatureScheme> schemes{
@@ -400,10 +400,10 @@ generate_basic_session()
   BasicSessionTestVectors tv;
 
   std::vector<CipherSuite> suites{
-    CipherSuite::P256_SHA256_AES128GCM,
-    CipherSuite::P256_SHA256_AES128GCM,
-    CipherSuite::X25519_SHA256_AES128GCM,
-    CipherSuite::X25519_SHA256_AES128GCM,
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   };
 
   std::vector<SignatureScheme> schemes{

--- a/include/common.h
+++ b/include/common.h
@@ -59,24 +59,27 @@ operator!=(const T& lhs, const T& rhs) {
 
 enum struct CipherSuite : uint16_t
 {
-  P256_SHA256_AES128GCM = 0x0000,
-  P521_SHA512_AES256GCM = 0x0010,
-  X25519_SHA256_AES128GCM = 0x0001,
-  X448_SHA512_AES256GCM = 0x0011,
-  unknown = 0xffff,
+  unknown = 0x0000,
+  X25519_AES128GCM_SHA256_Ed25519 = 0x0001,
+  P256_AES128GCM_SHA256_P256 = 0x0002,
+  X25519_CHACHA20POLY1305_SHA256_Ed25519 = 0x0003, // Unsupported
+  X448_AES256GCM_SHA512_Ed448 = 0x0004,
+  P521_AES256GCM_SHA512_P521 = 0x0005,
+  X448_CHACHA20POLY1305_SHA512_Ed448 = 0x0006, // Unsupported
 };
-
-size_t suite_nonce_size(CipherSuite suite);
-size_t suite_key_size(CipherSuite suite);
 
 enum struct SignatureScheme : uint16_t
 {
+  unknown = 0x0000,
   P256_SHA256 = 0x0403,
   P521_SHA512 = 0x0603,
   Ed25519 = 0x0807,
   Ed448 = 0x0808,
-  unknown = 0xffff,
 };
+
+SignatureScheme suite_signature_scheme(CipherSuite suite);
+size_t suite_nonce_size(CipherSuite suite);
+size_t suite_key_size(CipherSuite suite);
 
 ///
 /// Error types

--- a/include/common.h
+++ b/include/common.h
@@ -77,10 +77,16 @@ enum struct SignatureScheme : uint16_t
   Ed448 = 0x0808,
 };
 
+struct CipherDetails {
+  const size_t secret_size;
+  const size_t key_size;
+  const size_t nonce_size;
+  const SignatureScheme scheme;
+
+  static const CipherDetails& get(CipherSuite suite);
+};
+
 extern const std::array<CipherSuite, 6> all_supported_suites;
-SignatureScheme suite_signature_scheme(CipherSuite suite);
-size_t suite_nonce_size(CipherSuite suite);
-size_t suite_key_size(CipherSuite suite);
 
 ///
 /// Error types

--- a/include/common.h
+++ b/include/common.h
@@ -62,10 +62,10 @@ enum struct CipherSuite : uint16_t
   unknown = 0x0000,
   X25519_AES128GCM_SHA256_Ed25519 = 0x0001,
   P256_AES128GCM_SHA256_P256 = 0x0002,
-  X25519_CHACHA20POLY1305_SHA256_Ed25519 = 0x0003, // Unsupported
+  X25519_CHACHA20POLY1305_SHA256_Ed25519 = 0x0003,
   X448_AES256GCM_SHA512_Ed448 = 0x0004,
   P521_AES256GCM_SHA512_P521 = 0x0005,
-  X448_CHACHA20POLY1305_SHA512_Ed448 = 0x0006, // Unsupported
+  X448_CHACHA20POLY1305_SHA512_Ed448 = 0x0006,
 };
 
 enum struct SignatureScheme : uint16_t
@@ -77,7 +77,7 @@ enum struct SignatureScheme : uint16_t
   Ed448 = 0x0808,
 };
 
-extern const std::array<CipherSuite, 4> all_supported_suites;
+extern const std::array<CipherSuite, 6> all_supported_suites;
 SignatureScheme suite_signature_scheme(CipherSuite suite);
 size_t suite_nonce_size(CipherSuite suite);
 size_t suite_key_size(CipherSuite suite);

--- a/include/common.h
+++ b/include/common.h
@@ -77,6 +77,7 @@ enum struct SignatureScheme : uint16_t
   Ed448 = 0x0808,
 };
 
+extern const std::array<CipherSuite, 4> all_supported_suites;
 SignatureScheme suite_signature_scheme(CipherSuite suite);
 size_t suite_nonce_size(CipherSuite suite);
 size_t suite_key_size(CipherSuite suite);

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -134,8 +134,9 @@ class SignaturePublicKey
 {
 public:
   SignaturePublicKey();
-  SignaturePublicKey(SignatureScheme scheme, bytes data);
+  SignaturePublicKey(CipherSuite suite, bytes data);
 
+  void set_cipher_suite(CipherSuite suite);
   void set_signature_scheme(SignatureScheme scheme);
   SignatureScheme signature_scheme() const;
   bool verify(const bytes& message, const bytes& signature) const;
@@ -154,9 +155,9 @@ class SignaturePrivateKey
 public:
   SignaturePrivateKey();
 
-  static SignaturePrivateKey generate(SignatureScheme scheme);
-  static SignaturePrivateKey parse(SignatureScheme scheme, const bytes& data);
-  static SignaturePrivateKey derive(SignatureScheme scheme,
+  static SignaturePrivateKey generate(CipherSuite suite);
+  static SignaturePrivateKey parse(CipherSuite suite, const bytes& data);
+  static SignaturePrivateKey derive(CipherSuite suite,
                                     const bytes& secret);
 
   bytes sign(const bytes& message) const;
@@ -166,11 +167,12 @@ public:
   TLS_TRAITS(tls::pass, tls::vector<2>, tls::vector<2>)
 
 private:
+  CipherSuite _suite;
   SignatureScheme _scheme;
   bytes _data;
   bytes _pub_data;
 
-  SignaturePrivateKey(SignatureScheme scheme, const bytes& data);
+  SignaturePrivateKey(CipherSuite suite, const bytes& data);
 };
 
 } // namespace mls

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -93,7 +93,7 @@ template<CipherSuite CS>
 extern const CipherDetails cipher_details;
 
 template<>
-static const CipherDetails
+const CipherDetails
   cipher_details<CipherSuite::X25519_AES128GCM_SHA256_Ed25519>{
     32,
     16,
@@ -102,16 +102,15 @@ static const CipherDetails
   };
 
 template<>
-static const CipherDetails
-  cipher_details<CipherSuite::P256_AES128GCM_SHA256_P256>{
-    32,
-    16,
-    12,
-    SignatureScheme::P256_SHA256,
-  };
+const CipherDetails cipher_details<CipherSuite::P256_AES128GCM_SHA256_P256>{
+  32,
+  16,
+  12,
+  SignatureScheme::P256_SHA256,
+};
 
 template<>
-static const CipherDetails
+const CipherDetails
   cipher_details<CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519>{
     32,
     32,
@@ -120,25 +119,23 @@ static const CipherDetails
   };
 
 template<>
-static const CipherDetails
-  cipher_details<CipherSuite::X448_AES256GCM_SHA512_Ed448>{
-    64,
-    32,
-    12,
-    SignatureScheme::Ed448,
-  };
+const CipherDetails cipher_details<CipherSuite::X448_AES256GCM_SHA512_Ed448>{
+  64,
+  32,
+  12,
+  SignatureScheme::Ed448,
+};
 
 template<>
-static const CipherDetails
-  cipher_details<CipherSuite::P521_AES256GCM_SHA512_P521>{
-    64,
-    32,
-    12,
-    SignatureScheme::P521_SHA512,
-  };
+const CipherDetails cipher_details<CipherSuite::P521_AES256GCM_SHA512_P521>{
+  64,
+  32,
+  12,
+  SignatureScheme::P521_SHA512,
+};
 
 template<>
-static const CipherDetails
+const CipherDetails
   cipher_details<CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448>{
     64,
     32,

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -89,59 +89,77 @@ const std::array<CipherSuite, 6> all_supported_suites = {
   CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448,
 };
 
-SignatureScheme
-suite_signature_scheme(CipherSuite suite)
+template<CipherSuite CS>
+extern const CipherDetails cipher_details;
+
+template<>
+static const CipherDetails
+  cipher_details<CipherSuite::X25519_AES128GCM_SHA256_Ed25519>{
+    32,
+    16,
+    12,
+    SignatureScheme::Ed25519,
+  };
+
+template<>
+static const CipherDetails
+  cipher_details<CipherSuite::P256_AES128GCM_SHA256_P256>{
+    32,
+    16,
+    12,
+    SignatureScheme::P256_SHA256,
+  };
+
+template<>
+static const CipherDetails
+  cipher_details<CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519>{
+    32,
+    16,
+    12,
+    SignatureScheme::Ed25519,
+  };
+
+template<>
+static const CipherDetails
+  cipher_details<CipherSuite::X448_AES256GCM_SHA512_Ed448>{
+    64,
+    32,
+    12,
+    SignatureScheme::Ed448,
+  };
+
+template<>
+static const CipherDetails
+  cipher_details<CipherSuite::P521_AES256GCM_SHA512_P521>{
+    64,
+    32,
+    12,
+    SignatureScheme::P521_SHA512,
+  };
+
+template<>
+static const CipherDetails
+  cipher_details<CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448>{
+    64,
+    32,
+    12,
+    SignatureScheme::Ed448,
+  };
+
+#define CIPHER_DETAILS_CASE(suite)                                             \
+  case CipherSuite::suite:                                                     \
+    return cipher_details<CipherSuite::suite>;
+
+inline const CipherDetails&
+CipherDetails::get(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
-    case CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519:
-      return SignatureScheme::Ed25519;
-
-    case CipherSuite::P256_AES128GCM_SHA256_P256:
-      return SignatureScheme::P256_SHA256;
-
-    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
-    case CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448:
-      return SignatureScheme::Ed448;
-
-    case CipherSuite::P521_AES256GCM_SHA512_P521:
-      return SignatureScheme::P521_SHA512;
-
-    default:
-      throw InvalidParameterError("Unsupported ciphersuite");
-  }
-}
-
-size_t
-suite_nonce_size(CipherSuite suite)
-{
-  switch (suite) {
-    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
-    case CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519:
-    case CipherSuite::P256_AES128GCM_SHA256_P256:
-    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
-    case CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448:
-    case CipherSuite::P521_AES256GCM_SHA512_P521:
-      return 12;
-
-    default:
-      throw InvalidParameterError("Unsupported ciphersuite");
-  }
-}
-
-size_t
-suite_key_size(CipherSuite suite)
-{
-  switch (suite) {
-    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
-    case CipherSuite::P256_AES128GCM_SHA256_P256:
-      return 16;
-
-    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
-    case CipherSuite::P521_AES256GCM_SHA512_P521:
-    case CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519:
-    case CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448:
-      return 32;
+    CIPHER_DETAILS_CASE(X25519_AES128GCM_SHA256_Ed25519)
+    CIPHER_DETAILS_CASE(P256_AES128GCM_SHA256_P256)
+    CIPHER_DETAILS_CASE(X25519_CHACHA20POLY1305_SHA256_Ed25519)
+    CIPHER_DETAILS_CASE(X448_AES256GCM_SHA512_Ed448)
+    CIPHER_DETAILS_CASE(P521_AES256GCM_SHA512_P521)
+    CIPHER_DETAILS_CASE(X448_CHACHA20POLY1305_SHA512_Ed448)
 
     default:
       throw InvalidParameterError("Unsupported ciphersuite");

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -80,6 +80,13 @@ operator<<(std::ostream& out, const bytes& data)
   return out << to_hex(abbrev) << "...";
 }
 
+const std::array<CipherSuite, 4> all_supported_suites = {
+  CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
+  CipherSuite::P256_AES128GCM_SHA256_P256,
+  CipherSuite::X448_AES256GCM_SHA512_Ed448,
+  CipherSuite::P521_AES256GCM_SHA512_P521,
+};
+
 SignatureScheme
 suite_signature_scheme(CipherSuite suite)
 {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -80,11 +80,13 @@ operator<<(std::ostream& out, const bytes& data)
   return out << to_hex(abbrev) << "...";
 }
 
-const std::array<CipherSuite, 4> all_supported_suites = {
+const std::array<CipherSuite, 6> all_supported_suites = {
   CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
   CipherSuite::P256_AES128GCM_SHA256_P256,
+  CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519,
   CipherSuite::X448_AES256GCM_SHA512_Ed448,
   CipherSuite::P521_AES256GCM_SHA512_P521,
+  CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448,
 };
 
 SignatureScheme
@@ -92,11 +94,16 @@ suite_signature_scheme(CipherSuite suite)
 {
   switch (suite) {
     case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
+    case CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519:
       return SignatureScheme::Ed25519;
+
     case CipherSuite::P256_AES128GCM_SHA256_P256:
       return SignatureScheme::P256_SHA256;
+
     case CipherSuite::X448_AES256GCM_SHA512_Ed448:
+    case CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448:
       return SignatureScheme::Ed448;
+
     case CipherSuite::P521_AES256GCM_SHA512_P521:
       return SignatureScheme::P521_SHA512;
 
@@ -110,8 +117,10 @@ suite_nonce_size(CipherSuite suite)
 {
   switch (suite) {
     case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
+    case CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519:
     case CipherSuite::P256_AES128GCM_SHA256_P256:
     case CipherSuite::X448_AES256GCM_SHA512_Ed448:
+    case CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448:
     case CipherSuite::P521_AES256GCM_SHA512_P521:
       return 12;
 
@@ -130,6 +139,8 @@ suite_key_size(CipherSuite suite)
 
     case CipherSuite::X448_AES256GCM_SHA512_Ed448:
     case CipherSuite::P521_AES256GCM_SHA512_P521:
+    case CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519:
+    case CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448:
       return 32;
 
     default:

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -114,7 +114,7 @@ template<>
 static const CipherDetails
   cipher_details<CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519>{
     32,
-    16,
+    32,
     12,
     SignatureScheme::Ed25519,
   };
@@ -150,7 +150,7 @@ static const CipherDetails
   case CipherSuite::suite:                                                     \
     return cipher_details<CipherSuite::suite>;
 
-inline const CipherDetails&
+const CipherDetails&
 CipherDetails::get(CipherSuite suite)
 {
   switch (suite) {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -80,14 +80,32 @@ operator<<(std::ostream& out, const bytes& data)
   return out << to_hex(abbrev) << "...";
 }
 
+SignatureScheme
+suite_signature_scheme(CipherSuite suite)
+{
+  switch (suite) {
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
+      return SignatureScheme::Ed25519;
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
+      return SignatureScheme::P256_SHA256;
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
+      return SignatureScheme::Ed448;
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
+      return SignatureScheme::P521_SHA512;
+
+    default:
+      throw InvalidParameterError("Unsupported ciphersuite");
+  }
+}
+
 size_t
 suite_nonce_size(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::P256_SHA256_AES128GCM:
-    case CipherSuite::P521_SHA512_AES256GCM:
-    case CipherSuite::X25519_SHA256_AES128GCM:
-    case CipherSuite::X448_SHA512_AES256GCM:
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
       return 12;
 
     default:
@@ -99,12 +117,12 @@ size_t
 suite_key_size(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::P256_SHA256_AES128GCM:
-    case CipherSuite::X25519_SHA256_AES128GCM:
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
       return 16;
 
-    case CipherSuite::P521_SHA512_AES256GCM:
-    case CipherSuite::X448_SHA512_AES256GCM:
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
       return 32;
 
     default:

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -452,7 +452,8 @@ SignaturePublicKey::verify(const bytes& message, const bytes& signature) const
 }
 
 SignaturePrivateKey::SignaturePrivateKey()
-  : _scheme(SignatureScheme::unknown)
+  : _suite(CipherSuite::unknown)
+  , _scheme(SignatureScheme::unknown)
 {}
 
 SignaturePrivateKey

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -1,5 +1,6 @@
 #include "crypto.h"
 
+#include <iostream>
 #include <string>
 
 namespace mls {
@@ -356,8 +357,9 @@ HPKEPublicKey::encrypt(CipherSuite suite,
   auto [enc, zz] = dhkem_encap(suite, data, seed);
   auto [key, nonce] = hpke_key_schedule(suite, *this, enc, zz);
 
-  // Context.Encrypt
   auto ct = primitive::seal(suite, key, nonce, aad, pt);
+
+  // Context.Encrypt
   return HPKECiphertext{ enc, ct };
 }
 

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -416,8 +416,8 @@ SignaturePublicKey::SignaturePublicKey()
   : _scheme(SignatureScheme::unknown)
 {}
 
-SignaturePublicKey::SignaturePublicKey(SignatureScheme scheme, bytes data)
-  : _scheme(scheme)
+SignaturePublicKey::SignaturePublicKey(CipherSuite suite, bytes data)
+  : _scheme(suite_signature_scheme(suite))
   , _data(std::move(data))
 {}
 
@@ -425,6 +425,12 @@ void
 SignaturePublicKey::set_signature_scheme(SignatureScheme scheme)
 {
   _scheme = scheme;
+}
+
+void
+SignaturePublicKey::set_cipher_suite(CipherSuite suite)
+{
+  _scheme = suite_signature_scheme(suite);
 }
 
 SignatureScheme
@@ -450,21 +456,23 @@ SignaturePrivateKey::SignaturePrivateKey()
 {}
 
 SignaturePrivateKey
-SignaturePrivateKey::generate(SignatureScheme scheme)
+SignaturePrivateKey::generate(CipherSuite suite)
 {
-  return SignaturePrivateKey(scheme, primitive::generate(scheme));
+  auto scheme = suite_signature_scheme(suite);
+  return SignaturePrivateKey(suite, primitive::generate(scheme));
 }
 
 SignaturePrivateKey
-SignaturePrivateKey::parse(SignatureScheme scheme, const bytes& data)
+SignaturePrivateKey::parse(CipherSuite suite, const bytes& data)
 {
-  return SignaturePrivateKey(scheme, data);
+  return SignaturePrivateKey(suite, data);
 }
 
 SignaturePrivateKey
-SignaturePrivateKey::derive(SignatureScheme scheme, const bytes& secret)
+SignaturePrivateKey::derive(CipherSuite suite, const bytes& secret)
 {
-  return SignaturePrivateKey(scheme, primitive::derive(scheme, secret));
+  auto scheme = suite_signature_scheme(suite);
+  return SignaturePrivateKey(suite, primitive::derive(scheme, secret));
 }
 
 bytes
@@ -476,14 +484,14 @@ SignaturePrivateKey::sign(const bytes& message) const
 SignaturePublicKey
 SignaturePrivateKey::public_key() const
 {
-  return SignaturePublicKey(_scheme, _pub_data);
+  return SignaturePublicKey(_suite, _pub_data);
 }
 
-SignaturePrivateKey::SignaturePrivateKey(SignatureScheme scheme,
-                                         const bytes& data)
-  : _scheme(scheme)
+SignaturePrivateKey::SignaturePrivateKey(CipherSuite suite, const bytes& data)
+  : _suite(suite)
+  , _scheme(suite_signature_scheme(suite))
   , _data(data)
-  , _pub_data(primitive::priv_to_pub(scheme, data))
+  , _pub_data(primitive::priv_to_pub(_scheme, data))
 {}
 
 } // namespace mls

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -303,9 +303,9 @@ hpke_key_schedule(CipherSuite suite,
 {
   auto [kem, kdf, aead] = hpke_suite(suite);
   auto Npk = hpke_npk(kem);
-  auto Nh = Digest(suite).output_size();
-  auto Nk = suite_key_size(suite);
-  auto Nn = suite_nonce_size(suite);
+  auto Nh = CipherDetails::get(suite).secret_size;
+  auto Nk = CipherDetails::get(suite).key_size;
+  auto Nn = CipherDetails::get(suite).nonce_size;
 
   // We only support base and no-info.  So we can hard-wire these inputs, and
   // skip VerifyMode().  We will need to generalize if we support other modes or
@@ -419,7 +419,7 @@ SignaturePublicKey::SignaturePublicKey()
 {}
 
 SignaturePublicKey::SignaturePublicKey(CipherSuite suite, bytes data)
-  : _scheme(suite_signature_scheme(suite))
+  : _scheme(CipherDetails::get(suite).scheme)
   , _data(std::move(data))
 {}
 
@@ -432,7 +432,7 @@ SignaturePublicKey::set_signature_scheme(SignatureScheme scheme)
 void
 SignaturePublicKey::set_cipher_suite(CipherSuite suite)
 {
-  _scheme = suite_signature_scheme(suite);
+  _scheme = CipherDetails::get(suite).scheme;
 }
 
 SignatureScheme
@@ -461,7 +461,7 @@ SignaturePrivateKey::SignaturePrivateKey()
 SignaturePrivateKey
 SignaturePrivateKey::generate(CipherSuite suite)
 {
-  auto scheme = suite_signature_scheme(suite);
+  auto scheme = CipherDetails::get(suite).scheme;
   return SignaturePrivateKey(suite, primitive::generate(scheme));
 }
 
@@ -474,7 +474,7 @@ SignaturePrivateKey::parse(CipherSuite suite, const bytes& data)
 SignaturePrivateKey
 SignaturePrivateKey::derive(CipherSuite suite, const bytes& secret)
 {
-  auto scheme = suite_signature_scheme(suite);
+  auto scheme = CipherDetails::get(suite).scheme;
   return SignaturePrivateKey(suite, primitive::derive(scheme, secret));
 }
 
@@ -492,7 +492,7 @@ SignaturePrivateKey::public_key() const
 
 SignaturePrivateKey::SignaturePrivateKey(CipherSuite suite, const bytes& data)
   : _suite(suite)
-  , _scheme(suite_signature_scheme(suite))
+  , _scheme(CipherDetails::get(suite).scheme)
   , _data(data)
   , _pub_data(primitive::priv_to_pub(_scheme, data))
 {}

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -224,11 +224,13 @@ hpke_suite(CipherSuite suite)
         HPKEKEMID::DHKEM_P521, HPKEKDFID::HKDF_SHA512, HPKEAEADID::AES_GCM_256);
 
     case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
+    case CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519:
       return std::make_tuple(HPKEKEMID::DHKEM_X25519,
                              HPKEKDFID::HKDF_SHA256,
                              HPKEAEADID::AES_GCM_128);
 
     case CipherSuite::X448_AES256GCM_SHA512_Ed448:
+    case CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448:
       return std::make_tuple(
         HPKEKEMID::DHKEM_X448, HPKEKDFID::HKDF_SHA512, HPKEAEADID::AES_GCM_256);
 

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -215,20 +215,20 @@ static std::tuple<HPKEKEMID, HPKEKDFID, HPKEAEADID>
 hpke_suite(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::P256_SHA256_AES128GCM:
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
       return std::make_tuple(
         HPKEKEMID::DHKEM_P256, HPKEKDFID::HKDF_SHA256, HPKEAEADID::AES_GCM_128);
 
-    case CipherSuite::P521_SHA512_AES256GCM:
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
       return std::make_tuple(
         HPKEKEMID::DHKEM_P521, HPKEKDFID::HKDF_SHA512, HPKEAEADID::AES_GCM_256);
 
-    case CipherSuite::X25519_SHA256_AES128GCM:
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
       return std::make_tuple(HPKEKEMID::DHKEM_X25519,
                              HPKEKDFID::HKDF_SHA256,
                              HPKEAEADID::AES_GCM_128);
 
-    case CipherSuite::X448_SHA512_AES256GCM:
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
       return std::make_tuple(
         HPKEKEMID::DHKEM_X448, HPKEKDFID::HKDF_SHA512, HPKEAEADID::AES_GCM_256);
 

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -62,9 +62,9 @@ HashRatchet::HashRatchet(CipherSuite suite_in,
   , node(node_in)
   , next_secret(std::move(base_secret_in))
   , next_generation(0)
-  , key_size(suite_key_size(suite_in))
-  , nonce_size(suite_nonce_size(suite_in))
-  , secret_size(Digest(suite).output_size())
+  , key_size(CipherDetails::get(suite_in).key_size)
+  , nonce_size(CipherDetails::get(suite_in).nonce_size)
+  , secret_size(CipherDetails::get(suite_in).secret_size)
 {}
 
 std::tuple<uint32_t, KeyAndNonce>
@@ -130,7 +130,7 @@ HashRatchet::erase(uint32_t generation)
 
 BaseKeySource::BaseKeySource(CipherSuite suite_in)
   : suite(suite_in)
-  , secret_size(Digest(suite).output_size())
+  , secret_size(CipherDetails::get(suite_in).secret_size)
 {}
 
 struct NoFSBaseKeySource : public BaseKeySource
@@ -165,7 +165,7 @@ struct TreeBaseKeySource : public BaseKeySource
     , root(tree_math::root(NodeCount{ group_size }))
     , width(NodeCount{ group_size })
     , secrets(NodeCount{ group_size }.val)
-    , secret_size(Digest(suite_in).output_size())
+    , secret_size(CipherDetails::get(suite_in).secret_size)
   {
     secrets[root.val] = std::move(application_secret_in);
   }
@@ -301,7 +301,7 @@ KeyScheduleEpoch::create(CipherSuite suite,
     derive_secret(suite, epoch_secret, "confirm", context);
   auto init_secret = derive_secret(suite, epoch_secret, "init", context);
 
-  auto key_size = suite_key_size(suite);
+  auto key_size = CipherDetails::get(suite).key_size;
   auto sender_data_key =
     hkdf_expand_label(suite, sender_data_secret, "sd key", {}, key_size);
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -126,14 +126,14 @@ Welcome::decrypt(const bytes& epoch_secret) const
 std::tuple<bytes, bytes>
 Welcome::group_info_key_nonce(const bytes& epoch_secret) const
 {
-  auto key_size = suite_key_size(cipher_suite);
-  auto nonce_size = suite_nonce_size(cipher_suite);
-  auto secret_size = Digest(cipher_suite).output_size();
+  auto details = CipherDetails::get(cipher_suite);
 
   auto secret = hkdf_expand_label(
-    cipher_suite, epoch_secret, "group info", {}, secret_size);
-  auto key = hkdf_expand_label(cipher_suite, secret, "key", {}, key_size);
-  auto nonce = hkdf_expand_label(cipher_suite, secret, "nonce", {}, nonce_size);
+    cipher_suite, epoch_secret, "group info", {}, details.secret_size);
+  auto key =
+    hkdf_expand_label(cipher_suite, secret, "key", {}, details.key_size);
+  auto nonce =
+    hkdf_expand_label(cipher_suite, secret, "nonce", {}, details.nonce_size);
 
   return std::make_tuple(key, nonce);
 }

--- a/src/primitives.cpp
+++ b/src/primitives.cpp
@@ -348,7 +348,7 @@ open(CipherSuite suite,
 {
   auto tag_size = openssl_tag_size(suite);
   if (ciphertext.size() < tag_size) {
-    throw InvalidParameterError("AES-GCM ciphertext smaller than tag size");
+    throw InvalidParameterError("AEAD ciphertext smaller than tag size");
   }
 
   auto ctx = make_typed_unique(EVP_CIPHER_CTX_new());
@@ -387,7 +387,7 @@ open(CipherSuite suite,
   // Providing nullptr as an argument is safe here because this
   // function never writes with GCM; it only verifies the tag
   if (1 != EVP_DecryptFinal(ctx.get(), nullptr, &out_size)) {
-    throw InvalidParameterError("AES-GCM authentication failure");
+    throw InvalidParameterError("AEAD authentication failure");
   }
 
   return plaintext;

--- a/src/primitives.cpp
+++ b/src/primitives.cpp
@@ -139,12 +139,12 @@ static const EVP_MD*
 openssl_digest_type(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::P256_SHA256_AES128GCM:
-    case CipherSuite::X25519_SHA256_AES128GCM:
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
       return EVP_sha256();
 
-    case CipherSuite::P521_SHA512_AES256GCM:
-    case CipherSuite::X448_SHA512_AES256GCM:
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
       return EVP_sha512();
 
     default:
@@ -253,12 +253,12 @@ static const EVP_CIPHER*
 openssl_cipher(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::P256_SHA256_AES128GCM:
-    case CipherSuite::X25519_SHA256_AES128GCM:
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
       return EVP_aes_128_gcm();
 
-    case CipherSuite::P521_SHA512_AES256GCM:
-    case CipherSuite::X448_SHA512_AES256GCM:
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
       return EVP_aes_256_gcm();
 
     default:
@@ -270,10 +270,10 @@ static size_t
 openssl_tag_size(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::P256_SHA256_AES128GCM:
-    case CipherSuite::P521_SHA512_AES256GCM:
-    case CipherSuite::X25519_SHA256_AES128GCM:
-    case CipherSuite::X448_SHA512_AES256GCM:
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
       return 16;
 
     default:
@@ -407,13 +407,13 @@ OpenSSLKeyType
 ossl_key_type(CipherSuite suite)
 {
   switch (suite) {
-    case CipherSuite::P256_SHA256_AES128GCM:
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
       return OpenSSLKeyType::P256;
-    case CipherSuite::P521_SHA512_AES256GCM:
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
       return OpenSSLKeyType::P521;
-    case CipherSuite::X25519_SHA256_AES128GCM:
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
       return OpenSSLKeyType::X25519;
-    case CipherSuite::X448_SHA512_AES256GCM:
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
       return OpenSSLKeyType::X448;
     default:
       throw InvalidParameterError("Unknown ciphersuite");
@@ -729,15 +729,16 @@ public:
 
   void set_secret(const bytes& data) override
   {
+    // Choose a suite that will result in the right hash algorithm
     CipherSuite ersatz_suite;
     switch (static_cast<RawKeyType>(_type)) {
       case RawKeyType::X25519:
       case RawKeyType::Ed25519:
-        ersatz_suite = CipherSuite::P256_SHA256_AES128GCM;
+        ersatz_suite = CipherSuite::P256_AES128GCM_SHA256_P256;
         break;
       case RawKeyType::X448:
       case RawKeyType::Ed448:
-        ersatz_suite = CipherSuite::P521_SHA512_AES256GCM;
+        ersatz_suite = CipherSuite::P521_AES256GCM_SHA512_P521;
         break;
       default:
         throw InvalidParameterError("set_secret not supported");
@@ -863,13 +864,14 @@ public:
 
   void set_secret(const bytes& data) override
   {
+    // Choose a suite that will result in the right hash algorithm
     CipherSuite ersatz_suite;
     switch (static_cast<ECKeyType>(_curve_nid)) {
       case ECKeyType::P256:
-        ersatz_suite = CipherSuite::P256_SHA256_AES128GCM;
+        ersatz_suite = CipherSuite::P256_AES128GCM_SHA256_P256;
         break;
       case ECKeyType::P521:
-        ersatz_suite = CipherSuite::P521_SHA512_AES256GCM;
+        ersatz_suite = CipherSuite::P521_AES256GCM_SHA512_P521;
         break;
       default:
         throw InvalidParameterError("set_secret not supported");

--- a/src/primitives.cpp
+++ b/src/primitives.cpp
@@ -141,10 +141,12 @@ openssl_digest_type(CipherSuite suite)
   switch (suite) {
     case CipherSuite::P256_AES128GCM_SHA256_P256:
     case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
+    case CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519:
       return EVP_sha256();
 
     case CipherSuite::P521_AES256GCM_SHA512_P521:
     case CipherSuite::X448_AES256GCM_SHA512_Ed448:
+    case CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448:
       return EVP_sha512();
 
     default:
@@ -261,6 +263,10 @@ openssl_cipher(CipherSuite suite)
     case CipherSuite::X448_AES256GCM_SHA512_Ed448:
       return EVP_aes_256_gcm();
 
+    case CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519:
+    case CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448:
+      return EVP_chacha20_poly1305();
+
     default:
       throw InvalidParameterError("Unsupported ciphersuite");
   }
@@ -274,6 +280,8 @@ openssl_tag_size(CipherSuite suite)
     case CipherSuite::P521_AES256GCM_SHA512_P521:
     case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
     case CipherSuite::X448_AES256GCM_SHA512_Ed448:
+    case CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519:
+    case CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448:
       return 16;
 
     default:
@@ -412,8 +420,10 @@ ossl_key_type(CipherSuite suite)
     case CipherSuite::P521_AES256GCM_SHA512_P521:
       return OpenSSLKeyType::P521;
     case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
+    case CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519:
       return OpenSSLKeyType::X25519;
     case CipherSuite::X448_AES256GCM_SHA512_Ed448:
+    case CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448:
       return OpenSSLKeyType::X448;
     default:
       throw InvalidParameterError("Unknown ciphersuite");

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -570,7 +570,7 @@ State::encrypt(const MLSPlaintext& pt)
   tls::ostream sender_data;
   sender_data << _index << generation;
 
-  auto sender_data_nonce = random_bytes(suite_nonce_size(_suite));
+  auto sender_data_nonce = random_bytes(CipherDetails::get(_suite).nonce_size);
   auto sender_data_aad_val =
     sender_data_aad(_group_id, _epoch, content_type, sender_data_nonce);
 

--- a/test/credential_test.cpp
+++ b/test/credential_test.cpp
@@ -5,10 +5,10 @@ using namespace mls;
 
 TEST(CredentialTest, Basic)
 {
-  auto scheme = SignatureScheme::P256_SHA256;
+  auto suite = CipherSuite::P256_AES128GCM_SHA256_P256;
 
   auto user_id = bytes{ 0x00, 0x01, 0x02, 0x03 };
-  auto priv = SignaturePrivateKey::generate(scheme);
+  auto priv = SignaturePrivateKey::generate(suite);
   auto pub = priv.public_key();
 
   auto cred = Credential::basic(user_id, pub);

--- a/test/crypto_test.cpp
+++ b/test/crypto_test.cpp
@@ -26,36 +26,6 @@ protected:
     from_hex("204a8fc6dda82f0a0ced7beb8e08a41657c16ef468b228a8279be331a703c3359"
              "6fd15c13b1b07f9aa1d3bea57789ca031ad85c7a71dd70354ec631238ca3445");
 
-  // AES-GCM
-  // https://tools.ietf.org/html/draft-mcgrew-gcm-test-01#section-4
-  const bytes aes128gcm_key = from_hex("4c80cdefbb5d10da906ac73c3613a634");
-  const bytes aes128gcm_nonce = from_hex("2e443b684956ed7e3b244cfe");
-  const bytes aes128gcm_aad = from_hex("000043218765432100000000");
-  const bytes aes128gcm_pt = from_hex("45000048699a000080114db7c0a80102"
-                                      "c0a801010a9bf15638d3010000010000"
-                                      "00000000045f736970045f7564700373"
-                                      "69700963796265726369747902646b00"
-                                      "0021000101020201");
-  const bytes aes128gcm_ct = from_hex("fecf537e729d5b07dc30df528dd22b76"
-                                      "8d1b98736696a6fd348509fa13ceac34"
-                                      "cfa2436f14a3f3cf65925bf1f4a13c5d"
-                                      "15b21e1884f5ff6247aeabb786b93bce"
-                                      "61bc17d768fd9732459018148f6cbe72"
-                                      "2fd04796562dfdb4");
-  const bytes aes256gcm_key = from_hex("abbccddef00112233445566778899aab"
-                                       "abbccddef00112233445566778899aab");
-  const bytes aes256gcm_nonce = from_hex("112233440102030405060708");
-  const bytes aes256gcm_aad = from_hex("4a2cbfe300000002");
-  const bytes aes256gcm_pt = from_hex("4500003069a6400080062690c0a80102"
-                                      "9389155e0a9e008b2dc57ee000000000"
-                                      "7002400020bf0000020405b401010402"
-                                      "01020201");
-  const bytes aes256gcm_ct = from_hex("ff425c9b724599df7a3bcd510194e00d"
-                                      "6a78107f1b0b1cbf06efae9d65a5d763"
-                                      "748a637985771d347f0545659f14e99d"
-                                      "ef842d8eb335f4eecfdbf831824b4c49"
-                                      "15956c96");
-
   // DH with P-256
   // KASValidityTest_ECCEphemeralUnified_NOKC_ZZOnly_init.fax [EC]
   // http://csrc.nist.gov/groups/STM/cavp/documents/keymgmt/kastestvectors.zip
@@ -186,6 +156,84 @@ protected:
 
   const CryptoTestVectors& tv;
 
+  struct AEADTest
+  {
+    const CipherSuite suite;
+    const bytes key;
+    const bytes nonce;
+    const bytes aad;
+    const bytes pt;
+    const bytes ct;
+
+    void run() const
+    {
+      auto encrypted = primitive::seal(suite, key, nonce, aad, pt);
+      std::cout << "enc " << encrypted << std::endl;
+      std::cout << "kat " << ct << std::endl;
+
+      ASSERT_EQ(encrypted, ct);
+
+      auto decrypted = primitive::open(suite, key, nonce, aad, ct);
+      ASSERT_EQ(decrypted, pt);
+    }
+  };
+
+  // AES-GCM
+  // https://tools.ietf.org/html/draft-mcgrew-gcm-test-01#section-4
+  const AEADTest aes128gcm_test{
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    from_hex("4c80cdefbb5d10da906ac73c3613a634"),
+    from_hex("2e443b684956ed7e3b244cfe"),
+    from_hex("000043218765432100000000"),
+    from_hex("45000048699a000080114db7c0a80102c0a801010a9bf15638d3010000010000"
+             "00000000045f736970045f756470037369700963796265726369747902646b00"
+             "0021000101020201"),
+    from_hex("fecf537e729d5b07dc30df528dd22b768d1b98736696a6fd348509fa13ceac34"
+             "cfa2436f14a3f3cf65925bf1f4a13c5d15b21e1884f5ff6247aeabb786b93bce"
+             "61bc17d768fd9732459018148f6cbe722fd04796562dfdb4"),
+  };
+
+  const AEADTest aes256gcm_test{
+    CipherSuite::P521_AES256GCM_SHA512_P521,
+    from_hex(
+      "abbccddef00112233445566778899aababbccddef00112233445566778899aab"),
+    from_hex("112233440102030405060708"),
+    from_hex("4a2cbfe300000002"),
+    from_hex("4500003069a6400080062690c0a801029389155e0a9e008b2dc57ee000000000"
+             "7002400020bf0000020405b40101040201020201"),
+    from_hex("ff425c9b724599df7a3bcd510194e00d6a78107f1b0b1cbf06efae9d65a5d763"
+             "748a637985771d347f0545659f14e99def842d8eb335f4eecfdbf831824b4c49"
+             "15956c96"),
+  };
+
+  // ChaCha20-Poly1305
+  // https://tools.ietf.org/html/rfc8439#appendix-A.5
+  const AEADTest chacha_test{
+    CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519,
+    from_hex("1c9240a5eb55d38af333888604f6b5f0"
+             "473917c1402b80099dca5cbc207075c0"),
+    from_hex("000000000102030405060708"),
+    from_hex("f33388860000000000004e91"),
+    from_hex("496e7465726e65742d4472616674732061726520647261667420646f63756d65"
+             "6e74732076616c696420666f722061206d6178696d756d206f6620736978206d"
+             "6f6e74687320616e64206d617920626520757064617465642c207265706c6163"
+             "65642c206f72206f62736f6c65746564206279206f7468657220646f63756d65"
+             "6e747320617420616e792074696d652e20497420697320696e617070726f7072"
+             "6961746520746f2075736520496e7465726e65742d4472616674732061732072"
+             "65666572656e6365206d6174657269616c206f7220746f206369746520746865"
+             "6d206f74686572207468616e206173202fe2809c776f726b20696e2070726f67"
+             "726573732e2fe2809d"),
+    from_hex("64a0861575861af460f062c79be643bd5e805cfd345cf389f108670ac76c8cb2"
+             "4c6cfc18755d43eea09ee94e382d26b0bdb7b73c321b0100d4f03b7f355894cf"
+             "332f830e710b97ce98c8a84abd0b948114ad176e008d33bd60f982b1ff37c855"
+             "9797a06ef4f0ef61c186324e2b3506383606907b6a7c02b0f9f6157b53c867e4"
+             "b9166c767b804d46a59b5216cde7a4e99040c5a40433225ee282a1b0a06c523e"
+             "af4534d7f83fa1155b0047718cbc546a0d072b04b3564eea1b422273f548271a"
+             "0bb2316053fa76991955ebd63159434ecebb4e466dae5a1073a6727627097a10"
+             "49e617d91d361094fa68f0ff77987130305beaba2eda04df997b714d6c6f2c29"
+             "a6ad5cb4022b02709beead9d67890cbb22392336fea1851f38"),
+  };
+
   CryptoTest()
     : tv(TestLoader<CryptoTestVectors>::get())
   {}
@@ -227,57 +275,24 @@ TEST_F(CryptoTest, SHA2)
   ASSERT_EQ(metrics.digest, 1);
 }
 
-TEST_F(CryptoTest, AES128GCM)
+TEST_F(CryptoTest, KnownAnswerAEAD)
 {
-  auto suite = CipherSuite::P256_AES128GCM_SHA256_P256;
-
-  auto encrypted = primitive::seal(
-    suite, aes128gcm_key, aes128gcm_nonce, aes128gcm_aad, aes128gcm_pt);
-  ASSERT_EQ(encrypted, aes128gcm_ct);
-
-  auto decrypted = primitive::open(
-    suite, aes128gcm_key, aes128gcm_nonce, aes128gcm_aad, aes128gcm_ct);
-  ASSERT_EQ(decrypted, aes128gcm_pt);
-
-  auto rtt_key = random_bytes(CipherDetails::get(suite).key_size);
-  auto rtt_nonce = random_bytes(CipherDetails::get(suite).nonce_size);
-  auto rtt_aad = random_bytes(100);
-  auto rtt_pt = random_bytes(50);
-
-  auto rtt_encrypted =
-    primitive::seal(suite, rtt_key, rtt_nonce, rtt_aad, rtt_pt);
-  auto rtt_decrypted =
-    primitive::open(suite, rtt_key, rtt_nonce, rtt_aad, rtt_encrypted);
-  ASSERT_EQ(rtt_decrypted, rtt_pt);
-}
-
-TEST_F(CryptoTest, AES256GCM)
-{
-  auto suite = CipherSuite::P521_AES256GCM_SHA512_P521;
-
-  auto encrypted = primitive::seal(
-    suite, aes256gcm_key, aes256gcm_nonce, aes256gcm_aad, aes256gcm_pt);
-  ASSERT_EQ(encrypted, aes256gcm_ct);
-
-  auto decrypted = primitive::open(
-    suite, aes256gcm_key, aes256gcm_nonce, aes256gcm_aad, aes256gcm_ct);
-  ASSERT_EQ(decrypted, aes256gcm_pt);
-
-  auto rtt_key = random_bytes(CipherDetails::get(suite).key_size);
-  auto rtt_nonce = random_bytes(CipherDetails::get(suite).nonce_size);
-  auto rtt_aad = random_bytes(100);
-  auto rtt_pt = random_bytes(50);
-
-  auto rtt_encrypted =
-    primitive::seal(suite, rtt_key, rtt_nonce, rtt_aad, rtt_pt);
-  auto rtt_decrypted =
-    primitive::open(suite, rtt_key, rtt_nonce, rtt_aad, rtt_encrypted);
-  ASSERT_EQ(rtt_decrypted, rtt_pt);
+  aes128gcm_test.run();
+  aes256gcm_test.run();
+  chacha_test.run();
 }
 
 TEST_F(CryptoTest, RoundTripAEAD)
 {
   for (auto suite : all_supported_suites) {
+    auto key = random_bytes(CipherDetails::get(suite).key_size);
+    auto nonce = random_bytes(CipherDetails::get(suite).nonce_size);
+    auto aad = random_bytes(100);
+    auto pt = random_bytes(50);
+
+    auto encrypted = primitive::seal(suite, key, nonce, aad, pt);
+    auto decrypted = primitive::open(suite, key, nonce, aad, encrypted);
+    ASSERT_EQ(decrypted, pt);
   }
 }
 
@@ -303,17 +318,6 @@ TEST_F(CryptoTest, BasicDH)
     ASSERT_EQ(gX, gX);
     ASSERT_EQ(gY, gY);
     ASSERT_NE(gX, gY);
-
-    CryptoMetrics::reset();
-    auto se = gX.encrypt(suite, {}, s);
-    ASSERT_EQ(CryptoMetrics::snapshot().fixed_base_dh, 1);
-    ASSERT_EQ(CryptoMetrics::snapshot().var_base_dh, 1);
-
-    CryptoMetrics::reset();
-    auto sd = x.decrypt(suite, {}, se);
-    ASSERT_EQ(sd, s);
-    ASSERT_EQ(CryptoMetrics::snapshot().fixed_base_dh, 0);
-    ASSERT_EQ(CryptoMetrics::snapshot().var_base_dh, 1);
   }
 }
 
@@ -423,7 +427,6 @@ TEST_F(CryptoTest, BasicSignature)
 TEST_F(CryptoTest, SignatureSerialize)
 {
   for (auto suite : all_supported_suites) {
-    auto scheme = suite_signature_scheme(suite);
     auto x = SignaturePrivateKey::generate(suite);
     auto gX = x.public_key();
 
@@ -431,7 +434,7 @@ TEST_F(CryptoTest, SignatureSerialize)
     ASSERT_EQ(parsed, gX);
 
     auto gX2 = tls::get<SignaturePublicKey>(tls::marshal(gX));
-    gX2.set_signature_scheme(scheme);
+    gX2.set_cipher_suite(suite);
     ASSERT_EQ(gX2, gX);
   }
 }

--- a/test/crypto_test.cpp
+++ b/test/crypto_test.cpp
@@ -5,9 +5,6 @@
 
 using namespace mls;
 
-#define CIPHERSUITE CipherSuite::P256_SHA256_AES128GCM
-#define SIG_SCHEME SignatureScheme::P256_SHA256
-
 class CryptoTest : public ::testing::Test
 {
 protected:
@@ -216,8 +213,8 @@ TEST_F(CryptoTest, Interop)
 
 TEST_F(CryptoTest, SHA2)
 {
-  auto suite256 = CipherSuite::P256_SHA256_AES128GCM;
-  auto suite512 = CipherSuite::P521_SHA512_AES256GCM;
+  auto suite256 = CipherSuite::P256_AES128GCM_SHA256_P256;
+  auto suite512 = CipherSuite::P521_AES256GCM_SHA512_P521;
 
   CryptoMetrics::reset();
   ASSERT_EQ(Digest(suite256).write(sha2_in).digest(), sha256_out);
@@ -232,7 +229,7 @@ TEST_F(CryptoTest, SHA2)
 
 TEST_F(CryptoTest, AES128GCM)
 {
-  auto suite = CipherSuite::P256_SHA256_AES128GCM;
+  auto suite = CipherSuite::P256_AES128GCM_SHA256_P256;
 
   auto encrypted = primitive::seal(
     suite, aes128gcm_key, aes128gcm_nonce, aes128gcm_aad, aes128gcm_pt);
@@ -256,7 +253,7 @@ TEST_F(CryptoTest, AES128GCM)
 
 TEST_F(CryptoTest, AES256GCM)
 {
-  auto suite = CipherSuite::P521_SHA512_AES256GCM;
+  auto suite = CipherSuite::P521_AES256GCM_SHA512_P521;
 
   auto encrypted = primitive::seal(
     suite, aes256gcm_key, aes256gcm_nonce, aes256gcm_aad, aes256gcm_pt);
@@ -280,10 +277,10 @@ TEST_F(CryptoTest, AES256GCM)
 
 TEST_F(CryptoTest, BasicDH)
 {
-  std::vector<CipherSuite> suites{ CipherSuite::P256_SHA256_AES128GCM,
-                                   CipherSuite::P521_SHA512_AES256GCM,
-                                   CipherSuite::X25519_SHA256_AES128GCM,
-                                   CipherSuite::X448_SHA512_AES256GCM };
+  std::vector<CipherSuite> suites{ CipherSuite::P256_AES128GCM_SHA256_P256,
+                                   CipherSuite::P521_AES256GCM_SHA512_P521,
+                                   CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
+                                   CipherSuite::X448_AES256GCM_SHA512_Ed448 };
 
   for (auto suite : suites) {
     auto s = bytes{ 0, 1, 2, 3 };
@@ -321,10 +318,10 @@ TEST_F(CryptoTest, BasicDH)
 
 TEST_F(CryptoTest, DHSerialize)
 {
-  std::vector<CipherSuite> suites{ CipherSuite::P256_SHA256_AES128GCM,
-                                   CipherSuite::P521_SHA512_AES256GCM,
-                                   CipherSuite::X25519_SHA256_AES128GCM,
-                                   CipherSuite::X448_SHA512_AES256GCM };
+  std::vector<CipherSuite> suites{ CipherSuite::P256_AES128GCM_SHA256_P256,
+                                   CipherSuite::P521_AES256GCM_SHA512_P521,
+                                   CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
+                                   CipherSuite::X448_AES256GCM_SHA512_Ed448 };
 
   for (auto suite : suites) {
     auto x = HPKEPrivateKey::derive(suite, { 0, 1, 2, 3 });
@@ -340,7 +337,7 @@ TEST_F(CryptoTest, DHSerialize)
 
 TEST_F(CryptoTest, P256DH)
 {
-  auto suite = CipherSuite::P256_SHA256_AES128GCM;
+  auto suite = CipherSuite::P256_AES128GCM_SHA256_P256;
 
   auto pkA = primitive::priv_to_pub(suite, p256dh_skA);
   ASSERT_EQ(pkA, p256dh_pkA);
@@ -351,7 +348,7 @@ TEST_F(CryptoTest, P256DH)
 
 TEST_F(CryptoTest, P521DH)
 {
-  auto suite = CipherSuite::P521_SHA512_AES256GCM;
+  auto suite = CipherSuite::P521_AES256GCM_SHA512_P521;
 
   auto pkA = primitive::priv_to_pub(suite, p521dh_skA);
   ASSERT_EQ(pkA, p521dh_pkA);
@@ -362,7 +359,7 @@ TEST_F(CryptoTest, P521DH)
 
 TEST_F(CryptoTest, X25519)
 {
-  auto suite = CipherSuite::X25519_SHA256_AES128GCM;
+  auto suite = CipherSuite::X25519_AES128GCM_SHA256_Ed25519;
 
   auto pkA = primitive::priv_to_pub(suite, x25519_skA);
   auto pkB = primitive::priv_to_pub(suite, x25519_skB);
@@ -377,7 +374,7 @@ TEST_F(CryptoTest, X25519)
 
 TEST_F(CryptoTest, X448)
 {
-  auto suite = CipherSuite::X448_SHA512_AES256GCM;
+  auto suite = CipherSuite::X448_AES256GCM_SHA512_Ed448;
 
   auto pkA = primitive::priv_to_pub(suite, x448_skA);
   auto pkB = primitive::priv_to_pub(suite, x448_skB);
@@ -392,10 +389,10 @@ TEST_F(CryptoTest, X448)
 
 TEST_F(CryptoTest, HPKE)
 {
-  std::vector<CipherSuite> suites{ CipherSuite::P256_SHA256_AES128GCM,
-                                   CipherSuite::P521_SHA512_AES256GCM,
-                                   CipherSuite::X25519_SHA256_AES128GCM,
-                                   CipherSuite::X448_SHA512_AES256GCM };
+  std::vector<CipherSuite> suites{ CipherSuite::P256_AES128GCM_SHA256_P256,
+                                   CipherSuite::P521_AES256GCM_SHA512_P521,
+                                   CipherSuite::X25519_AES128GCM_SHA256_Ed25519,
+                                   CipherSuite::X448_AES256GCM_SHA512_Ed448 };
 
   auto aad = random_bytes(100);
   auto original = random_bytes(100);

--- a/test/crypto_test.cpp
+++ b/test/crypto_test.cpp
@@ -239,8 +239,8 @@ TEST_F(CryptoTest, AES128GCM)
     suite, aes128gcm_key, aes128gcm_nonce, aes128gcm_aad, aes128gcm_ct);
   ASSERT_EQ(decrypted, aes128gcm_pt);
 
-  auto rtt_key = random_bytes(suite_key_size(suite));
-  auto rtt_nonce = random_bytes(suite_nonce_size(suite));
+  auto rtt_key = random_bytes(CipherDetails::get(suite).key_size);
+  auto rtt_nonce = random_bytes(CipherDetails::get(suite).nonce_size);
   auto rtt_aad = random_bytes(100);
   auto rtt_pt = random_bytes(50);
 
@@ -263,8 +263,8 @@ TEST_F(CryptoTest, AES256GCM)
     suite, aes256gcm_key, aes256gcm_nonce, aes256gcm_aad, aes256gcm_ct);
   ASSERT_EQ(decrypted, aes256gcm_pt);
 
-  auto rtt_key = random_bytes(suite_key_size(suite));
-  auto rtt_nonce = random_bytes(suite_nonce_size(suite));
+  auto rtt_key = random_bytes(CipherDetails::get(suite).key_size);
+  auto rtt_nonce = random_bytes(CipherDetails::get(suite).nonce_size);
   auto rtt_aad = random_bytes(100);
   auto rtt_pt = random_bytes(50);
 
@@ -273,6 +273,12 @@ TEST_F(CryptoTest, AES256GCM)
   auto rtt_decrypted =
     primitive::open(suite, rtt_key, rtt_nonce, rtt_aad, rtt_encrypted);
   ASSERT_EQ(rtt_decrypted, rtt_pt);
+}
+
+TEST_F(CryptoTest, RoundTripAEAD)
+{
+  for (auto suite : all_supported_suites) {
+  }
 }
 
 TEST_F(CryptoTest, BasicDH)

--- a/test/messages_test.cpp
+++ b/test/messages_test.cpp
@@ -37,20 +37,18 @@ protected:
 TEST_F(MessagesTest, Interop)
 {
   for (const auto& tc : tv.cases) {
-    auto reproducible = deterministic_signature_scheme(tc.signature_scheme);
+    auto reproducible = deterministic_signature_scheme(tc.cipher_suite);
 
     // Miscellaneous data items we need to construct messages
     auto dh_priv = HPKEPrivateKey::derive(tc.cipher_suite, tv.dh_seed);
     auto dh_key = dh_priv.public_key();
-    auto sig_priv =
-      SignaturePrivateKey::derive(tc.signature_scheme, tv.sig_seed);
+    auto sig_priv = SignaturePrivateKey::derive(tc.cipher_suite, tv.sig_seed);
     auto sig_key = sig_priv.public_key();
     auto cred = Credential::basic(tv.user_id, sig_priv.public_key());
 
     DeterministicHPKE lock;
     auto tree =
       TestTreeKEMPublicKey{ tc.cipher_suite,
-                            tc.signature_scheme,
                             { tv.random, tv.random, tv.random, tv.random } };
     tree.blank_path(LeafIndex{ 2 });
 

--- a/test/session_test.cpp
+++ b/test/session_test.cpp
@@ -7,7 +7,7 @@ using namespace mls;
 class SessionTest : public ::testing::Test
 {
 protected:
-  const CipherSuite suite = CipherSuite::P256_SHA256_AES128GCM;
+  const CipherSuite suite = CipherSuite::P256_AES128GCM_SHA256_P256;
   const SignatureScheme scheme = SignatureScheme::Ed25519;
   const int group_size = 5;
   const size_t secret_size = 32;
@@ -147,8 +147,10 @@ TEST_F(SessionTest, CiphersuiteNegotiation)
   // Alice supports P-256 and X25519
   auto idA = new_identity_key();
   auto credA = Credential::basic(user_id, idA.public_key());
-  std::vector<CipherSuite> ciphersA{ CipherSuite::P256_SHA256_AES128GCM,
-                                     CipherSuite::X25519_SHA256_AES128GCM };
+  std::vector<CipherSuite> ciphersA{
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519
+  };
   std::vector<KeyPackage> kpsA;
   std::vector<Session::InitInfo> infosA;
   for (auto suiteA : ciphersA) {
@@ -163,8 +165,10 @@ TEST_F(SessionTest, CiphersuiteNegotiation)
   // Bob supports P-256 and P-521
   auto idB = new_identity_key();
   auto credB = Credential::basic(user_id, idB.public_key());
-  std::vector<CipherSuite> ciphersB{ CipherSuite::P256_SHA256_AES128GCM,
-                                     CipherSuite::X25519_SHA256_AES128GCM };
+  std::vector<CipherSuite> ciphersB{
+    CipherSuite::P256_AES128GCM_SHA256_P256,
+    CipherSuite::X25519_AES128GCM_SHA256_Ed25519
+  };
   std::vector<KeyPackage> kpsB;
   std::vector<Session::InitInfo> infosB;
   for (auto suiteB : ciphersB) {
@@ -182,7 +186,7 @@ TEST_F(SessionTest, CiphersuiteNegotiation)
   TestSession alice = std::get<0>(session_welcome_add);
   TestSession bob = Session::join(infosB, std::get<1>(session_welcome_add));
   ASSERT_EQ(alice, bob);
-  ASSERT_EQ(alice.cipher_suite(), CipherSuite::P256_SHA256_AES128GCM);
+  ASSERT_EQ(alice.cipher_suite(), CipherSuite::P256_AES128GCM_SHA256_P256);
 }
 
 class RunningSessionTest : public SessionTest

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -7,7 +7,7 @@ using namespace mls;
 class StateTest : public ::testing::Test
 {
 protected:
-  const CipherSuite suite = CipherSuite::P256_SHA256_AES128GCM;
+  const CipherSuite suite = CipherSuite::P256_AES128GCM_SHA256_P256;
   const SignatureScheme scheme = SignatureScheme::P256_SHA256;
 
   const size_t group_size = 5;

--- a/test/state_test.cpp
+++ b/test/state_test.cpp
@@ -8,7 +8,6 @@ class StateTest : public ::testing::Test
 {
 protected:
   const CipherSuite suite = CipherSuite::P256_AES128GCM_SHA256_P256;
-  const SignatureScheme scheme = SignatureScheme::P256_SHA256;
 
   const size_t group_size = 5;
   const bytes group_id = { 0, 1, 2, 3 };
@@ -24,7 +23,7 @@ protected:
   {
     for (size_t i = 0; i < group_size; i += 1) {
       auto init_secret = random_bytes(32);
-      auto identity_priv = SignaturePrivateKey::generate(scheme);
+      auto identity_priv = SignaturePrivateKey::generate(suite);
       auto credential = Credential::basic(user_id, identity_priv.public_key());
       auto init_priv = HPKEPrivateKey::derive(suite, init_secret);
       auto key_package =

--- a/test/test_vectors.cpp
+++ b/test/test_vectors.cpp
@@ -24,8 +24,7 @@ const std::string BasicSessionTestVectors::file_name = "./basic_session.bin";
 bool
 deterministic_signature_scheme(CipherSuite suite)
 {
-  auto scheme = suite_signature_scheme(suite);
-  switch (scheme) {
+  switch (CipherDetails::get(suite).scheme) {
     case SignatureScheme::P256_SHA256:
       return false;
     case SignatureScheme::P521_SHA512:

--- a/test/test_vectors.cpp
+++ b/test/test_vectors.cpp
@@ -22,8 +22,9 @@ const std::string BasicSessionTestVectors::file_name = "./basic_session.bin";
 ///
 
 bool
-deterministic_signature_scheme(SignatureScheme scheme)
+deterministic_signature_scheme(CipherSuite suite)
 {
+  auto scheme = suite_signature_scheme(suite);
   switch (scheme) {
     case SignatureScheme::P256_SHA256:
       return false;

--- a/test/treekem_test.cpp
+++ b/test/treekem_test.cpp
@@ -10,7 +10,6 @@ class TreeKEMTest : public ::testing::Test
 {
 protected:
   const CipherSuite suite = CipherSuite::P256_AES128GCM_SHA256_P256;
-  const SignatureScheme scheme = SignatureScheme::Ed25519;
 
   const TreeKEMTestVectors tv;
 
@@ -23,7 +22,7 @@ protected:
   {
     auto init_secret = random_bytes(32);
     auto init_priv = HPKEPrivateKey::derive(suite, init_secret);
-    auto sig_priv = SignaturePrivateKey::generate(scheme);
+    auto sig_priv = SignaturePrivateKey::generate(suite);
     auto cred = Credential::basic({ 0, 1, 2, 3 }, sig_priv.public_key());
     auto kp = KeyPackage{ suite, init_priv.public_key(), cred, sig_priv };
     return std::make_tuple(init_secret, init_priv, sig_priv, kp);
@@ -284,8 +283,8 @@ TEST_F(TreeKEMTest, Interop)
       auto context = bytes{ uint8_t(i), uint8_t(j) };
       auto init_priv =
         HPKEPrivateKey::derive(tc.cipher_suite, tv.init_secrets[j].data);
-      auto sig_priv = SignaturePrivateKey::derive(tc.signature_scheme,
-                                                  tv.init_secrets[j].data);
+      auto sig_priv =
+        SignaturePrivateKey::derive(tc.cipher_suite, tv.init_secrets[j].data);
       auto cred = Credential::basic(context, sig_priv.public_key());
       auto kp =
         KeyPackage{ tc.cipher_suite, init_priv.public_key(), cred, sig_priv };

--- a/test/treekem_test.cpp
+++ b/test/treekem_test.cpp
@@ -9,7 +9,7 @@ using namespace mls;
 class TreeKEMTest : public ::testing::Test
 {
 protected:
-  const CipherSuite suite = CipherSuite::P256_SHA256_AES128GCM;
+  const CipherSuite suite = CipherSuite::P256_AES128GCM_SHA256_P256;
   const SignatureScheme scheme = SignatureScheme::Ed25519;
 
   const TreeKEMTestVectors tv;


### PR DESCRIPTION
This PR adds support for ciphersuites that use Chacha20-Poly1305 for their AEAD.  In addition, it does some aesthetic cleanup on (a) how cipher details are managed, and (b) how crypto tests are structured.

Depends on #90 