### PR TITLE
Identify ciphers and expose credentials

### DIFF
--- a/include/mls/credential.h
+++ b/include/mls/credential.h
@@ -79,7 +79,6 @@ operator>>(tls::istream& str, X509Credential& obj);
 class Credential
 {
 public:
-  bytes identity() const;
   SignaturePublicKey public_key() const;
   bool valid_for(const SignaturePrivateKey& priv) const;
 

--- a/include/mls/credential.h
+++ b/include/mls/credential.h
@@ -53,7 +53,9 @@ struct X509Credential
 
   SignaturePublicKey public_key() const;
 
+  // TODO(rlb) This should be const or exposed via a method
   std::vector<CertData> der_chain;
+
   static const CredentialType type;
 
 private:
@@ -79,8 +81,14 @@ operator>>(tls::istream& str, X509Credential& obj);
 class Credential
 {
 public:
+  CredentialType type() const;
   SignaturePublicKey public_key() const;
   bool valid_for(const SignaturePrivateKey& priv) const;
+
+  template<typename T>
+  const T& get() const {
+    return std::get<T>(_cred);
+  }
 
   static Credential basic(const bytes& identity,
                           const SignaturePublicKey& public_key);

--- a/include/mls/credential.h
+++ b/include/mls/credential.h
@@ -86,7 +86,8 @@ public:
   bool valid_for(const SignaturePrivateKey& priv) const;
 
   template<typename T>
-  const T& get() const {
+  const T& get() const
+  {
     return std::get<T>(_cred);
   }
 

--- a/lib/hpke/include/hpke/digest.h
+++ b/lib/hpke/include/hpke/digest.h
@@ -19,14 +19,15 @@ struct Digest
   template<ID id>
   static const Digest& get();
 
+  const ID id;
+
   bytes hash(const bytes& data) const;
   bytes hmac(const bytes& key, const bytes& data) const;
 
   size_t hash_size() const;
 
 private:
-  ID id;
-  size_t output_size;
+  const size_t output_size;
 
   explicit Digest(ID id);
   friend Digest make_digest(ID id);

--- a/lib/hpke/include/hpke/hpke.h
+++ b/lib/hpke/include/hpke/hpke.h
@@ -22,7 +22,6 @@ struct KEM
   template<KEM::ID>
   static const KEM& get();
 
-  KEM(ID id_in);
   virtual ~KEM() = default;
 
   struct PublicKey
@@ -64,6 +63,9 @@ struct KEM
   virtual size_t enc_size() const = 0;
   virtual size_t pk_size() const = 0;
   virtual size_t sk_size() const = 0;
+
+  protected:
+  KEM(ID id_in);
 };
 
 struct KDF
@@ -78,7 +80,6 @@ struct KDF
   template<KDF::ID id>
   static const KDF& get();
 
-  KDF(ID id_in);
   virtual ~KDF() = default;
 
   const ID id;
@@ -99,6 +100,9 @@ struct KDF
                        const bytes& label,
                        const bytes& info,
                        size_t size) const;
+
+  protected:
+  KDF(ID id_in);
 };
 
 struct AEAD
@@ -113,7 +117,6 @@ struct AEAD
   template<AEAD::ID id>
   static const AEAD& get();
 
-  AEAD(ID id_in);
   virtual ~AEAD() = default;
 
   const ID id;
@@ -129,6 +132,9 @@ struct AEAD
 
   virtual size_t key_size() const = 0;
   virtual size_t nonce_size() const = 0;
+
+  protected:
+  AEAD(ID id_in);
 };
 
 struct Context

--- a/lib/hpke/include/hpke/hpke.h
+++ b/lib/hpke/include/hpke/hpke.h
@@ -64,7 +64,7 @@ struct KEM
   virtual size_t pk_size() const = 0;
   virtual size_t sk_size() const = 0;
 
-  protected:
+protected:
   KEM(ID id_in);
 };
 
