### PR TITLE
Streamline and complete the session API

### DIFF
--- a/cmd/api_example/main.cpp
+++ b/cmd/api_example/main.cpp
@@ -66,10 +66,7 @@ main() // NOLINT(bugprone-exception-escape)
   // Alice adds Bob and Charlie to the session
   auto add_bob = alice_session.add(bob_join.key_package());
   auto add_charlie = alice_session.add(charlie_join.key_package());
-
-  alice_session.handle(add_bob);
-  alice_session.handle(add_charlie);
-  auto [welcome, commit] = alice_session.commit();
+  auto [welcome, commit] = alice_session.commit({add_bob, add_charlie});
   alice_session.handle(commit);
 
   // Bob and Charlie initialize their sessions
@@ -84,9 +81,7 @@ main() // NOLINT(bugprone-exception-escape)
 
   // Bob updates his key
   auto update = bob_session.update();
-  bob_session.handle(update);
-
-  auto [_1, update_commit] = bob_session.commit();
+  auto [_1, update_commit] = bob_session.commit({update});
   bob_session.handle(update_commit);
 
   // Everyone else processes the update and commit
@@ -103,9 +98,7 @@ main() // NOLINT(bugprone-exception-escape)
 
   // Charlie removes Bob
   auto remove = charlie_session.remove(1);
-  charlie_session.handle(remove);
-
-  auto [_2, remove_commit] = charlie_session.commit();
+  auto [_2, remove_commit] = charlie_session.commit({remove});
   charlie_session.handle(remove_commit);
 
   // Alice and Charlie process the message (Bob is gone)

--- a/cmd/api_example/main.cpp
+++ b/cmd/api_example/main.cpp
@@ -9,41 +9,14 @@
 
 using namespace mls;
 
-const auto suite =
-  CipherSuite{ CipherSuite::ID::X25519_AES128GCM_SHA256_Ed25519 };
-
-class User
+mls::Client
+create_client(CipherSuite suite, const std::string& name)
 {
-public:
-  explicit User(const std::string& name)
-    : _identity_priv(SignaturePrivateKey::generate(suite))
-  {
-    auto id = bytes(name.begin(), name.end());
-    _cred = Credential::basic(id, _identity_priv.public_key);
-  }
-
-  Session::InitInfo temp_init_info()
-  {
-    auto init_secret = random_bytes(32);
-    auto init_key = HPKEPrivateKey::derive(suite, init_secret);
-    auto kp = KeyPackage{ suite, init_key.public_key, _cred, _identity_priv };
-    return { init_secret, _identity_priv, kp };
-  }
-
-  KeyPackage fresh_key_package()
-  {
-    auto info = temp_init_info();
-    _infos.push_back(info);
-    return info.key_package;
-  }
-
-  const std::vector<Session::InitInfo>& infos() const { return _infos; }
-
-private:
-  SignaturePrivateKey _identity_priv;
-  Credential _cred;
-  std::vector<Session::InitInfo> _infos;
-};
+  auto id = bytes(name.begin(), name.end());
+  auto sig_priv = SignaturePrivateKey::generate(suite);
+  auto cred = Credential::basic(id, sig_priv.public_key);
+  return Client(suite, sig_priv, cred);
+}
 
 void
 verify_send(const std::string& label, Session& send, Session& recv)
@@ -70,74 +43,76 @@ verify(const std::string& label, Session& alice, Session& bob)
 int
 main() // NOLINT(bugprone-exception-escape)
 {
+  const auto suite =
+    mls::CipherSuite{ mls::CipherSuite::ID::X25519_AES128GCM_SHA256_Ed25519 };
+
   ////////// DRAMATIS PERSONAE ///////////
 
-  auto alice = User{ "alice" };
-  auto bob = User{ "bob" };
-  auto charlie = User{ "charlie" };
+  auto alice_client = create_client(suite, "alice");
+  auto bob_client = create_client(suite, "bob");
+  auto charlie_client = create_client(suite, "charlie");
 
   ////////// ACT I: CREATION ///////////
 
-  // Bob posts a KeyPackage
-  auto kpB = bob.fresh_key_package();
-
-  // Alice starts a session with Bob
-  auto infoA = alice.temp_init_info();
   auto group_id = bytes{ 0, 1, 2, 3 };
-  auto [sessionA, welcome] =
-    Session::start(group_id, { infoA }, { kpB }, random_bytes(32));
-
-  // Bob looks up his CIK based on the welcome, and initializes
-  // his session
-  auto sessionB = Session::join(bob.infos(), welcome);
-
-  // Alice and Bob should now be on the same page
-  verify("create", sessionA, sessionB);
+  auto alice_session = alice_client.begin_session(group_id);
 
   ////////// ACT II: ADDITION ///////////
 
-  // Charlie posts a KeyPackage
-  auto kpC1 = charlie.fresh_key_package();
+  // Bob and Charlie post KeyPackages
+  auto bob_join = bob_client.start_join();
+  auto charlie_join = charlie_client.start_join();
 
-  // Alice adds Charlie to the session
-  bytes add;
-  std::tie(welcome, add) = sessionA.add(random_bytes(32), kpC1);
+  // Alice adds Bob and Charlie to the session
+  auto add_bob = alice_session.add(bob_join.key_package());
+  auto add_charlie = alice_session.add(charlie_join.key_package());
 
-  // Charlie initializes his session
-  auto sessionC = Session::join(charlie.infos(), welcome);
+  alice_session.handle(add_bob);
+  alice_session.handle(add_charlie);
+  auto [welcome, commit] = alice_session.commit();
+  alice_session.handle(commit);
 
-  // Alice and Bob updates their sessions to reflect Charlie's addition
-  sessionA.handle(add);
-  sessionB.handle(add);
+  // Bob and Charlie initialize their sessions
+  auto bob_session = bob_join.complete(welcome);
+  auto charlie_session = charlie_join.complete(welcome);
 
-  verify("add A->B", sessionA, sessionB);
-  verify("add A->C", sessionA, sessionC);
-  verify("add B->C", sessionB, sessionC);
+  verify("add A->B", alice_session, bob_session);
+  verify("add A->C", alice_session, charlie_session);
+  verify("add B->C", bob_session, charlie_session);
 
   ////////// ACT III: UPDATE ///////////
 
   // Bob updates his key
-  auto update = sessionB.update(random_bytes(32));
+  auto update = bob_session.update();
+  bob_session.handle(update);
 
-  // Everyone processes the update
-  sessionA.handle(update);
-  sessionB.handle(update);
-  sessionC.handle(update);
+  auto [_1, update_commit] = bob_session.commit();
+  bob_session.handle(update_commit);
 
-  verify("update A->B", sessionA, sessionB);
-  verify("update A->C", sessionA, sessionC);
-  verify("update B->C", sessionB, sessionC);
+  // Everyone else processes the update and commit
+  alice_session.handle(update);
+  alice_session.handle(update_commit);
+  charlie_session.handle(update);
+  charlie_session.handle(update_commit);
+
+  verify("update A->B", alice_session, bob_session);
+  verify("update A->C", alice_session, charlie_session);
+  verify("update B->C", bob_session, charlie_session);
 
   ////////// ACT IV: REMOVE ///////////
 
   // Charlie removes Bob
-  auto remove = sessionC.remove(random_bytes(32), 1);
+  auto remove = charlie_session.remove(1);
+  charlie_session.handle(remove);
+
+  auto [_2, remove_commit] = charlie_session.commit();
+  charlie_session.handle(remove_commit);
 
   // Alice and Charlie process the message (Bob is gone)
-  sessionA.handle(remove);
-  sessionC.handle(remove);
+  alice_session.handle(remove);
+  alice_session.handle(remove_commit);
 
-  verify("remove A->C", sessionA, sessionC);
+  verify("remove A->C", alice_session, charlie_session);
 
   std::cout << "ok" << std::endl;
   return 0;

--- a/cmd/api_example/main.cpp
+++ b/cmd/api_example/main.cpp
@@ -82,6 +82,7 @@ main() // NOLINT(bugprone-exception-escape)
   // Bob updates his key
   auto update = bob_session.update();
   auto [_1, update_commit] = bob_session.commit({update});
+  silence_unused(_1);
   bob_session.handle(update_commit);
 
   // Everyone else processes the update and commit
@@ -99,6 +100,7 @@ main() // NOLINT(bugprone-exception-escape)
   // Charlie removes Bob
   auto remove = charlie_session.remove(1);
   auto [_2, remove_commit] = charlie_session.commit({remove});
+  silence_unused(_2);
   charlie_session.handle(remove_commit);
 
   // Alice and Charlie process the message (Bob is gone)

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -187,6 +187,7 @@ generate_key_schedule()
         handshake_keys,
         epoch.application_secret,
         application_keys,
+        epoch.exporter_secret,
         epoch.confirmation_key,
         epoch.init_secret,
       });

