### PR TITLE
Add clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,16 @@
+---
+Checks:            '*,
+                    -fuchsia-*,
+                    -google-runtime-references,
+                    -hicpp-no-assembler,
+                    -readability-magic-numbers,
+                    -cppcoreguidelines-avoid-magic-numbers,
+                    -modernize-use-trailing-return-type,
+                    -cppcoreguidelines-non-private-member-variables-in-classes,
+                    -misc-non-private-member-variables-in-classes,
+                    -modernize-use-nodiscard,
+                    -google-build-using-namespace,
+                    -cert-err58-cpp,
+                    '
+WarningsAsErrors:  '*'
+HeaderFilterRegex: '*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,9 @@ jobs:
         brew install pkgconfig doctest
         brew reinstall openssl
 
+    - name: configure to use clang-tidy
+      run: make tidy
+
     - name: build
       run: make everything
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(mlspp
   LANGUAGES CXX
 )
 
+option(CLANG_TIDY "Perform linting with clang-tidy" OFF)
+
 ###
 ### Dependencies
 ###
@@ -21,6 +23,15 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
   add_compile_options(-Wall -pedantic -Wextra -Werror)
 elseif(MSVC)
   add_compile_options(/W4 /WX)
+endif()
+
+if(CLANG_TIDY)
+  find_program(CLANG_TIDY_EXE NAMES "clang-tidy")
+  if(CLANG_TIDY_EXE)
+    set(CMAKE_CXX_CLANG_TIDY  ${CLANG_TIDY_EXE})
+  else()
+    message(WARNING "clang-tidy requested, but not found")
+  endif()
 endif()
 
 ###

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # This is just a convenience Makefile to avoid having to remember
 # all the CMake commands and their arguments.
 
-# Set CMAKE_GENERATOR to choose how you build, e.g.:
+# Set CMAKE_GENERATOR in the environment to select how you build, e.g.:
 #   CMAKE_GENERATOR=Ninja
 
 BUILD_DIR=build
@@ -10,13 +10,16 @@ CLANG_FORMAT=clang-format -i
 TEST_VECTOR_DIR=./build/test
 TEST_GEN=./build/cmd/test_gen/test_gen
 
-.PHONY: all test gen example clean cclean format
+.PHONY: all tidy test gen example everything clean cclean format
 
 all: ${BUILD_DIR}
 	cmake --build ${BUILD_DIR} --target mlspp
 
 ${BUILD_DIR}: CMakeLists.txt test/CMakeLists.txt cmd/CMakeLists.txt