@@ -101,7 +101,7 @@ struct KDF
                        const bytes& info,
                        size_t size) const;
 
-  protected:
+protected:
   KDF(ID id_in);
 };
 
@@ -133,7 +133,7 @@ struct AEAD
   virtual size_t key_size() const = 0;
   virtual size_t nonce_size() const = 0;
 
-  protected:
+protected:
   AEAD(ID id_in);
 };
 

--- a/lib/hpke/include/hpke/hpke.h
+++ b/lib/hpke/include/hpke/hpke.h
@@ -22,6 +22,7 @@ struct KEM
   template<KEM::ID>
   static const KEM& get();
 
+  KEM(ID id_in);
   virtual ~KEM() = default;
 
   struct PublicKey
@@ -34,6 +35,8 @@ struct KEM
     virtual ~PrivateKey() = default;
     virtual std::unique_ptr<PublicKey> public_key() const = 0;
   };
+
+  const ID id;
 
   virtual std::unique_ptr<PrivateKey> generate_key_pair() const = 0;
   virtual std::unique_ptr<PrivateKey> derive_key_pair(
@@ -75,7 +78,10 @@ struct KDF
   template<KDF::ID id>
   static const KDF& get();
 
+  KDF(ID id_in);
   virtual ~KDF() = default;
+
+  const ID id;
 
   virtual bytes extract(const bytes& salt, const bytes& ikm) const = 0;
   virtual bytes expand(const bytes& prk,
@@ -107,7 +113,10 @@ struct AEAD
   template<AEAD::ID id>
   static const AEAD& get();
 
+  AEAD(ID id_in);
   virtual ~AEAD() = default;
+
+  const ID id;
 
   virtual bytes seal(const bytes& key,
                      const bytes& nonce,

--- a/lib/hpke/include/hpke/signature.h
+++ b/lib/hpke/include/hpke/signature.h
@@ -21,7 +21,6 @@ struct Signature
   template<Signature::ID id>
   static const Signature& get();
 
-  Signature(ID id_in);
   virtual ~Signature() = default;
 
   struct PublicKey
@@ -52,6 +51,9 @@ struct Signature
   virtual bool verify(const bytes& data,
                       const bytes& sig,
                       const PublicKey& pk) const = 0;
+
+  protected:
+  Signature(ID id_in);
 };
 
 } // namespace hpke

--- a/lib/hpke/include/hpke/signature.h
+++ b/lib/hpke/include/hpke/signature.h
@@ -21,6 +21,7 @@ struct Signature
   template<Signature::ID id>
   static const Signature& get();
 
+  Signature(ID id_in);
   virtual ~Signature() = default;
 
   struct PublicKey
@@ -33,6 +34,8 @@ struct Signature
     virtual ~PrivateKey() = default;
     virtual std::unique_ptr<PublicKey> public_key() const = 0;
   };
+
+  const ID id;
 
   virtual std::unique_ptr<PrivateKey> generate_key_pair() const = 0;
   virtual std::unique_ptr<PrivateKey> derive_key_pair(

--- a/lib/hpke/include/hpke/signature.h
+++ b/lib/hpke/include/hpke/signature.h
@@ -52,7 +52,7 @@ struct Signature
                       const bytes& sig,
                       const PublicKey& pk) const = 0;
 
-  protected:
+protected:
   Signature(ID id_in);
 };
 

--- a/lib/hpke/src/aead_cipher.cpp
+++ b/lib/hpke/src/aead_cipher.cpp
@@ -106,11 +106,11 @@ openssl_cipher(AEAD::ID cipher)
   }
 }
 
-AEADCipher::AEADCipher(AEAD::ID cipher_in)
-  : cipher(cipher_in)
-  , nk(cipher_key_size(cipher_in))
-  , nn(cipher_nonce_size(cipher_in))
-  , tag_size(cipher_tag_size(cipher_in))
+AEADCipher::AEADCipher(AEAD::ID id_in)
+  : AEAD(id_in)
+  , nk(cipher_key_size(id))
+  , nn(cipher_nonce_size(id))
+  , tag_size(cipher_tag_size(id))
 {}
 
 bytes