--- a/include/mls/credential.h
+++ b/include/mls/credential.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "mls/common.h"
-#include "mls/crypto.h"
+#include <mls/common.h>
+#include <mls/crypto.h>
 
 namespace mls {
 

--- a/include/mls/crypto.h
+++ b/include/mls/crypto.h
@@ -5,8 +5,8 @@
 #include <hpke/random.h>
 #include <hpke/signature.h>
 #include <mls/common.h>
-#include <openssl/evp.h>
 #include <tls/tls_syntax.h>
+
 #include <vector>
 
 namespace mls {

--- a/include/mls/crypto.h
+++ b/include/mls/crypto.h
@@ -41,6 +41,9 @@ struct CipherSuite
                           const std::string& label,
                           const bytes& context,
                           size_t length) const;
+  bytes derive_secret(const bytes& secret,
+                      const std::string& label,
+                      const bytes& context) const;
 
   TLS_SERIALIZABLE(id)
 

--- a/include/mls/key_schedule.h
+++ b/include/mls/key_schedule.h
@@ -91,6 +91,9 @@ struct KeyScheduleEpoch
 
   KeyScheduleEpoch() = default;
 
+  static KeyScheduleEpoch first(CipherSuite suite,
+                                const bytes& init_secret,
+                                const bytes& context);
   static KeyScheduleEpoch create(CipherSuite suite,
                                  LeafCount size,
                                  const bytes& epoch_secret,

--- a/include/mls/key_schedule.h
+++ b/include/mls/key_schedule.h
@@ -86,6 +86,7 @@ struct KeyScheduleEpoch
   bytes application_secret;
   GroupKeySource application_keys;
 
+  bytes exporter_secret;
   bytes confirmation_key;
   bytes init_secret;
 

--- a/include/mls/session.h
+++ b/include/mls/session.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <mls/crypto.h>
-#include <mls/credential.h>
 #include <mls/common.h>
+#include <mls/credential.h>
+#include <mls/crypto.h>
 
 namespace mls {
 
@@ -63,7 +63,9 @@ public:
   // Information about the current state
   epoch_t current_epoch() const;
   uint32_t index() const;
-  bytes do_export(const std::string& label, const bytes& context, size_t size) const;
+  bytes do_export(const std::string& label,
+                  const bytes& context,
+                  size_t size) const;
 
   // Application message protection
   bytes protect(const bytes& plaintext);

--- a/include/mls/session.h
+++ b/include/mls/session.h
@@ -55,6 +55,8 @@ public:
   bytes add(const bytes& key_package_data);
   bytes update();
   bytes remove(uint32_t index);
+  std::tuple<bytes, bytes> commit(const bytes& proposal);
+  std::tuple<bytes, bytes> commit(const std::vector<bytes>& proposals);
   std::tuple<bytes, bytes> commit();
 
   // Message consumers

--- a/include/mls/session.h
+++ b/include/mls/session.h
@@ -12,11 +12,11 @@ class Session
 public:
   struct InitInfo
   {
-    bytes init_secret;
+    HPKEPrivateKey init_priv;
     SignaturePrivateKey sig_priv;
     KeyPackage key_package;
 
-    InitInfo(bytes init_secret_in,
+    InitInfo(HPKEPrivateKey init_priv_in,
              SignaturePrivateKey sig_priv_in,
              KeyPackage key_package);
   };
@@ -26,8 +26,7 @@ public:
   static std::tuple<Session, bytes> start(
     const bytes& group_id,
     const std::vector<InitInfo>& my_info,
-    const std::vector<KeyPackage>& key_packages,
-    const bytes& initial_secret);
+    const std::vector<KeyPackage>& key_packages);
   static Session join(const std::vector<InitInfo>& my_info,
                       const bytes& welcome);
 
@@ -56,7 +55,7 @@ protected:
   bytes export_message(const MLSPlaintext& plaintext);
   MLSPlaintext import_message(const bytes& encoded);
 
-  void make_init_key(const bytes& init_secret);
+  void make_init_key(const HPKEPrivateKey& init_priv);
   void add_state(epoch_t prior_epoch, const State& state);
   State& current_state();
   const State& current_state() const;

--- a/include/mls/session.h
+++ b/include/mls/session.h
@@ -7,38 +7,56 @@
 
 namespace mls {
 
+class PendingJoin;
+class Session;
+
+class Client {
+public:
+  Client(CipherSuite suite_in, SignaturePrivateKey sig_priv_in, Credential cred_in);
+
+  Session begin_session(const bytes& group_id) const;
+
+  PendingJoin start_join() const;
+
+private:
+  const CipherSuite suite;
+  const SignaturePrivateKey sig_priv;
+  const Credential cred;
+};
+
+class PendingJoin {
+public:
+  bytes key_package() const;
+  Session complete(const bytes& welcome) const;
+
+private:
+  const CipherSuite suite;
+  const HPKEPrivateKey init_priv;
+  const SignaturePrivateKey sig_priv;
+  const KeyPackage key_package_inner;
+
+  PendingJoin(CipherSuite suite_in, SignaturePrivateKey sig_priv_in, Credential cred_in);
+  friend class Client;
+};
+
 class Session
 {
 public:
-  struct InitInfo
-  {
-    HPKEPrivateKey init_priv;
-    SignaturePrivateKey sig_priv;
-    KeyPackage key_package;
-
-    InitInfo(HPKEPrivateKey init_priv_in,
-             SignaturePrivateKey sig_priv_in,
-             KeyPackage key_package);
-  };
-
   Session(const Session& other) = default;
 
-  static std::tuple<Session, bytes> start(
-    const bytes& group_id,
-    const std::vector<InitInfo>& my_info,
-    const std::vector<KeyPackage>& key_packages);
-  static Session join(const std::vector<InitInfo>& my_info,
-                      const bytes& welcome);
-
+  // Settings
   void encrypt_handshake(bool enabled);
 
-  bytes add(const KeyPackage& key_package);
+  // Message producers
+  bytes add(const bytes& key_package_data);
   bytes update();
   bytes remove(uint32_t index);
   std::tuple<bytes, bytes> commit();
 
+  // Message consumers
   bool handle(const bytes& handshake_data);
 
+  // Application message protection
   bytes protect(const bytes& plaintext);
   bytes unprotect(const bytes& ciphertext);
 
@@ -49,13 +67,24 @@ protected:
 
   std::optional<std::tuple<bytes, State>> _outbound_cache;
 
+  // Session creators
   Session();
+  static Session begin(const bytes& group_id,
+                       const HPKEPrivateKey& init_priv,
+                       const SignaturePrivateKey& sig_priv,
+                       const KeyPackage& key_package);
+  static Session join(const HPKEPrivateKey& init_priv,
+                      const SignaturePrivateKey& sig_priv,
+                      const KeyPackage& key_package,
+                      const bytes& welcome_data);
+
+  friend class Client;
+  friend class PendingJoin;
 
   bytes fresh_secret() const;
   bytes export_message(const MLSPlaintext& plaintext);
   MLSPlaintext import_message(const bytes& encoded);
 
-  void make_init_key(const HPKEPrivateKey& init_priv);
   void add_state(epoch_t prior_epoch, const State& state);
   State& current_state();
   const State& current_state() const;

--- a/include/mls/session.h
+++ b/include/mls/session.h
@@ -33,10 +33,9 @@ public:
 
   void encrypt_handshake(bool enabled);
 
-  std::tuple<Welcome, bytes> add(const bytes& add_secret,
-                                 const KeyPackage& key_package);
-  bytes update(const bytes& leaf_secret);
-  bytes remove(const bytes& evict_secret, uint32_t index);
+  std::tuple<Welcome, bytes> add(const KeyPackage& key_package);
+  bytes update();
+  bytes remove(uint32_t index);
 
   void handle(const bytes& handshake_data);
 
@@ -52,6 +51,7 @@ protected:
 
   Session();
 
+  bytes fresh_secret() const;
   std::tuple<Welcome, bytes> commit_and_cache(const bytes& secret,
                                               const MLSPlaintext& proposal);
   void make_init_key(const bytes& init_secret);

--- a/include/mls/session.h
+++ b/include/mls/session.h
@@ -63,6 +63,7 @@ public:
   // Information about the current state
   epoch_t current_epoch() const;
   uint32_t index() const;
+  bytes do_export(const std::string& label, const bytes& context, size_t size) const;
 
   // Application message protection
   bytes protect(const bytes& plaintext);

--- a/include/mls/session.h
+++ b/include/mls/session.h
@@ -23,21 +23,22 @@ public:
 
   Session(const Session& other) = default;
 
-  static std::tuple<Session, Welcome> start(
+  static std::tuple<Session, bytes> start(
     const bytes& group_id,
     const std::vector<InitInfo>& my_info,
     const std::vector<KeyPackage>& key_packages,
     const bytes& initial_secret);
   static Session join(const std::vector<InitInfo>& my_info,
-                      const Welcome& welcome);
+                      const bytes& welcome);
 
   void encrypt_handshake(bool enabled);
 
-  std::tuple<Welcome, bytes> add(const KeyPackage& key_package);
+  bytes add(const KeyPackage& key_package);
   bytes update();
   bytes remove(uint32_t index);
+  std::tuple<bytes, bytes> commit();
 
-  void handle(const bytes& handshake_data);
+  bool handle(const bytes& handshake_data);
 
   bytes protect(const bytes& plaintext);
   bytes unprotect(const bytes& ciphertext);
@@ -52,8 +53,9 @@ protected:
   Session();
 
   bytes fresh_secret() const;
-  std::tuple<Welcome, bytes> commit_and_cache(const bytes& secret,
-                                              const MLSPlaintext& proposal);
+  bytes export_message(const MLSPlaintext& plaintext);
+  MLSPlaintext import_message(const bytes& encoded);
+
   void make_init_key(const bytes& init_secret);
   void add_state(epoch_t prior_epoch, const State& state);
   State& current_state();

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -80,6 +80,7 @@ public:
   epoch_t epoch() const { return _epoch; }
   LeafIndex index() const { return _index; }
   CipherSuite cipher_suite() const { return _suite; }
+  bytes do_export(const std::string& label, const bytes& context, size_t size) const;
 
   ///
   /// General encryption and decryption

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -80,7 +80,9 @@ public:
   epoch_t epoch() const { return _epoch; }
   LeafIndex index() const { return _index; }
   CipherSuite cipher_suite() const { return _suite; }
-  bytes do_export(const std::string& label, const bytes& context, size_t size) const;
+  bytes do_export(const std::string& label,
+                  const bytes& context,
+                  size_t size) const;
 
   ///
   /// General encryption and decryption

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -48,12 +48,12 @@ public:
   // Initialize an empty group
   State(bytes group_id,
         CipherSuite suite,
-        const bytes& init_secret,
+        const HPKEPrivateKey& init_priv,
         SignaturePrivateKey sig_priv,
         const KeyPackage& key_package);
 
   // Initialize a group from a Welcome
-  State(const bytes& init_secret,
+  State(const HPKEPrivateKey& init_priv,
         SignaturePrivateKey sig_priv,
         const KeyPackage& kp,
         const Welcome& welcome);

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -54,6 +54,9 @@ struct TreeKEMPrivateKey
   std::map<NodeIndex, bytes> path_secrets;
   std::map<NodeIndex, HPKEPrivateKey> private_key_cache;
 
+  static TreeKEMPrivateKey solo(CipherSuite suite,
+                                LeafIndex index,
+                                const HPKEPrivateKey& leaf_priv);
   static TreeKEMPrivateKey create(CipherSuite suite,
                                   LeafCount size,
                                   LeafIndex index,
@@ -61,12 +64,14 @@ struct TreeKEMPrivateKey
   static TreeKEMPrivateKey joiner(CipherSuite suite,
                                   LeafCount size,
                                   LeafIndex index,
-                                  const bytes& leaf_secret,
+                                  const HPKEPrivateKey& leaf_secret,
                                   NodeIndex intersect,
                                   const std::optional<bytes>& path_secret);
 
   void set_leaf_secret(const bytes& secret);
   std::tuple<NodeIndex, bytes, bool> shared_path_secret(LeafIndex to) const;
+
+  bool have_private_key(NodeIndex n) const;
   std::optional<HPKEPrivateKey> private_key(NodeIndex n);
   std::optional<HPKEPrivateKey> private_key(NodeIndex n) const;
 

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -64,7 +64,7 @@ struct TreeKEMPrivateKey
   static TreeKEMPrivateKey joiner(CipherSuite suite,
                                   LeafCount size,
                                   LeafIndex index,
-                                  const HPKEPrivateKey& leaf_secret,
+                                  const HPKEPrivateKey& leaf_priv,
                                   NodeIndex intersect,
                                   const std::optional<bytes>& path_secret);
 

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -125,6 +125,16 @@ CipherSuite::expand_with_label(const bytes& secret,
   return get().hpke.kdf.expand(secret, label_bytes, length);
 }
 
+bytes
+CipherSuite::derive_secret(const bytes& secret,
+                           const std::string& label,
+                           const bytes& context) const
+{
+  auto context_hash = get().digest.hash(context);
+  auto size = get().digest.hash_size();
+  return expand_with_label(secret, label, context_hash, size);
+}
+
 const std::array<CipherSuite::ID, 6> all_supported_suites = {
   CipherSuite::ID::X25519_AES128GCM_SHA256_Ed25519,
   CipherSuite::ID::P256_AES128GCM_SHA256_P256,

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -290,10 +290,8 @@ KeyScheduleEpoch::create(CipherSuite suite,
   auto handshake_secret =
     suite.derive_secret(epoch_secret, "handshake", context);
   auto application_secret = suite.derive_secret(epoch_secret, "app", context);
-  auto exporter_secret =
-    suite.derive_secret(epoch_secret, "exporter", context);
-  auto confirmation_key =
-    suite.derive_secret(epoch_secret, "confirm", context);
+  auto exporter_secret = suite.derive_secret(epoch_secret, "exporter", context);
+  auto confirmation_key = suite.derive_secret(epoch_secret, "confirm", context);
   auto init_secret = suite.derive_secret(epoch_secret, "init", context);
 
   auto key_size = suite.get().hpke.aead.key_size();

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -15,17 +15,6 @@ zeroize(bytes& data) // NOLINT(google-runtime-references)
 /// Key Derivation Functions
 ///
 
-bytes
-derive_secret(CipherSuite suite,
-              const bytes& secret,
-              const std::string& label,
-              const bytes& context)
-{
-  auto context_hash = suite.get().digest.hash(context);
-  auto size = suite.get().digest.hash_size();
-  return suite.expand_with_label(secret, label, context_hash, size);
-}
-
 struct ApplicationContext
 {
   NodeIndex node;
@@ -297,13 +286,15 @@ KeyScheduleEpoch::create(CipherSuite suite,
                          const bytes& context)
 {
   auto sender_data_secret =
-    derive_secret(suite, epoch_secret, "sender data", context);
+    suite.derive_secret(epoch_secret, "sender data", context);
   auto handshake_secret =
-    derive_secret(suite, epoch_secret, "handshake", context);
-  auto application_secret = derive_secret(suite, epoch_secret, "app", context);
+    suite.derive_secret(epoch_secret, "handshake", context);
+  auto application_secret = suite.derive_secret(epoch_secret, "app", context);
+  auto exporter_secret =
+    suite.derive_secret(epoch_secret, "exporter", context);
   auto confirmation_key =
-    derive_secret(suite, epoch_secret, "confirm", context);
-  auto init_secret = derive_secret(suite, epoch_secret, "init", context);
+    suite.derive_secret(epoch_secret, "confirm", context);
+  auto init_secret = suite.derive_secret(epoch_secret, "init", context);
 
   auto key_size = suite.get().hpke.aead.key_size();
   auto sender_data_key =
@@ -322,6 +313,7 @@ KeyScheduleEpoch::create(CipherSuite suite,
                            GroupKeySource{ handshake_base.release() },
                            application_secret,
                            GroupKeySource{ application_base.release() },
+                           exporter_secret,
                            confirmation_key,
                            init_secret };
 }
@@ -347,12 +339,13 @@ operator==(const KeyScheduleEpoch& lhs, const KeyScheduleEpoch& rhs)
   auto sender_data_key = (lhs.sender_data_key == rhs.sender_data_key);
   auto handshake_secret = (lhs.handshake_secret == rhs.handshake_secret);
   auto application_secret = (lhs.application_secret == rhs.application_secret);
+  auto exporter_secret = (lhs.exporter_secret == rhs.exporter_secret);
   auto confirmation_key = (lhs.confirmation_key == rhs.confirmation_key);
   auto init_secret = (lhs.init_secret == rhs.init_secret);
 
   return suite && epoch_secret && sender_data_secret && sender_data_key &&
-         handshake_secret && application_secret && confirmation_key &&
-         init_secret;
+         handshake_secret && application_secret && exporter_secret &&
+         confirmation_key && init_secret;
 }
 
 } // namespace mls

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -1,14 +1,63 @@
-#include "mls/session.h"
-#include "mls/common.h"
-#include "mls/state.h"
+#include <mls/session.h>
+
+#include <mls/messages.h>
+#include <mls/state.h>
+
+#include <map>
 
 namespace mls {
+
+///
+/// Inner struct declarations for PendingJoin and Session
+///
+
+struct PendingJoin::Inner
+{
+  const CipherSuite suite;
+  const HPKEPrivateKey init_priv;
+  const SignaturePrivateKey sig_priv;
+  const KeyPackage key_package;
+
+  Inner(CipherSuite suite_in,
+        SignaturePrivateKey sig_priv_in,
+        Credential cred_in);
+
+  static PendingJoin create(CipherSuite suite,
+                            SignaturePrivateKey sig_priv,
+                            Credential cred);
+};
+
+struct Session::Inner
+{
+  std::map<epoch_t, State> state;
+  epoch_t current_epoch;
+  bool encrypt_handshake;
+  std::optional<std::tuple<bytes, State>> outbound_cache;
+
+  static Session begin(const bytes& group_id,
+                       const HPKEPrivateKey& init_priv,
+                       const SignaturePrivateKey& sig_priv,
+                       const KeyPackage& key_package);
+  static Session join(const HPKEPrivateKey& init_priv,
+                      const SignaturePrivateKey& sig_priv,
+                      const KeyPackage& key_package,
+                      const bytes& welcome_data);
+
+  bytes fresh_secret() const;
+  bytes export_message(const MLSPlaintext& plaintext);
+  MLSPlaintext import_message(const bytes& encoded);
+  void add_state(epoch_t prior_epoch, const State& group_state);
+  const State& current_state() const;
+  State& current_state();
+};
 
 ///
 /// Client
 ///
 
-Client::Client(CipherSuite suite_in, SignaturePrivateKey sig_priv_in, Credential cred_in)
+Client::Client(CipherSuite suite_in,
+               SignaturePrivateKey sig_priv_in,
+               Credential cred_in)
   : suite(suite_in)
   , sig_priv(std::move(sig_priv_in))
   , cred(std::move(cred_in))
@@ -19,115 +68,88 @@ Client::begin_session(const bytes& group_id) const
 {
   auto init_priv = HPKEPrivateKey::generate(suite);
   auto kp = KeyPackage{ suite, init_priv.public_key, cred, sig_priv };
-  return Session::begin(group_id, init_priv, sig_priv, kp);
+  return Session::Inner::begin(group_id, init_priv, sig_priv, kp);
 }
 
 PendingJoin
 Client::start_join() const
 {
-  return PendingJoin(suite, sig_priv, cred);
+  return PendingJoin::Inner::create(suite, sig_priv, cred);
 }
 
 ///
 /// PendingJoin
 ///
 
-PendingJoin::PendingJoin(CipherSuite suite_in, SignaturePrivateKey sig_priv_in, Credential cred_in)
+PendingJoin::Inner::Inner(CipherSuite suite_in,
+                          SignaturePrivateKey sig_priv_in,
+                          Credential cred_in)
   : suite(suite_in)
   , init_priv(HPKEPrivateKey::generate(suite))
   , sig_priv(std::move(sig_priv_in))
-  , key_package_inner(suite, init_priv.public_key, cred_in, sig_priv)
+  , key_package(suite, init_priv.public_key, cred_in, sig_priv)
+{}
+
+PendingJoin
+PendingJoin::Inner::create(CipherSuite suite,
+                           SignaturePrivateKey sig_priv,
+                           Credential cred)
+{
+  auto inner = std::make_unique<Inner>(suite, sig_priv, cred);
+  return PendingJoin(inner.release());
+}
+
+PendingJoin::~PendingJoin() = default;
+
+PendingJoin::PendingJoin(Inner* inner_in)
+  : inner(inner_in)
 {}
 
 bytes
 PendingJoin::key_package() const
 {
-  return tls::marshal(key_package_inner);
+  return tls::marshal(inner->key_package);
 }
 
 Session
 PendingJoin::complete(const bytes& welcome) const
 {
-  return Session::join(init_priv, sig_priv, key_package_inner, welcome);
+  return Session::Inner::join(
+    inner->init_priv, inner->sig_priv, inner->key_package, welcome);
 }
 
 ///
 /// Session
 ///
 
-Session::Session()
-  : _current_epoch(0)
-  , _encrypt_handshake(false)
-{}
-
 Session
-Session::begin(const bytes& group_id,
-               const HPKEPrivateKey& init_priv,
-               const SignaturePrivateKey& sig_priv,
-               const KeyPackage& key_package)
+Session::Inner::begin(const bytes& group_id,
+                      const HPKEPrivateKey& init_priv,
+                      const SignaturePrivateKey& sig_priv,
+                      const KeyPackage& key_package)
 {
-  Session session;
-  session.add_state(0, { group_id, key_package.cipher_suite, init_priv, sig_priv, key_package });
-  return session;
+  auto inner = std::make_unique<Inner>();
+  inner->add_state(
+    0,
+    { group_id, key_package.cipher_suite, init_priv, sig_priv, key_package });
+  return Session(inner.release());
 }
 
 Session
-Session::join(const HPKEPrivateKey& init_priv,
-              const SignaturePrivateKey& sig_priv,
-              const KeyPackage& key_package,
-              const bytes& welcome_data)
+Session::Inner::join(const HPKEPrivateKey& init_priv,
+                     const SignaturePrivateKey& sig_priv,
+                     const KeyPackage& key_package,
+                     const bytes& welcome_data)
 {
   auto welcome = tls::get<Welcome>(welcome_data);
 
-  Session session;
-  session.add_state(0, { init_priv, sig_priv, key_package, welcome });
-  return session;
-}
-
-void
-Session::encrypt_handshake(bool enabled)
-{
-  _encrypt_handshake = enabled;
+  auto inner = std::make_unique<Inner>();
+  inner->add_state(0, { init_priv, sig_priv, key_package, welcome });
+  return Session(inner.release());
 }
 
 bytes
-Session::add(const bytes& key_package_data)
-{
-  auto key_package = tls::get<KeyPackage>(key_package_data);
-  auto proposal = current_state().add(key_package);
-  return export_message(proposal);
-}
-
-bytes
-Session::update()
-{
-  auto leaf_secret = fresh_secret();
-  auto proposal = current_state().update(leaf_secret);
-  return export_message(proposal);
-}
-
-bytes
-Session::remove(uint32_t index)
-{
-  auto proposal = current_state().remove(LeafIndex{ index });
-  return export_message(proposal);
-}
-
-std::tuple<bytes, bytes>
-Session::commit()
-{
-  auto commit_secret = fresh_secret();
-  auto [commit, welcome, new_state] = current_state().commit(commit_secret);
-
-  auto commit_msg = export_message(commit);
-  auto welcome_msg = tls::marshal(welcome);
-
-  _outbound_cache = std::make_tuple(commit_msg, new_state);
-  return std::make_tuple(welcome_msg, commit_msg);
-}
-
-bytes
-Session::fresh_secret() const
+Session::Inner::fresh_secret() const
 {
   const auto suite = current_state().cipher_suite();
   const auto secret_size = suite.get().hpke.kdf.hash_size();
@@ -135,9 +157,9 @@ Session::fresh_secret() const
 }
 
 bytes
-Session::export_message(const MLSPlaintext& plaintext)
+Session::Inner::export_message(const MLSPlaintext& plaintext)
 {
-  if (!_encrypt_handshake) {
+  if (!encrypt_handshake) {
     return tls::marshal(plaintext);
   }
 
@@ -146,9 +168,9 @@ Session::export_message(const MLSPlaintext& plaintext)
 }
 
 MLSPlaintext
-Session::import_message(const bytes& encoded)
+Session::Inner::import_message(const bytes& encoded)
 {
-  if (!_encrypt_handshake) {
+  if (!encrypt_handshake) {
     return tls::get<MLSPlaintext>(encoded);
   }
 
@@ -156,10 +178,105 @@ Session::import_message(const bytes& encoded)
   return current_state().decrypt(ciphertext);
 }
 
+void
+Session::Inner::add_state(epoch_t prior_epoch, const State& group_state)
+{
+  // XXX(rlb@ipv.sx) Assumes no epoch collisions, which is clearly
+  // not the case with the current linear updating.
+  state.emplace(group_state.epoch(), group_state);
+
+  // XXX(rlb@ipv.sx) First successor updates the head pointer
+  if (prior_epoch == current_epoch || state.size() == 1) {
+    current_epoch = group_state.epoch();
+  }
+}
+
+const State&
+Session::Inner::current_state() const
+{
+  if (state.count(current_epoch) == 0) {
+    throw MissingStateError("No state available for current epoch");
+  }
+
+  return state.at(current_epoch);
+}
+
+State&
+Session::Inner::current_state()
+{
+  if (state.count(current_epoch) == 0) {
+    throw MissingStateError("No state available for current epoch");
+  }
+
+  return state.at(current_epoch);
+}
+
+Session::Session(const Session& other)
+  : inner(std::make_unique<Inner>(*other.inner))
+{}
+
+Session&
+Session::operator=(const Session& other)
+{
+  if (&other != this) {
+    inner = std::make_unique<Inner>(*other.inner);
+  }
+  return *this;
+}
+
+Session::~Session() = default;
+
+Session::Session(Inner* inner_in)
+  : inner(inner_in)
+{}
+
+void
+Session::encrypt_handshake(bool enabled)
+{
+  inner->encrypt_handshake = enabled;
+}
+
+bytes
+Session::add(const bytes& key_package_data)
+{
+  auto key_package = tls::get<KeyPackage>(key_package_data);
+  auto proposal = inner->current_state().add(key_package);
+  return inner->export_message(proposal);
+}
+
+bytes
+Session::update()
+{
+  auto leaf_secret = inner->fresh_secret();
+  auto proposal = inner->current_state().update(leaf_secret);
+  return inner->export_message(proposal);
+}
+
+bytes
+Session::remove(uint32_t index)
+{
+  auto proposal = inner->current_state().remove(LeafIndex{ index });
+  return inner->export_message(proposal);
+}
+
+std::tuple<bytes, bytes>
+Session::commit()
+{
+  auto commit_secret = inner->fresh_secret();
+  auto [commit, welcome, new_state] =
+    inner->current_state().commit(commit_secret);
+
+  auto commit_msg = inner->export_message(commit);
+  auto welcome_msg = tls::marshal(welcome);
+
+  inner->outbound_cache = std::make_tuple(commit_msg, new_state);
+  return std::make_tuple(welcome_msg, commit_msg);
+}
+
 bool
 Session::handle(const bytes& handshake_data)
 {
-  auto handshake = import_message(handshake_data);
+  auto handshake = inner->import_message(handshake_data);
 
   if (handshake.sender.sender_type != SenderType::member) {
     throw ProtocolError("External senders not supported");
@@ -167,35 +284,47 @@ Session::handle(const bytes& handshake_data)
 
   auto is_commit = std::holds_alternative<CommitData>(handshake.content);
   if (is_commit &&
-      LeafIndex(handshake.sender.sender) == current_state().index()) {
-    if (!_outbound_cache.has_value()) {
+      LeafIndex(handshake.sender.sender) == inner->current_state().index()) {
+    if (!inner->outbound_cache.has_value()) {
       throw ProtocolError("Received from self without sending");
     }
 
-    const auto& cached_msg = std::get<0>(_outbound_cache.value());
-    const auto& next_state = std::get<1>(_outbound_cache.value());
+    const auto& cached_msg = std::get<0>(inner->outbound_cache.value());
+    const auto& next_state = std::get<1>(inner->outbound_cache.value());
     if (cached_msg != handshake_data) {
       throw ProtocolError("Received message different from cached");
     }
 
-    add_state(handshake.epoch, next_state);
-    _outbound_cache = std::nullopt;
+    inner->add_state(handshake.epoch, next_state);
+    inner->outbound_cache = std::nullopt;
     return true;
   }
 
-  auto maybe_next_state = current_state().handle(handshake);
+  auto maybe_next_state = inner->current_state().handle(handshake);
   if (!maybe_next_state.has_value()) {
     return false;
   }
 
-  add_state(handshake.epoch, maybe_next_state.value());
+  inner->add_state(handshake.epoch, maybe_next_state.value());
   return true;
+}
+
+epoch_t
+Session::current_epoch() const
+{
+  return inner->current_epoch;
+}
+
+uint32_t
+Session::index() const
+{
+  return inner->current_state().index().val;
 }
 
 bytes
 Session::protect(const bytes& plaintext)
 {
-  auto ciphertext = current_state().protect(plaintext);
+  auto ciphertext = inner->current_state().protect(plaintext);
   return tls::marshal(ciphertext);
 }
 
@@ -206,64 +335,31 @@ bytes
 Session::unprotect(const bytes& ciphertext)
 {
   auto ciphertext_obj = tls::get<MLSCiphertext>(ciphertext);
-  if (_state.count(ciphertext_obj.epoch) == 0) {
+  if (inner->state.count(ciphertext_obj.epoch) == 0) {
     throw MissingStateError("No state available to decrypt ciphertext");
   }
 
-  auto& state = _state.at(ciphertext_obj.epoch);
+  auto& state = inner->state.at(ciphertext_obj.epoch);
   return state.unprotect(ciphertext_obj);
-}
-
-void
-Session::add_state(epoch_t prior_epoch, const State& state)
-{
-  // XXX(rlb@ipv.sx) Assumes no epoch collisions, which is clearly
-  // not the case with the current linear updating.
-  _state.emplace(state.epoch(), state);
-
-  // XXX(rlb@ipv.sx) First successor updates the head pointer
-  if (prior_epoch == _current_epoch || _state.size() == 1) {
-    _current_epoch = state.epoch();
-  }
-}
-
-const State&
-Session::current_state() const
-{
-  if (_state.count(_current_epoch) == 0) {
-    throw MissingStateError("No state available for current epoch");
-  }
-
-  return _state.at(_current_epoch);
-}
-
-State&
-Session::current_state()
-{
-  if (_state.count(_current_epoch) == 0) {
-    throw MissingStateError("No state available for current epoch");
-  }
-
-  return _state.at(_current_epoch);
 }
 
 bool
 operator==(const Session& lhs, const Session& rhs)
 {
-  if (lhs._encrypt_handshake != rhs._encrypt_handshake) {
+  if (lhs.inner->encrypt_handshake != rhs.inner->encrypt_handshake) {
     return false;
   }
 
-  if (lhs._current_epoch != rhs._current_epoch) {
+  if (lhs.inner->current_epoch != rhs.inner->current_epoch) {
     return false;
   }
 
-  for (const auto& pair : lhs._state) {
-    if (rhs._state.count(pair.first) == 0) {
+  for (const auto& pair : lhs.inner->state) {
+    if (rhs.inner->state.count(pair.first) == 0) {
       continue;
     }
 
-    if (rhs._state.at(pair.first) != pair.second) {
+    if (rhs.inner->state.at(pair.first) != pair.second) {
       return false;
     }
   }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -95,7 +95,8 @@ PendingJoin::Inner::create(CipherSuite suite,
                            SignaturePrivateKey sig_priv,
                            Credential cred)
 {
-  auto inner = std::make_unique<Inner>(suite, std::move(sig_priv), std::move(cred));
+  auto inner =
+    std::make_unique<Inner>(suite, std::move(sig_priv), std::move(cred));
   return PendingJoin(inner.release());
 }
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -125,7 +125,7 @@ PendingJoin::complete(const bytes& welcome) const
 
 Session::Inner::Inner(State state)
   : history{ std::move(state) }
-  , encrypt_handshake(false)
+  , encrypt_handshake(true)
 {}
 
 Session

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -316,6 +316,12 @@ Session::index() const
 }
 
 bytes
+Session::do_export(const std::string& label, const bytes& context, size_t size) const
+{
+  return inner->history.front().do_export(label, context, size);
+}
+
+bytes
 Session::protect(const bytes& plaintext)
 {
   auto ciphertext = inner->history.front().protect(plaintext);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -18,12 +18,14 @@ State::State(bytes group_id,
   , _index(0)
   , _identity_priv(std::move(sig_priv))
 {
-  _keys.suite = suite;
-  _keys.init_secret = bytes(suite.get().digest.hash_size(), 0);
-
   auto index = _tree.add_leaf(key_package);
   _tree.set_hash_all();
   _tree_priv = TreeKEMPrivateKey::solo(suite, index, init_priv);
+
+  // TODO(RLB): Align this to the latest spec
+  auto group_ctx = tls::marshal(group_context());
+  auto epoch_secret = bytes(suite.get().digest.hash_size(), 0);
+  _keys = KeyScheduleEpoch::create(_suite, LeafCount(1), epoch_secret, group_ctx);
 }
 
 // Initialize a group from a Welcome

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -25,7 +25,8 @@ State::State(bytes group_id,
   // TODO(RLB): Align this to the latest spec
   auto group_ctx = tls::marshal(group_context());
   auto epoch_secret = bytes(suite.get().digest.hash_size(), 0);
-  _keys = KeyScheduleEpoch::create(_suite, LeafCount(1), epoch_secret, group_ctx);
+  _keys =
+    KeyScheduleEpoch::create(_suite, LeafCount(1), epoch_secret, group_ctx);
 }
 
 // Initialize a group from a Welcome
@@ -570,7 +571,9 @@ State::verify_confirmation(const bytes& confirmation) const
 }
 
 bytes
-State::do_export(const std::string& label, const bytes& context, size_t size) const
+State::do_export(const std::string& label,
+                 const bytes& context,
+                 size_t size) const
 {
   // TODO(RLB): Align with latest spec
   auto secret = _suite.derive_secret(_keys.exporter_secret, label, context);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -569,6 +569,14 @@ State::verify_confirmation(const bytes& confirmation) const
   return constant_time_eq(confirm, confirmation);
 }
 
+bytes
+State::do_export(const std::string& label, const bytes& context, size_t size) const
+{
+  // TODO(RLB): Align with latest spec
+  auto secret = _suite.derive_secret(_keys.exporter_secret, label, context);
+  return _suite.expand_with_label(secret, "exporter", context, size);
+}
+
 MLSCiphertext
 State::encrypt(const MLSPlaintext& pt)
 {

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1,4 +1,4 @@
-#include "mls/state.h"
+#include <mls/state.h>
 
 namespace mls {
 

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -1,4 +1,4 @@
-#include "mls/treekem.h"
+#include <mls/treekem.h>
 
 namespace mls {
 

--- a/test/key_schedule.cpp
+++ b/test/key_schedule.cpp
@@ -50,6 +50,7 @@ TEST_CASE("Key Schedule Interop")
       REQUIRE(my_epoch.handshake_secret == epoch.handshake_secret);
       REQUIRE(my_epoch.application_secret == epoch.application_secret);
 
+      REQUIRE(my_epoch.exporter_secret == epoch.exporter_secret);
       REQUIRE(my_epoch.confirmation_key == epoch.confirmation_key);
       REQUIRE(my_epoch.init_secret == epoch.init_secret);
 

--- a/test/session.cpp
+++ b/test/session.cpp
@@ -93,6 +93,11 @@ protected:
       ref = 1;
     }
 
+    auto label = std::string("test");
+    auto context = bytes{ 4, 5, 6, 7 };
+    auto size = 16;
+    auto ref_export = sessions[ref].do_export(label, context, size);
+
     // Verify that everyone ended up in consistent states, and that
     // they can send and be received.
     for (auto& session : sessions) {
@@ -112,6 +117,8 @@ protected:
         auto decrypted = other.unprotect(encrypted);
         REQUIRE(plaintext == decrypted);
       }
+
+      REQUIRE(ref_export == session.do_export(label, context, size));
     }
 
     // Verify that the epoch got updated

--- a/test/session.cpp
+++ b/test/session.cpp
@@ -16,7 +16,7 @@ protected:
 
   static const uint32_t no_except = 0xffffffff;
 
-  std::vector<TestSession> sessions;
+  std::vector<Session> sessions;
 
   HPKEPrivateKey new_init_key() { return HPKEPrivateKey::generate(suite); }
 

--- a/test/session.cpp
+++ b/test/session.cpp
@@ -77,8 +77,7 @@ protected:
 
     auto initial_epoch = sessions[0].current_epoch();
 
-    auto add_secret = fresh_secret();
-    auto [welcome, add] = sessions[from].add(add_secret, key_package);
+    auto [welcome, add] = sessions[from].add(key_package);
     auto next = Session::join({ init_info }, welcome);
     broadcast(add, index);
 
@@ -204,8 +203,7 @@ TEST_CASE_FIXTURE(RunningSessionTest, "Update within Session")
 {
   for (int i = 0; i < group_size; i += 1) {
     auto initial_epoch = sessions[0].current_epoch();
-    auto update_secret = fresh_secret();
-    auto update = sessions[i].update(update_secret);
+    auto update = sessions[i].update();
     broadcast(update);
     check(initial_epoch);
   }
@@ -216,7 +214,7 @@ TEST_CASE_FIXTURE(RunningSessionTest, "Remove within Session")
   for (int i = group_size - 1; i > 0; i -= 1) {
     auto initial_epoch = sessions[0].current_epoch();
     auto evict_secret = fresh_secret();
-    auto remove = sessions[i - 1].remove(evict_secret, i);
+    auto remove = sessions[i - 1].remove(i);
     sessions.pop_back();
     broadcast(remove);
     check(initial_epoch);
@@ -230,8 +228,7 @@ TEST_CASE_FIXTURE(RunningSessionTest, "Replace within Session")
 
     // Remove target
     auto initial_epoch = sessions[i].current_epoch();
-    auto evict_secret = fresh_secret();
-    auto remove = sessions[i].remove(evict_secret, target);
+    auto remove = sessions[i].remove(target);
     broadcast(remove, target);
     check(initial_epoch, target);
 
@@ -249,8 +246,7 @@ TEST_CASE_FIXTURE(RunningSessionTest, "Full Session Life-Cycle")
   // 2. Have everyone update
   for (int i = 0; i < group_size - 1; i += 1) {
     auto initial_epoch = sessions[0].current_epoch();
-    auto update_secret = fresh_secret();
-    auto update = sessions[i].update(update_secret);
+    auto update = sessions[i].update();
     broadcast(update);
     check(initial_epoch);
   }
@@ -258,8 +254,7 @@ TEST_CASE_FIXTURE(RunningSessionTest, "Full Session Life-Cycle")
   // 3. Remove everyone but the creator
   for (int i = group_size - 1; i > 0; i -= 1) {
     auto initial_epoch = sessions[0].current_epoch();
-    auto evict_secret = fresh_secret();
-    auto remove = sessions[i - 1].remove(evict_secret, i);
+    auto remove = sessions[i - 1].remove(i);
     sessions.pop_back();
     broadcast(remove);
     check(initial_epoch);

--- a/test/session.cpp
+++ b/test/session.cpp
@@ -190,8 +190,8 @@ TEST_CASE_FIXTURE(RunningSessionTest, "Replace within Session")
     auto initial_epoch = sessions[i].current_epoch();
     auto remove = sessions[i].remove(target);
     broadcast(remove, target);
-    auto [_welcome, commit] = sessions[i].commit();
-    broadcast(commit, target);
+    auto welcome_commit = sessions[i].commit();
+    broadcast(std::get<1>(welcome_commit), target);
     check(initial_epoch, target);
 
     // Re-add at target

--- a/test/session.cpp
+++ b/test/session.cpp
@@ -157,8 +157,8 @@ TEST_CASE_FIXTURE(RunningSessionTest, "Update within Session")
     auto update = sessions[i].update();
     broadcast(update);
 
-    auto [_welcome, commit] = sessions[i].commit();
-    broadcast(commit);
+    auto welcome_commit = sessions[i].commit();
+    broadcast(std::get<1>(welcome_commit));
 
     check(initial_epoch);
   }
@@ -174,8 +174,8 @@ TEST_CASE_FIXTURE(RunningSessionTest, "Remove within Session")
     auto remove = sessions[i - 1].remove(i);
     broadcast(remove);
 
-    auto [_welcome, commit] = sessions[i - 1].commit();
-    broadcast(commit);
+    auto welcome_commit = sessions[i - 1].commit();
+    broadcast(std::get<1>(welcome_commit));
 
     check(initial_epoch);
   }
@@ -210,8 +210,8 @@ TEST_CASE_FIXTURE(RunningSessionTest, "Full Session Life-Cycle")
     auto initial_epoch = sessions[0].current_epoch();
     auto update = sessions[i].update();
     broadcast(update);
-    auto [_welcome, commit] = sessions[i].commit();
-    broadcast(commit);
+    auto welcome_commit = sessions[i].commit();
+    broadcast(std::get<1>(welcome_commit));
     check(initial_epoch);
   }
 
@@ -221,8 +221,8 @@ TEST_CASE_FIXTURE(RunningSessionTest, "Full Session Life-Cycle")
     sessions.pop_back();
     auto remove = sessions[i - 1].remove(i);
     broadcast(remove);
-    auto [_welcome, commit] = sessions[i - 1].commit();
-    broadcast(commit);
+    auto welcome_commit = sessions[i - 1].commit();
+    broadcast(std::get<1>(welcome_commit));
     check(initial_epoch);
   }
 }

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -18,7 +18,7 @@ public:
       auto key_package =
         KeyPackage{ suite, init_priv.public_key, credential, identity_priv };
 
-      init_secrets.push_back(init_secret);
+      init_privs.push_back(init_priv);
       identity_privs.push_back(identity_priv);
       key_packages.push_back(key_package);
     }
@@ -32,7 +32,7 @@ protected:
   const bytes user_id = { 4, 5, 6, 7 };
   const bytes test_message = from_hex("01020304");
 
-  std::vector<bytes> init_secrets;
+  std::vector<HPKEPrivateKey> init_privs;
   std::vector<SignaturePrivateKey> identity_privs;
   std::vector<KeyPackage> key_packages;
   std::vector<State> states;
@@ -46,9 +46,8 @@ protected:
 TEST_CASE_FIXTURE(StateTest, "Two Person")
 {
   // Initialize the creator's state
-  auto first0 = State{
-    group_id, suite, init_secrets[0], identity_privs[0], key_packages[0]
-  };
+  auto first0 =
+    State{ group_id, suite, init_privs[0], identity_privs[0], key_packages[0] };
 
   // Create an Add proposal for the new participant
   auto add = first0.add(key_packages[1]);
@@ -60,7 +59,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person")
 
   // Initialize the second participant from the Welcome
   auto second0 =
-    State{ init_secrets[1], identity_privs[1], key_packages[1], welcome };
+    State{ init_privs[1], identity_privs[1], key_packages[1], welcome };
   REQUIRE(first1 == second0);
 
   /// Verify that they can exchange protected messages
@@ -73,7 +72,7 @@ TEST_CASE_FIXTURE(StateTest, "Add Multiple Members")
 {
   // Initialize the creator's state
   states.emplace_back(
-    group_id, suite, init_secrets[0], identity_privs[0], key_packages[0]);
+    group_id, suite, init_privs[0], identity_privs[0], key_packages[0]);
 
   // Create and process an Add proposal for each new participant
   for (size_t i = 1; i < group_size; i += 1) {
@@ -89,7 +88,7 @@ TEST_CASE_FIXTURE(StateTest, "Add Multiple Members")
   // Initialize the new joiners from the welcome
   for (size_t i = 1; i < group_size; i += 1) {
     states.emplace_back(
-      init_secrets[i], identity_privs[i], key_packages[i], welcome);
+      init_privs[i], identity_privs[i], key_packages[i], welcome);
   }
 
   // Verify that everyone can send and be received
@@ -106,7 +105,7 @@ TEST_CASE_FIXTURE(StateTest, "Full Size Group")
 {
   // Initialize the creator's state
   states.emplace_back(
-    group_id, suite, init_secrets[0], identity_privs[0], key_packages[0]);
+    group_id, suite, init_privs[0], identity_privs[0], key_packages[0]);
 
   // Each participant invites the next
   for (size_t i = 1; i < group_size; i += 1) {
@@ -126,7 +125,7 @@ TEST_CASE_FIXTURE(StateTest, "Full Size Group")
     }
 
     states.emplace_back(
-      init_secrets[i], identity_privs[i], key_packages[i], welcome);
+      init_privs[i], identity_privs[i], key_packages[i], welcome);
 
     // Check that everyone ended up in the same place
     for (const auto& state : states) {
@@ -152,7 +151,7 @@ protected:
   RunningGroupTest()
   {
     states.emplace_back(
-      group_id, suite, init_secrets[0], identity_privs[0], key_packages[0]);
+      group_id, suite, init_privs[0], identity_privs[0], key_packages[0]);
 
     for (size_t i = 1; i < group_size; i += 1) {
       auto add = states[0].add(key_packages[i]);
@@ -164,7 +163,7 @@ protected:
     states[0] = new_state;
     for (size_t i = 1; i < group_size; i += 1) {
       states.emplace_back(
-        init_secrets[i], identity_privs[i], key_packages[i], welcome);
+        init_privs[i], identity_privs[i], key_packages[i], welcome);
     }
 
     check_consistency();

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -45,7 +45,8 @@ protected:
     return random_bytes(suite.get().hpke.kdf.hash_size());
   }
 
-  void verify_group_functionality(std::vector<State>& states) {
+  void verify_group_functionality(std::vector<State>& states)
+  {
     if (states.empty()) {
       return;
     }
@@ -63,7 +64,8 @@ protected:
     auto ref = states[0].do_export(export_label, export_context, export_size);
     REQUIRE(ref.size() == export_size);
     for (auto& state : states) {
-      REQUIRE(ref == state.do_export(export_label, export_context, export_size));
+      REQUIRE(ref ==
+              state.do_export(export_label, export_context, export_size));
     }
   }
 };
@@ -87,7 +89,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person")
     State{ init_privs[1], identity_privs[1], key_packages[1], welcome };
   REQUIRE(first1 == second0);
 
-  auto group = std::vector<State>{first1, second0};
+  auto group = std::vector<State>{ first1, second0 };
   verify_group_functionality(group);
 }
 

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -390,41 +390,6 @@ public:
   KeyScheduleEpoch keys() const { return _keys; }
 };
 
-class TestSession : public Session
-{
-public:
-  using Session::Session;
-  TestSession(const Session& other)
-    : Session(other)
-  {}
-
-  uint32_t index() const { return current_state().index().val; }
-
-  epoch_t current_epoch() const { return _current_epoch; }
-
-  CipherSuite cipher_suite() const { return current_state().cipher_suite(); }
-
-  bytes current_epoch_secret() const
-  {
-    return TestState(current_state()).keys().epoch_secret;
-  }
-
-  bytes current_application_secret() const
-  {
-    return TestState(current_state()).keys().application_secret;
-  }
-
-  bytes current_confirmation_key() const
-  {
-    return TestState(current_state()).keys().confirmation_key;
-  }
-
-  bytes current_init_secret() const
-  {
-    return TestState(current_state()).keys().init_secret;
-  }
-};
-
 } // namespace mls
 
 /////

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -173,6 +173,7 @@ struct KeyScheduleTestVectors
     bytes application_secret;
     std::vector<KeyAndNonce> application_keys;
 
+    bytes exporter_secret;
     bytes confirmation_key;
     bytes init_secret;
 
@@ -185,6 +186,7 @@ struct KeyScheduleTestVectors
                      handshake_keys,
                      application_secret,
                      application_keys,
+                     exporter_secret,
                      confirmation_key,
                      init_secret);
     TLS_TRAITS(tls::pass,
@@ -196,6 +198,7 @@ struct KeyScheduleTestVectors
                tls::vector<4>,
                tls::vector<1>,
                tls::vector<4>,
+               tls::vector<1>,
                tls::vector<1>,
                tls::vector<1>)
   };


### PR DESCRIPTION
The Session API has been kind of pro-forma for a while.  This PR makes several changes that make it more usable.

* Generate secrets internally to Session, rather than making the caller provide entropy
* Don’t commit on every operation, so that callers can coalesce operations into one Commit
* Explicit join process (Client -> PendingJoin -> Session)
* Hide the internals of API classes (as a prelude to slimming down the set of public headers)
* Implement and expose the MLS exporter

There is still some work to do to make this fully functional (e.g., exposing the roster) and fully minimal (e.g., making headers private).  But this seemed like a good start.