-	cmake -H. -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug
+	cmake -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug .
+
+tidy:
+	cmake -B${BUILD_DIR} -DCLANG_TIDY=ON -DCMAKE_BUILD_TYPE=Debug .
 
 test: ${BUILD_DIR} test/*
 	cmake --build ${BUILD_DIR} --target mlspp_test
@@ -31,7 +34,7 @@ example: ${BUILD_DIR}
 	cmake --build ${BUILD_DIR} --target api_example
 	./build/cmd/api_example/api_example
 
-everything: ${BUILD_DIR}
+everything:
 	cmake --build ${BUILD_DIR}
 
 clean:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 MLS++
 =====
 
-Draft implementation of the proposed [Messaging Layer
+Implementation of the proposed [Messaging Layer
 Security](https://github.com/ekr/mls-protocol/blob/master/draft-barnes-mls-protocol.md)
-protocol in C++.  Depends on C++14 STL for data structures and
+protocol in C++.  Depends on C++17, STL for data structures, and
 OpenSSL for crypto.
 
 
@@ -13,7 +13,6 @@ Quickstart
 Using the convenient Makefile that wraps CMake:
 
 ```
-> git submodule update --init
 > make
 > make test
 ```
@@ -23,9 +22,6 @@ Conventions
 
 * Following Mozilla `clang-format` style.  If you use the top-level
   Makefile (as suggested above), it will auto-format for you.
-* For convenience, the following shortcuts are available:
-  * `std::experimental::optional<T>` as `mls::optional<T>`
-  * `std::vector<uint8_t>` as `bytes`
 * General naming conventions:
   * Camel case for classes (`RatchetNode`)
   * Snake case for variables, functions, members (`derive_epoch_keys`)

--- a/cmd/api_example/main.cpp
+++ b/cmd/api_example/main.cpp
@@ -14,7 +14,7 @@ const auto suite = CipherSuite::X25519_AES128GCM_SHA256_Ed25519;
 class User
 {
 public:
-  User(const std::string& name)
+  explicit User(const std::string& name)
   {
     _identity_priv = SignaturePrivateKey::generate(suite);
     auto id = bytes(name.begin(), name.end());
@@ -45,7 +45,7 @@ private:
 };
 
 void
-verify_send(std::string label, Session& send, Session& recv)
+verify_send(const std::string& label, Session& send, Session& recv)
 {
   auto plaintext = bytes{ 0, 1, 2, 3 };
   auto encrypted = send.protect(plaintext);
@@ -56,7 +56,7 @@ verify_send(std::string label, Session& send, Session& recv)
 }
 
 void
-verify(std::string label, Session& alice, Session& bob)
+verify(const std::string& label, Session& alice, Session& bob)
 {
   if (alice != bob) {
     throw std::runtime_error(label + ": not equal");
@@ -67,7 +67,7 @@ verify(std::string label, Session& alice, Session& bob)
 }
 
 int
-main()
+main() // NOLINT(bugprone-exception-escape)
 {
   ////////// DRAMATIS PERSONAE ///////////
 

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -134,11 +134,7 @@ generate_key_schedule()
   };
 
   GroupContext base_group_context{
-    { 0xA0, 0xA0, 0xA0, 0xA0 },
-    0,
-    bytes(32, 0xA1),
-    bytes(32, 0xA2),
-    {},
+    { 0xA0, 0xA0, 0xA0, 0xA0 }, 0, bytes(32, 0xA1), bytes(32, 0xA2), {},
   };
 
   tv.n_epochs = 50;
@@ -352,8 +348,8 @@ generate_messages()
 
     // Construct an MLSCiphertext
     auto ciphertext = MLSCiphertext{
-      tv.group_id, tv.epoch,  ContentType::application,
-      tv.random,   tv.random, tv.random, tv.random,
+      tv.group_id, tv.epoch,  ContentType::application, tv.random, tv.random,
+      tv.random,   tv.random,
     };
 
     tv.cases.push_back({ suite,

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -283,9 +283,7 @@ generate_messages()
 
   // Construct a test case for each suite
   DeterministicHPKE lock;
-  for (size_t i = 0; i < suites.size(); ++i) {
-    auto suite = suites[i];
-
+  for (auto suite : suites) {
     // Miscellaneous data items we need to construct messages
     auto dh_priv = HPKEPrivateKey::derive(suite, tv.dh_seed);
     auto dh_key = dh_priv.public_key();
@@ -434,7 +432,7 @@ generate_basic_session()
           tv.group_id, { init_infos[0] }, { key_packages[1] }, commit_secret);
         session.encrypt_handshake(encrypt);
 
-        sessions.push_back(session);
+        sessions.emplace_back(session);
         welcome = welcome_new;
       } else {
         std::tie(welcome, add) =
@@ -446,7 +444,7 @@ generate_basic_session()
 
       auto joiner = Session::join({ init_infos[j] }, welcome);
       joiner.encrypt_handshake(encrypt);
-      sessions.push_back(joiner);
+      sessions.emplace_back(joiner);
 
       transcript.emplace_back(welcome, add, commit_secret, sessions[0]);
     }
@@ -463,7 +461,7 @@ generate_basic_session()
     }
 
     // Remove everyone (R->L)
-    for (int j = tv.group_size - 2; j >= 0; --j) {
+    for (int j = static_cast<int>(tv.group_size) - 2; j >= 0; --j) {
       auto commit_secret = pseudo_random(suite, transcript.size());
       auto remove = sessions[j].remove(commit_secret, j + 1);
       for (int k = 0; k <= j; ++k) {
@@ -498,7 +496,8 @@ write_test_vectors(const T& vectors)
                                 T::file_name);
   }
 
-  auto data = reinterpret_cast<const char*>(marshaled.data());
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  const auto* data = reinterpret_cast<const char*>(marshaled.data());
   file.write(data, marshaled.size());
 }
 
@@ -549,7 +548,7 @@ verify_session_repro(const F& generator)
 }
 
 int
-main()
+main() // NOLINT(bugprone-exception-escape)
 {
   auto tree_math = generate_tree_math();
   write_test_vectors(tree_math);

--- a/include/mls/key_schedule.h
+++ b/include/mls/key_schedule.h
@@ -97,7 +97,7 @@ struct KeyScheduleEpoch
                                  const bytes& context);
   KeyScheduleEpoch next(LeafCount size,
                         const bytes& update_secret,
-                        const bytes& context);
+                        const bytes& context) const;
 };
 
 bool

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -261,10 +261,9 @@ enum struct SenderType : uint8_t
   new_member = 3,
 };
 
-struct Sender
-{
-  SenderType sender_type;
-  uint32_t sender;
+struct Sender {
+    SenderType sender_type{SenderType::invalid};
+    uint32_t sender{0};
 
   TLS_SERIALIZABLE(sender_type, sender);
 };

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -261,9 +261,10 @@ enum struct SenderType : uint8_t
   new_member = 3,
 };
 
-struct Sender {
-    SenderType sender_type{SenderType::invalid};
-    uint32_t sender{0};
+struct Sender
+{
+  SenderType sender_type{ SenderType::invalid };
+  uint32_t sender{ 0 };
 
   TLS_SERIALIZABLE(sender_type, sender);
 };

--- a/include/mls/primitives.h
+++ b/include/mls/primitives.h
@@ -17,7 +17,7 @@ public:
   ~Digest();
   Digest& write(uint8_t byte);
   Digest& write(const bytes& data);
-  bytes digest();
+  bytes digest() const;
 
   size_t output_size() const;
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -26,7 +26,7 @@ from_hex(const std::string& hex)
     throw std::invalid_argument("Odd-length hex string");
   }
 
-  int len = hex.length() / 2;
+  int len = static_cast<int>(hex.length()) / 2;
   bytes out(len);
   for (int i = 0; i < len; i += 1) {
     std::string byte = hex.substr(2 * i, 2);
@@ -151,20 +151,28 @@ const CipherDetails
     SignatureScheme::Ed448,
   };
 
-#define CIPHER_DETAILS_CASE(suite)                                             \
-  case CipherSuite::suite:                                                     \
-    return cipher_details<CipherSuite::suite>;
-
 const CipherDetails&
 CipherDetails::get(CipherSuite suite)
 {
   switch (suite) {
-    CIPHER_DETAILS_CASE(X25519_AES128GCM_SHA256_Ed25519)
-    CIPHER_DETAILS_CASE(P256_AES128GCM_SHA256_P256)
-    CIPHER_DETAILS_CASE(X25519_CHACHA20POLY1305_SHA256_Ed25519)
-    CIPHER_DETAILS_CASE(X448_AES256GCM_SHA512_Ed448)
-    CIPHER_DETAILS_CASE(P521_AES256GCM_SHA512_P521)
-    CIPHER_DETAILS_CASE(X448_CHACHA20POLY1305_SHA512_Ed448)
+    case CipherSuite::X25519_AES128GCM_SHA256_Ed25519:
+      return cipher_details<CipherSuite::X25519_AES128GCM_SHA256_Ed25519>;
+
+    case CipherSuite::P256_AES128GCM_SHA256_P256:
+      return cipher_details<CipherSuite::P256_AES128GCM_SHA256_P256>;
+
+    case CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519:
+      return cipher_details<
+        CipherSuite::X25519_CHACHA20POLY1305_SHA256_Ed25519>;
+
+    case CipherSuite::X448_AES256GCM_SHA512_Ed448:
+      return cipher_details<CipherSuite::X448_AES256GCM_SHA512_Ed448>;
+
+    case CipherSuite::P521_AES256GCM_SHA512_P521:
+      return cipher_details<CipherSuite::P521_AES256GCM_SHA512_P521>;
+
+    case CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448:
+      return cipher_details<CipherSuite::X448_CHACHA20POLY1305_SHA512_Ed448>;
 
     default:
       throw InvalidParameterError("Unsupported ciphersuite");

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -236,6 +236,10 @@ GroupKeySource::GroupKeySource(const GroupKeySource& other)
 GroupKeySource&
 GroupKeySource::operator=(const GroupKeySource& other)
 {
+  if (&other == this) {
+    return *this;
+  }
+
   suite = other.suite;
   if (other.base_source != nullptr) {
     base_source.reset(other.base_source->dup());
@@ -325,7 +329,7 @@ KeyScheduleEpoch::create(CipherSuite suite,
 KeyScheduleEpoch
 KeyScheduleEpoch::next(LeafCount size,
                        const bytes& update_secret,
-                       const bytes& context)
+                       const bytes& context) const
 {
   auto new_epoch_secret = hkdf_extract(suite, init_secret, update_secret);
   return KeyScheduleEpoch::create(suite, size, new_epoch_secret, context);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -56,10 +56,10 @@ Session::start(const bytes& group_id,
     throw ProtocolError("Negotiation failure");
   }
 
-  auto& suite = my_selected_info->key_package.cipher_suite;
-  auto& init_secret = my_selected_info->init_secret;
-  auto& sig_priv = my_selected_info->sig_priv;
-  auto& kp = my_selected_info->key_package;
+  const auto suite = my_selected_info->key_package.cipher_suite;
+  const auto& init_secret = my_selected_info->init_secret;
+  const auto& sig_priv = my_selected_info->sig_priv;
+  const auto& kp = my_selected_info->key_package;
 
   auto init_state = State{ group_id, suite, init_secret, sig_priv, kp };
   auto add = init_state.add(*other_selected_kp);
@@ -142,12 +142,14 @@ void
 Session::handle(const bytes& handshake_data)
 {
   auto& state = current_state();
-  MLSPlaintext proposal, commit;
+  MLSPlaintext proposal;
+  MLSPlaintext commit;
   tls::istream r(handshake_data);
   if (_encrypt_handshake) {
     // TODO(rlb): Verify that epoch of the ciphertext matches that of the
     // current state
-    MLSCiphertext enc_proposal, enc_commit;
+    MLSCiphertext enc_proposal;
+    MLSCiphertext enc_commit;
     r >> enc_proposal >> enc_commit;
     proposal = state.decrypt(enc_proposal);
     commit = state.decrypt(enc_commit);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -308,7 +308,7 @@ State::handle(const MLSPlaintext& pt)
   }
 
   // Apply the commit
-  auto& commit_data = std::get<CommitData>(pt.content);
+  const auto& commit_data = std::get<CommitData>(pt.content);
   State next = *this;
   next.apply(commit_data.commit);
 
@@ -586,7 +586,7 @@ MLSCiphertext
 State::encrypt(const MLSPlaintext& pt)
 {
   // Pull from the key schedule
-  uint32_t generation;
+  uint32_t generation = 0;
   KeyAndNonce keys;
   ContentType content_type;
   if (std::holds_alternative<ApplicationData>(pt.content)) {
@@ -664,7 +664,7 @@ State::decrypt(const MLSCiphertext& ct)
 
   tls::istream r(sender_data);
   Sender raw_sender;
-  uint32_t generation;
+  uint32_t generation = 0;
   r >> raw_sender >> generation;
 
   if (raw_sender.sender_type != SenderType::member) {

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -235,10 +235,7 @@ GroupContext
 State::group_context() const
 {
   return GroupContext{
-    _group_id,
-    _epoch,
-    _tree.root_hash(),
-    _confirmed_transcript_hash,
+    _group_id,   _epoch, _tree.root_hash(), _confirmed_transcript_hash,
     _extensions,
   };
 }

--- a/src/tls_syntax.cpp
+++ b/src/tls_syntax.cpp
@@ -83,7 +83,7 @@ istream::read_uint(T& data, int length)
 istream&
 operator>>(istream& in, bool& data)
 {
-  uint8_t val;
+  uint8_t val = 0;
   in >> val;
 
   // Linter thinks uint8_t is signed (?)

--- a/src/tree_math.cpp
+++ b/src/tree_math.cpp
@@ -179,15 +179,21 @@ ancestor(LeafIndex l, LeafIndex r)
 {
   auto ln = NodeIndex(l);
   auto rn = NodeIndex(r);
+  if (ln == rn) {
+    return ln;
+  }
 
   uint8_t k = 0;
+  uint8_t one = 1;
   while (ln != rn) {
-    ln.val = ln.val >> 1;
-    rn.val = rn.val >> 1;
+    ln.val = ln.val >> one;
+    rn.val = rn.val >> one;
     k += 1;
   }
 
-  return NodeIndex((ln.val << k) + (1 << (k - 1)) - 1);
+  uint32_t prefix = ln.val << k;
+  uint32_t stop = (one << uint8_t(k - 1));
+  return NodeIndex(prefix + (stop - 1));
 }
 
 } // namespace tree_math

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -175,7 +175,8 @@ TreeKEMPrivateKey::decap(LeafIndex from,
 
   size_t dpi = 0;
   auto last = NodeIndex(from);
-  NodeIndex overlap_node, copath_node;
+  NodeIndex overlap_node;
+  NodeIndex copath_node;
   for (dpi = 0; dpi < dp.size(); dpi++) {
     if (tree_math::in_path(ni, dp[dpi])) {
       overlap_node = dp[dpi];
@@ -243,7 +244,7 @@ TreeKEMPrivateKey::consistent(const TreeKEMPrivateKey& other) const
     return false;
   }
 
-  for (auto& entry : path_secrets) {
+  for (const auto& entry : path_secrets) {
     auto other_entry = other.path_secrets.find(entry.first);
     if (other_entry == other.path_secrets.end()) {
       continue;
@@ -264,16 +265,16 @@ TreeKEMPrivateKey::consistent(const TreeKEMPublicKey& other) const
     return false;
   }
 
-  for (auto& entry : path_secrets) {
+  for (const auto& entry : path_secrets) {
     auto n = entry.first;
     auto priv = private_key(n).value();
 
-    auto& opt_node = other.node_at(n).node;
+    const auto& opt_node = other.node_at(n).node;
     if (!opt_node.has_value()) {
       return false;
     }
 
-    auto& pub = opt_node.value().public_key();
+    const auto& pub = opt_node.value().public_key();
     if (priv.public_key() != pub) {
       return false;
     }
@@ -411,14 +412,14 @@ std::vector<NodeIndex>
 TreeKEMPublicKey::resolve(NodeIndex index) const
 {
   if (nodes[index.val].node.has_value()) {
-    auto& node = nodes[index.val].node.value();
+    const auto& node = nodes[index.val].node.value();
     auto out = std::vector<NodeIndex>{ index };
     if (std::holds_alternative<KeyPackage>(node.node)) {
       return out;
     }
 
-    auto& parent = std::get<ParentNode>(node.node);
-    auto& unmerged = parent.unmerged_leaves;
+    const auto& parent = std::get<ParentNode>(node.node);
+    const auto& unmerged = parent.unmerged_leaves;
     std::transform(unmerged.begin(),
                    unmerged.end(),
                    std::back_inserter(out),
@@ -495,7 +496,7 @@ TreeKEMPublicKey::encap(LeafIndex from,
     auto copath = tree_math::sibling(last, NodeCount(size()));
     auto res = resolve(copath);
     for (auto nr : res) {
-      auto& node_pub = node_at(nr).node.value().public_key();
+      const auto& node_pub = node_at(nr).node.value().public_key();
       auto ct = node_pub.encrypt(suite, context, path_secret);
       node.node_secrets.push_back(ct);
     }

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -139,8 +139,8 @@ TEST_CASE("Messages Interop")
 
     // MLSCiphertext
     MLSCiphertext ciphertext{
-      tv.group_id, tv.epoch,  ContentType::application,
-      tv.random,   tv.random, tv.random, tv.random,
+      tv.group_id, tv.epoch,  ContentType::application, tv.random, tv.random,
+      tv.random,   tv.random,
     };
     tls_round_trip(tc.ciphertext, ciphertext, true);
   }

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -149,7 +149,6 @@ protected:
   std::vector<State> states;
 
   RunningGroupTest()
-    : StateTest()
   {
     states.emplace_back(
       group_id, suite, init_secrets[0], identity_privs[0], key_packages[0]);
@@ -202,7 +201,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Update Everyone in a Group")
 
 TEST_CASE_FIXTURE(RunningGroupTest, "Remove Members from a Group")
 {
-  for (int i = group_size - 2; i > 0; i -= 1) {
+  for (int i = static_cast<int>(group_size) - 2; i > 0; i -= 1) {
     auto remove = states[i].remove(LeafIndex{ uint32_t(i + 1) });
     states[i].handle(remove);
     auto [commit, welcome, new_state] = states[i].commit(fresh_secret());

--- a/test/test_vectors.cpp
+++ b/test/test_vectors.cpp
@@ -26,13 +26,13 @@ deterministic_signature_scheme(CipherSuite suite)
 {
   switch (CipherDetails::get(suite).scheme) {
     case SignatureScheme::P256_SHA256:
-      return false;
     case SignatureScheme::P521_SHA512:
       return false;
+
     case SignatureScheme::Ed25519:
-      return true;
     case SignatureScheme::Ed448:
       return true;
+
     default:
       return false;
   }

--- a/test/tls_syntax.cpp
+++ b/test/tls_syntax.cpp
@@ -32,8 +32,8 @@ const IntSelector Uint16::type = IntSelector::uint16;
 // A struct to test struct encoding and traits
 struct ExampleStruct
 {
-  uint16_t a{0};
-  std::array<uint32_t, 4> b{0, 0, 0, 0};
+  uint16_t a{ 0 };
+  std::array<uint32_t, 4> b{ 0, 0, 0, 0 };
   std::optional<uint8_t> c;
   std::vector<uint8_t> d;
   std::variant<Uint8, Uint16> e;
@@ -133,22 +133,22 @@ istream_test(T val, T& data, const std::vector<uint8_t>& enc)
 
 TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS istream")
 {
-  bool data_bool;
+  bool data_bool = false;
   istream_test(val_bool, data_bool, enc_bool);
 
-  uint8_t data_uint8;
+  uint8_t data_uint8 = 0;
   istream_test(val_uint8, data_uint8, enc_uint8);
 
-  uint16_t data_uint16;
+  uint16_t data_uint16 = 0;
   istream_test(val_uint16, data_uint16, enc_uint16);
 
-  uint32_t data_uint32;
+  uint32_t data_uint32 = 0;
   istream_test(val_uint32, data_uint32, enc_uint32);
 
-  uint64_t data_uint64;
+  uint64_t data_uint64 = 0;
   istream_test(val_uint64, data_uint64, enc_uint64);
 
-  std::array<uint16_t, 4> data_array;
+  std::array<uint16_t, 4> data_array = { 0, 0, 0, 0 };
   istream_test(val_array, data_array, enc_array);
 
   ExampleStruct data_struct;

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -244,7 +244,7 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM encap/decap")
     auto [new_adder_priv, path] =
       pub.encap(adder, context, leaf_secret, sig_privs.back(), std::nullopt);
     privs[i] = new_adder_priv;
-    // TODO verify parent_hash_valid
+    // TODO(RLB) verify parent_hash_valid
 
     pub.merge(adder, path);
     REQUIRE(privs[i].consistent(pub));


### PR DESCRIPTION
This PR adds clang-tidy to the build system (including CI), with a `.clang-tidy` file that enables most checks while suppressing some that are too aggressive.  The PR also includes the code fixes that were necessary to clear any errors reported by clang-tidy.