@@ -124,8 +124,8 @@ AEADCipher::seal(const bytes& key,
     throw openssl_error();
   }
 
-  const auto* ocipher = openssl_cipher(cipher);
-  if (1 != EVP_EncryptInit(ctx.get(), ocipher, key.data(), nonce.data())) {
+  const auto* cipher = openssl_cipher(id);
+  if (1 != EVP_EncryptInit(ctx.get(), cipher, key.data(), nonce.data())) {
     throw openssl_error();
   }
 
@@ -174,8 +174,8 @@ AEADCipher::open(const bytes& key,
     throw openssl_error();
   }
 
-  const auto* ocipher = openssl_cipher(cipher);
-  if (1 != EVP_DecryptInit(ctx.get(), ocipher, key.data(), nonce.data())) {
+  const auto* cipher = openssl_cipher(id);
+  if (1 != EVP_DecryptInit(ctx.get(), cipher, key.data(), nonce.data())) {
     throw openssl_error();
   }
 

--- a/lib/hpke/src/aead_cipher.h
+++ b/lib/hpke/src/aead_cipher.h
@@ -24,12 +24,11 @@ struct AEADCipher : public AEAD
   size_t nonce_size() const override;
 
 private:
-  const AEAD::ID cipher;
   const size_t nk;
   const size_t nn;
   const size_t tag_size;
 
-  AEADCipher(AEAD::ID cipher_in);
+  AEADCipher(AEAD::ID id_in);
   friend AEADCipher make_aead(AEAD::ID cipher_in);
 
   template<AEAD::ID id>

--- a/lib/hpke/src/dhkem.cpp
+++ b/lib/hpke/src/dhkem.cpp
@@ -86,7 +86,8 @@ DHKEM::get<KEM::ID::DHKEM_X448_SHA512>()
 }
 
 DHKEM::DHKEM(KEM::ID kem_id_in, const Group& group_in, const KDF& kdf_in)
-  : group(group_in)
+  : KEM(kem_id_in)
+  , group(group_in)
   , kdf(kdf_in)
 {
   static const auto label_kem = to_bytes("KEM");

--- a/lib/hpke/src/group.cpp
+++ b/lib/hpke/src/group.cpp
@@ -283,7 +283,7 @@ private:
 
   uint8_t bitmask() const
   {
-    switch (group_id) {
+    switch (id) {
       case Group::ID::P256:
       case Group::ID::P384:
         return 0xff;
@@ -477,7 +477,7 @@ Group::get<Group::ID::Ed448>()
 size_t
 Group::dh_size() const
 {
-  switch (group_id) {
+  switch (id) {
     case Group::ID::P256:
       return 32;
     case Group::ID::P384:
@@ -497,7 +497,7 @@ Group::dh_size() const
 size_t
 Group::pk_size() const
 {
-  switch (group_id) {
+  switch (id) {
     case Group::ID::P256:
       return 65;
     case Group::ID::P384:
@@ -520,7 +520,7 @@ Group::pk_size() const
 size_t
 Group::sk_size() const
 {
-  switch (group_id) {
+  switch (id) {
     case Group::ID::P256:
       return 32;
     case Group::ID::P384:

--- a/lib/hpke/src/group.h
+++ b/lib/hpke/src/group.h
@@ -39,6 +39,8 @@ struct Group
 
   virtual ~Group() = default;
 
+  const ID id;
+
   virtual std::unique_ptr<PrivateKey> generate_key_pair() const = 0;
   virtual std::unique_ptr<PrivateKey> derive_key_pair(
     const bytes& suite_id,
@@ -63,13 +65,12 @@ struct Group
   size_t sk_size() const;
 
 protected:
-  ID group_id;
   const KDF& kdf;
 
   friend struct DHKEM;
 
   Group(ID group_id_in, const KDF& kdf_in)
-    : group_id(group_id_in)
+    : id(group_id_in)
     , kdf(kdf_in)
   {}
 };

--- a/lib/hpke/src/hkdf.cpp
+++ b/lib/hpke/src/hkdf.cpp
@@ -58,6 +58,8 @@ digest_to_kdf(Digest::ID digest_id)
     case Digest::ID::SHA512:
       return KDF::ID::HKDF_SHA512;
   }
+
+  throw std::runtime_error("Unsupported algorithm");
 }
 
 HKDF::HKDF(const Digest& digest_in)

--- a/lib/hpke/src/hkdf.cpp
+++ b/lib/hpke/src/hkdf.cpp
@@ -47,8 +47,22 @@ HKDF::get<Digest::ID::SHA512>()
   return HKDF::instance<Digest::ID::SHA512>;
 }
 
+static KDF::ID
+digest_to_kdf(Digest::ID digest_id)
+{
+  switch (digest_id) {
+    case Digest::ID::SHA256:
+      return KDF::ID::HKDF_SHA256;
+    case Digest::ID::SHA384:
+      return KDF::ID::HKDF_SHA384;
+    case Digest::ID::SHA512:
+      return KDF::ID::HKDF_SHA512;
+  }
+}
+
 HKDF::HKDF(const Digest& digest_in)
-  : digest(digest_in)
+  : KDF(digest_to_kdf(digest_in.id))
+  , digest(digest_in)
 {}
 
 bytes

--- a/lib/hpke/src/hpke.cpp
+++ b/lib/hpke/src/hpke.cpp
@@ -31,6 +31,10 @@ static const bytes label_secret = to_bytes("secret");
 /// Factory methods for primitives
 ///
 
+KEM::KEM(KEM::ID id_in)
+  : id(id_in)
+{}
+
 template<>
 const KEM&
 KEM::get<KEM::ID::DHKEM_P256_SHA256>()
@@ -114,6 +118,10 @@ KDF::get<KDF::ID::HKDF_SHA512>()
   return HKDF::get<Digest::ID::SHA512>();
 }
 
+KDF::KDF(KDF::ID id_in)
+  : id(id_in)
+{}
+
 bytes
 KDF::labeled_extract(const bytes& suite_id,
                      const bytes& salt,
@@ -155,6 +163,10 @@ AEAD::get<AEAD::ID::CHACHA20_POLY1305>()
 {
   return AEADCipher::get<AEAD::ID::CHACHA20_POLY1305>();
 }
+
+AEAD::AEAD(AEAD::ID id_in)
+  : id(id_in)
+{}
 
 ///
 /// Encryption Contexts

--- a/lib/hpke/src/signature.cpp
+++ b/lib/hpke/src/signature.cpp
@@ -21,7 +21,8 @@ struct ConcreteSignature : public Signature
     std::unique_ptr<Group::PrivateKey> group_priv;
   };
 
-  static Signature::ID group_to_sig(Group::ID group_id) {
+  static Signature::ID group_to_sig(Group::ID group_id)
+  {
     switch (group_id) {
       case Group::ID::P256:
         return Signature::ID::P256_SHA256;

--- a/lib/hpke/src/signature.cpp
+++ b/lib/hpke/src/signature.cpp
@@ -21,8 +21,26 @@ struct ConcreteSignature : public Signature
     std::unique_ptr<Group::PrivateKey> group_priv;
   };
 
+  static Signature::ID group_to_sig(Group::ID group_id) {
+    switch (group_id) {
+      case Group::ID::P256:
+        return Signature::ID::P256_SHA256;
+      case Group::ID::P384:
+        return Signature::ID::P384_SHA384;
+      case Group::ID::P521:
+        return Signature::ID::P521_SHA512;
+      case Group::ID::Ed25519:
+        return Signature::ID::Ed25519;
+      case Group::ID::Ed448:
+        return Signature::ID::Ed448;
+      default:
+        throw std::runtime_error("Unsupported group");
+    }
+  }
+
   explicit ConcreteSignature(const Group& group_in)
-    : group(group_in)
+    : Signature(group_to_sig(group_in.id))
+    , group(group_in)
   {}
 
   std::unique_ptr<Signature::PrivateKey> generate_key_pair() const override
@@ -140,6 +158,10 @@ Signature::get<Signature::ID::Ed448>()
 {
   return ConcreteSignature::instance<Signature::ID::Ed448>;
 }
+
+Signature::Signature(Signature::ID id_in)
+  : id(id_in)
+{}
 
 bytes
 Signature::serialize_private(const PrivateKey& /* unused */) const

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -90,17 +90,6 @@ operator>>(tls::istream& str, X509Credential& obj)
 /// Credential
 ///
 
-bytes
-Credential::identity() const
-{
-  switch (_cred.index()) {
-    case 0:
-      return std::get<BasicCredential>(_cred).identity;
-  }
-
-  throw std::bad_variant_access();
-}
-
 SignaturePublicKey
 Credential::public_key() const
 {

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -90,6 +90,19 @@ operator>>(tls::istream& str, X509Credential& obj)
 /// Credential
 ///
 
+CredentialType
+Credential::type() const
+{
+  switch (_cred.index()) {
+    case 0:
+      return CredentialType::basic;
+    case 1:
+      return CredentialType::x509;
+  }
+
+  throw std::bad_variant_access();
+}
+
 SignaturePublicKey
 Credential::public_key() const
 {

--- a/test/credential.cpp
+++ b/test/credential.cpp
@@ -12,7 +12,6 @@ TEST_CASE("Basic Credential")
   auto pub = priv.public_key;
 
   auto cred = Credential::basic(user_id, pub);
-  REQUIRE(cred.identity() == user_id);
   REQUIRE(cred.public_key() == pub);
 }
 

--- a/test/credential.cpp
+++ b/test/credential.cpp
@@ -13,6 +13,9 @@ TEST_CASE("Basic Credential")
 
   auto cred = Credential::basic(user_id, pub);
   REQUIRE(cred.public_key() == pub);
+
+  const auto& basic = cred.get<BasicCredential>();
+  REQUIRE(basic.identity == user_id);
 }
 
 TEST_CASE("X509 Credential Depth 2")
@@ -39,6 +42,9 @@ TEST_CASE("X509 Credential Depth 2")
 
   auto cred = Credential::x509(der_in);
   CHECK(cred.public_key().data.size() != 0);
+
+  auto x509 = cred.get<X509Credential>();
+  CHECK(x509.der_chain == der_in);
 }
 
 TEST_CASE("X509 Credential Depth 2 Marshal/Unmarshal")
@@ -69,6 +75,9 @@ TEST_CASE("X509 Credential Depth 2 Marshal/Unmarshal")
   auto marshalled = tls::marshal(original);
   auto unmarshaled = tls::get<Credential>(marshalled);
   CHECK(original.public_key() == unmarshaled.public_key());
+
+  auto x509 = unmarshaled.get<X509Credential>();
+  CHECK(x509.der_chain == der_in);
 }
 
 TEST_CASE("X509 Credential Depth 1 Marshal/Unmarshal")
@@ -91,4 +100,7 @@ TEST_CASE("X509 Credential Depth 1 Marshal/Unmarshal")
   auto marshalled = tls::marshal(original);
   auto unmarshaled = tls::get<Credential>(marshalled);
   CHECK(original.public_key() == unmarshaled.public_key());
+
+  auto x509 = unmarshaled.get<X509Credential>();
+  CHECK(x509.der_chain == der_in);
 }


### PR DESCRIPTION
Two major changes here:

* Crypto objects from the `hpke` library now all have a `const ID id` field 
* Credential objects now expose the underlying typed credential objects