### PR TITLE
Flat proposals list & constant-time add-only Commit

### DIFF
--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -304,9 +304,9 @@ generate_messages()
     key_package.extensions = ext_list;
     key_package.signature = tv.random;
 
-    // Construct DirectPath
-    auto direct_path =
-      DirectPath{ key_package,
+    // Construct UpdatePath
+    auto update_path =
+      UpdatePath{ key_package,
                   {
                     { dh_key, { fake_hpke_ciphertext, fake_hpke_ciphertext } },
                     { dh_key, { fake_hpke_ciphertext, fake_hpke_ciphertext } },
@@ -349,7 +349,7 @@ generate_messages()
       { { tv.random }, { tv.random } },
       { { tv.random }, { tv.random } },
       { { tv.random }, { tv.random } },
-      direct_path,
+      update_path,
     };
 
     // Construct an MLSCiphertext
@@ -360,7 +360,7 @@ generate_messages()
 
     tv.cases.push_back({ suite,
                          tls::marshal(key_package),
-                         tls::marshal(direct_path),
+                         tls::marshal(update_path),
                          tls::marshal(group_info),
                          tls::marshal(group_secrets),
                          tls::marshal(encrypted_group_secrets),

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -347,8 +347,6 @@ generate_messages()
     // Construct Commit
     auto commit = Commit{
       { { tv.random }, { tv.random } },
-      { { tv.random }, { tv.random } },
-      { { tv.random }, { tv.random } },
       update_path,
     };
 

--- a/include/mls/core_types.h
+++ b/include/mls/core_types.h
@@ -204,7 +204,7 @@ bool
 operator==(const KeyPackage& lhs, const KeyPackage& rhs);
 
 ///
-/// DirectPath
+/// UpdatePath
 ///
 
 // struct {
@@ -222,8 +222,8 @@ struct RatchetNode
 
 // struct {
 //    RatchetNode nodes<0..2^16-1>;
-// } DirectPath;
-struct DirectPath
+// } UpdatePath;
+struct UpdatePath
 {
   KeyPackage leaf_key_package;
   std::vector<RatchetNode> nodes;

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -206,14 +206,14 @@ struct ProposalID
 //     ProposalID updates<0..2^16-1>;
 //     ProposalID removes<0..2^16-1>;
 //     ProposalID adds<0..2^16-1>;
-//     DirectPath path;
+//     UpdatePath path;
 // } Commit;
 struct Commit
 {
   std::vector<ProposalID> updates;
   std::vector<ProposalID> removes;
   std::vector<ProposalID> adds;
-  DirectPath path;
+  UpdatePath path;
 
   TLS_SERIALIZABLE(updates, removes, adds, path)
   TLS_TRAITS(tls::vector<2>, tls::vector<2>, tls::vector<2>, tls::pass)

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -190,6 +190,8 @@ struct Proposal
 {
   std::variant<Add, Update, Remove> content;
 
+  ProposalType proposal_type() const;
+
   static const ContentType type;
   TLS_SERIALIZABLE(content)
   TLS_TRAITS(tls::variant<ProposalType>)
@@ -203,20 +205,16 @@ struct ProposalID
 };
 
 // struct {
-//     ProposalID updates<0..2^16-1>;
-//     ProposalID removes<0..2^16-1>;
-//     ProposalID adds<0..2^16-1>;
-//     UpdatePath path;
+//     ProposalID proposals<0..2^32-1>;
+//     optional<UpdatePath> path;
 // } Commit;
 struct Commit
 {
-  std::vector<ProposalID> updates;
-  std::vector<ProposalID> removes;
-  std::vector<ProposalID> adds;
-  UpdatePath path;
+  std::vector<ProposalID> proposals;
+  std::optional<UpdatePath> path;
 
-  TLS_SERIALIZABLE(updates, removes, adds, path)
-  TLS_TRAITS(tls::vector<2>, tls::vector<2>, tls::vector<2>, tls::pass)
+  TLS_SERIALIZABLE(proposals, path)
+  TLS_TRAITS(tls::vector<4>, tls::pass)
 };
 
 // struct {

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -145,8 +145,9 @@ protected:
   void apply(LeafIndex target, const Update& update);
   void apply(LeafIndex target, const Update& update, const bytes& leaf_secret);
   void apply(const Remove& remove);
-  std::vector<LeafIndex> apply(const std::vector<ProposalID>& ids);
-  std::vector<LeafIndex> apply(const Commit& commit);
+  std::vector<LeafIndex> apply(const std::vector<MLSPlaintext>& pts,
+                               ProposalType required_type);
+  std::tuple<bool, bool, std::vector<LeafIndex>> apply(const Commit& commit);
 
   // Compute a proposal ID
   ProposalID proposal_id(const MLSPlaintext& pt) const;

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -78,7 +78,7 @@ struct TreeKEMPrivateKey
   void decap(LeafIndex from,
              const TreeKEMPublicKey& pub,
              const bytes& context,
-             const DirectPath& path);
+             const UpdatePath& path);
 
   void truncate(LeafCount size);
 
@@ -107,7 +107,7 @@ struct TreeKEMPublicKey
   void update_leaf(LeafIndex index, const KeyPackage& kp);
   void blank_path(LeafIndex index);
 
-  void merge(LeafIndex from, const DirectPath& path);
+  void merge(LeafIndex from, const UpdatePath& path);
   void set_hash_all();
   bytes root_hash() const;
   LeafCount size() const;
@@ -116,7 +116,7 @@ struct TreeKEMPublicKey
   std::optional<KeyPackage> key_package(LeafIndex index) const;
   std::vector<NodeIndex> resolve(NodeIndex index) const;
 
-  std::tuple<TreeKEMPrivateKey, DirectPath> encap(
+  std::tuple<TreeKEMPrivateKey, UpdatePath> encap(
     LeafIndex from,
     const bytes& context,
     const bytes& leaf_secret,

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -125,11 +125,11 @@ operator==(const KeyPackage& lhs, const KeyPackage& rhs)
 }
 
 ///
-/// DirectPath
+/// UpdatePath
 ///
 
 void
-DirectPath::sign(CipherSuite suite,
+UpdatePath::sign(CipherSuite suite,
                  const HPKEPublicKey& init_pub,
                  const SignaturePrivateKey& sig_priv,
                  const std::optional<KeyPackageOpts>& opts)

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -151,6 +151,13 @@ const ProposalType Add::type = ProposalType::add;
 const ProposalType Update::type = ProposalType::update;
 const ProposalType Remove::type = ProposalType::remove;
 
+ProposalType
+Proposal::proposal_type() const
+{
+  static auto get_type = [](auto&& v) -> ProposalType { return v.type; };
+  return std::visit(get_type, content);
+}
+
 const ContentType Proposal::type = ContentType::proposal;
 const ContentType CommitData::type = ContentType::commit;
 const ContentType ApplicationData::type = ContentType::application;

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -328,7 +328,7 @@ State::handle(const MLSPlaintext& pt)
   State next = *this;
   next.apply(commit_data.commit);
 
-  // Decapsulate and apply the DirectPath
+  // Decapsulate and apply the UpdatePath
   auto ctx = tls::marshal(GroupContext{
     next._group_id,
     next._epoch + 1,

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -193,39 +193,51 @@ State::commit(const bytes& leaf_secret) const
   auto joiners = std::vector<KeyPackage>{};
   for (const auto& pt : _pending_proposals) {
     auto id = proposal_id(pt);
-    auto proposal = std::get<Proposal>(pt.content).content;
+    const auto& proposal = std::get<Proposal>(pt.content).content;
     if (std::holds_alternative<Add>(proposal)) {
-      commit.adds.push_back(id);
-      auto add = std::get<Add>(proposal);
+      const auto& add = std::get<Add>(proposal);
       joiners.push_back(add.key_package);
-    } else if (std::holds_alternative<Update>(proposal)) {
-      commit.updates.push_back(id);
-    } else if (std::holds_alternative<Remove>(proposal)) {
-      commit.removes.push_back(id);
     }
+
+    commit.proposals.push_back(id);
   }
 
   // Apply proposals
   State next = *this;
-  auto joiner_locations = next.apply(commit);
+  auto [has_updates, has_removes, joiner_locations] = next.apply(commit);
   next._pending_proposals.clear();
 
   // KEM new entropy to the group and the new joiners
-  auto ctx = tls::marshal(GroupContext{
-    next._group_id,
-    next._epoch + 1,
-    next._tree.root_hash(),
-    next._confirmed_transcript_hash,
-    next._extensions,
-  });
-  auto [new_priv, path] =
-    next._tree.encap(_index, ctx, leaf_secret, _identity_priv, std::nullopt);
-  next._tree_priv = new_priv;
-  commit.path = path;
+  auto path_required = has_updates || has_removes || commit.proposals.empty();
+  auto update_secret = bytes(_suite.get().hpke.kdf.hash_size(), 0);
+  auto path_secrets =
+    std::vector<std::optional<bytes>>(joiner_locations.size());
+  if (path_required) {
+    auto ctx = tls::marshal(GroupContext{
+      next._group_id,
+      next._epoch + 1,
+      next._tree.root_hash(),
+      next._confirmed_transcript_hash,
+      next._extensions,
+    });
+    auto [new_priv, path] =
+      next._tree.encap(_index, ctx, leaf_secret, _identity_priv, std::nullopt);
+    next._tree_priv = new_priv;
+    commit.path = path;
+    update_secret = new_priv.update_secret;
+
+    for (size_t i = 0; i < joiner_locations.size(); i++) {
+      auto [overlap, shared_path_secret, ok] =
+        new_priv.shared_path_secret(joiner_locations[i]);
+      silence_unused(overlap);
+      silence_unused(ok);
+
+      path_secrets[i] = shared_path_secret;
+    }
+  }
 
   // Create the Commit message and advance the transcripts / key schedule
-  auto pt =
-    next.ratchet_and_sign(commit, new_priv.update_secret, group_context());
+  auto pt = next.ratchet_and_sign(commit, update_secret, group_context());
 
   // Complete the GroupInfo and form the Welcome
   auto group_info = GroupInfo{
@@ -241,11 +253,7 @@ State::commit(const bytes& leaf_secret) const
 
   auto welcome = Welcome{ _suite, next._keys.epoch_secret, group_info };
   for (size_t i = 0; i < joiners.size(); i++) {
-    auto [overlap, path_secret, ok] =
-      new_priv.shared_path_secret(joiner_locations[i]);
-    silence_unused(overlap);
-    silence_unused(ok);
-    welcome.encrypt(joiners[i], path_secret);
+    welcome.encrypt(joiners[i], path_secrets[i]);
   }
 
   return std::make_tuple(pt, welcome, next);
@@ -328,16 +336,21 @@ State::handle(const MLSPlaintext& pt)
   State next = *this;
   next.apply(commit_data.commit);
 
-  // Decapsulate and apply the UpdatePath
-  auto ctx = tls::marshal(GroupContext{
-    next._group_id,
-    next._epoch + 1,
-    next._tree.root_hash(),
-    next._confirmed_transcript_hash,
-    next._extensions,
-  });
-  next._tree_priv.decap(sender, next._tree, ctx, commit_data.commit.path);
-  next._tree.merge(sender, commit_data.commit.path);
+  // Decapsulate and apply the UpdatePath, if provided
+  auto update_secret = bytes(_suite.get().hpke.kdf.hash_size(), 0);
+  if (commit_data.commit.path.has_value()) {
+    auto ctx = tls::marshal(GroupContext{
+      next._group_id,
+      next._epoch + 1,
+      next._tree.root_hash(),
+      next._confirmed_transcript_hash,
+      next._extensions,
+    });
+    const auto& path = commit_data.commit.path.value();
+    next._tree_priv.decap(sender, next._tree, ctx, path);
+    next._tree.merge(sender, path);
+    update_secret = next._tree_priv.update_secret;
+  }
 
   // Update the transcripts and advance the key schedule
   next._confirmed_transcript_hash = _suite.get().digest.hash(
@@ -346,7 +359,7 @@ State::handle(const MLSPlaintext& pt)
     next._confirmed_transcript_hash + pt.commit_auth_data());
 
   next._epoch += 1;
-  next.update_epoch_secrets(next._tree_priv.update_secret);
+  next.update_epoch_secrets(update_secret);
 
   // Verify the confirmation MAC
   if (!next.verify_confirmation(commit_data.confirmation)) {
@@ -404,53 +417,82 @@ State::find_proposal(const ProposalID& id)
 }
 
 std::vector<LeafIndex>
-State::apply(const std::vector<ProposalID>& ids)
+State::apply(const std::vector<MLSPlaintext>& pts, ProposalType required_type)
 {
-  auto joiner_locations = std::vector<LeafIndex>{};
-  for (const auto& id : ids) {
-    auto maybe_pt = find_proposal(id);
-    if (!maybe_pt.has_value()) {
-      throw ProtocolError("Commit of unknown proposal");
+  auto locations = std::vector<LeafIndex>{};
+  for (const auto& pt : pts) {
+    auto proposal = std::get<Proposal>(pt.content).content;
+    auto proposal_type = std::get<Proposal>(pt.content).proposal_type();
+    if (proposal_type != required_type) {
+      continue;
     }
 
-    auto pt = maybe_pt.value();
-    auto proposal = std::get<Proposal>(pt.content).content;
-    if (std::holds_alternative<Add>(proposal)) {
-      joiner_locations.push_back(apply(std::get<Add>(proposal)));
-    } else if (std::holds_alternative<Update>(proposal)) {
-      auto& update = std::get<Update>(proposal);
-      auto sender = LeafIndex(pt.sender.sender);
-      if (sender != _index) {
-        apply(sender, update);
+    switch (proposal_type) {
+      case ProposalType::add: {
+        locations.push_back(apply(std::get<Add>(proposal)));
         break;
       }
 
-      if (_update_secrets.count(id.id) == 0) {
-        throw ProtocolError("Self-update with no cached secret");
+      case ProposalType::update: {
+        auto& update = std::get<Update>(proposal);
+        auto sender = LeafIndex(pt.sender.sender);
+        if (sender != _index) {
+          apply(sender, update);
+          break;
+        }
+
+        auto id = proposal_id(pt);
+        if (_update_secrets.count(id.id) == 0) {
+          throw ProtocolError("Self-update with no cached secret");
+        }
+
+        apply(sender, update, _update_secrets[id.id]);
+        locations.push_back(sender);
+        break;
       }
 
-      apply(sender, update, _update_secrets[id.id]);
-    } else if (std::holds_alternative<Remove>(proposal)) {
-      apply(std::get<Remove>(proposal));
-    } else {
-      throw InvalidParameterError("Invalid proposal type");
+      case ProposalType::remove: {
+        const auto& remove = std::get<Remove>(proposal);
+        apply(remove);
+        locations.push_back(remove.removed);
+        break;
+      }
+
+      default:
+        throw ProtocolError("Unknown proposal type");
     }
   }
 
-  return joiner_locations;
+  return locations;
 }
 
-std::vector<LeafIndex>
+std::tuple<bool, bool, std::vector<LeafIndex>>
 State::apply(const Commit& commit)
 {
-  apply(commit.updates);
-  apply(commit.removes);
-  auto joiner_locations = apply(commit.adds);
+  auto pts = std::vector<MLSPlaintext>(commit.proposals.size());
+  std::transform(commit.proposals.begin(),
+                 commit.proposals.end(),
+                 pts.begin(),
+                 [&](auto& id) {
+                   auto maybe_pt = find_proposal(id);
+                   if (!maybe_pt.has_value()) {
+                     throw ProtocolError("Commit of unknown proposal");
+                   }
+
+                   return maybe_pt.value();
+                 });
+
+  auto update_locations = apply(pts, ProposalType::update);
+  auto remove_locations = apply(pts, ProposalType::remove);
+  auto joiner_locations = apply(pts, ProposalType::add);
+
+  auto has_updates = !update_locations.empty();
+  auto has_removes = !remove_locations.empty();
 
   _tree.truncate();
   _tree_priv.truncate(_tree.size());
   _tree.set_hash_all();
-  return joiner_locations;
+  return std::make_tuple(has_updates, has_removes, joiner_locations);
 }
 
 ///

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -181,7 +181,7 @@ void
 TreeKEMPrivateKey::decap(LeafIndex from,
                          const TreeKEMPublicKey& pub,
                          const bytes& context,
-                         const DirectPath& path)
+                         const UpdatePath& path)
 {
   // Identify which node in the path secret we will be decrypting
   auto ni = NodeIndex(index);
@@ -366,7 +366,7 @@ TreeKEMPublicKey::blank_path(LeafIndex index)
 }
 
 void
-TreeKEMPublicKey::merge(LeafIndex from, const DirectPath& path)
+TreeKEMPublicKey::merge(LeafIndex from, const UpdatePath& path)
 {
   auto ni = NodeIndex(from);
   node_at(ni).node = Node{ path.leaf_key_package };
@@ -469,7 +469,7 @@ TreeKEMPublicKey::key_package(LeafIndex index) const
   return std::get<KeyPackage>(node.value().node);
 }
 
-std::tuple<TreeKEMPrivateKey, DirectPath>
+std::tuple<TreeKEMPrivateKey, UpdatePath>
 TreeKEMPublicKey::encap(LeafIndex from,
                         const bytes& context,
                         const bytes& leaf_secret,
@@ -482,13 +482,13 @@ TreeKEMPublicKey::encap(LeafIndex from,
     throw InvalidParameterError("Cannot encap from blank node");
   }
 
-  auto path = DirectPath{};
+  auto path = UpdatePath{};
   path.leaf_key_package = std::get<KeyPackage>(maybe_node.value().node);
 
   // Generate path secrets
   auto priv = TreeKEMPrivateKey::create(suite, size(), from, leaf_secret);
 
-  // Package into a DirectPath
+  // Package into a UpdatePath
   auto last = NodeIndex(from);
   for (auto n : tree_math::dirpath(NodeIndex(from), NodeCount(size()))) {
     auto path_secret = priv.path_secrets.at(n);
@@ -507,7 +507,7 @@ TreeKEMPublicKey::encap(LeafIndex from,
     last = n;
   }
 
-  // Sign the DirectPath
+  // Sign the UpdatePath
   auto leaf_priv = priv.private_key(NodeIndex(from)).value();
   path.sign(suite, leaf_priv.public_key, sig_priv, opts);
 

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -115,17 +115,23 @@ TEST_CASE("Messages Interop")
 
     // Proposals
     auto add_prop = Proposal{ Add{ key_package } };
+    CHECK(add_prop.proposal_type() == ProposalType::add);
+
     auto add_hs = MLSPlaintext{ tv.group_id, tv.epoch, tv.sender, add_prop };
     add_hs.signature = tv.random;
     tls_round_trip(tc.add_proposal, add_hs, true);
 
     auto update_prop = Proposal{ Update{ key_package } };
+    CHECK(update_prop.proposal_type() == ProposalType::update);
+
     auto update_hs =
       MLSPlaintext{ tv.group_id, tv.epoch, tv.sender, update_prop };
     update_hs.signature = tv.random;
     tls_round_trip(tc.update_proposal, update_hs, true);
 
     auto remove_prop = Proposal{ Remove{ LeafIndex(tv.sender.sender) } };
+    CHECK(remove_prop.proposal_type() == ProposalType::remove);
+
     auto remove_hs =
       MLSPlaintext{ tv.group_id, tv.epoch, tv.sender, remove_prop };
     remove_hs.signature = tv.random;
@@ -133,8 +139,6 @@ TEST_CASE("Messages Interop")
 
     // Commit
     auto commit = Commit{
-      { { tv.random }, { tv.random } },
-      { { tv.random }, { tv.random } },
       { { tv.random }, { tv.random } },
       update_path,
     };

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -82,14 +82,14 @@ TEST_CASE("Messages Interop")
     key_package.signature = tv.random;
     tls_round_trip(tc.key_package, key_package, reproducible);
 
-    // DirectPath
-    auto direct_path =
-      DirectPath{ key_package,
+    // UpdatePath
+    auto update_path =
+      UpdatePath{ key_package,
                   {
                     { dh_key, { fake_hpke_ciphertext, fake_hpke_ciphertext } },
                     { dh_key, { fake_hpke_ciphertext, fake_hpke_ciphertext } },
                   } };
-    tls_round_trip(tc.direct_path, direct_path, reproducible);
+    tls_round_trip(tc.update_path, update_path, reproducible);
 
     // GroupInfo, GroupSecrets, EncryptedGroupSecrets, and Welcome
     auto group_info = GroupInfo{ tv.group_id, tv.epoch, tree,     tv.random,
@@ -136,7 +136,7 @@ TEST_CASE("Messages Interop")
       { { tv.random }, { tv.random } },
       { { tv.random }, { tv.random } },
       { { tv.random }, { tv.random } },
-      direct_path,
+      update_path,
     };
     tls_round_trip(tc.commit, commit, true);
 

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -308,7 +308,7 @@ struct MessagesTestVectors
     CipherSuite cipher_suite;
 
     bytes key_package;
-    bytes direct_path;
+    bytes update_path;
     bytes group_info;
     bytes group_secrets;
     bytes encrypted_group_secrets;
@@ -321,7 +321,7 @@ struct MessagesTestVectors
 
     TLS_SERIALIZABLE(cipher_suite,
                      key_package,
-                     direct_path,
+                     update_path,
                      group_info,
                      group_secrets,
                      encrypted_group_secrets,

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -161,7 +161,7 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Public Key")
     auto index = LeafIndex(i);
     auto curr_size = LeafCount(i + 1);
 
-    auto path = DirectPath{ kp_path, {} };
+    auto path = UpdatePath{ kp_path, {} };
     auto dp = tree_math::dirpath(NodeIndex(index), NodeCount(curr_size));
     while (path.nodes.size() < dp.size()) {
       auto node_pub = HPKEPrivateKey::generate(suite).public_key;


### PR DESCRIPTION
In the current spec, the separate `adds`, `updates`, and `removes` arrays have been replaced by a single `proposals` array.  Also, a TreeKEM UpdatePath is only required when updating/removing.  This PR aligns mlspp with these changes.