### PR TITLE
Detach variants from contained types

### DIFF
--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -352,8 +352,9 @@ generate_messages()
 
     // Construct an MLSCiphertext
     auto ciphertext = MLSCiphertext{
-      tv.group_id, tv.epoch,  ContentType::application, tv.random, tv.random,
-      tv.random,   tv.random,
+      tv.group_id, tv.epoch,  ContentType::selector::application,
+      tv.random,   tv.random, tv.random,
+      tv.random,
     };
 
     tv.cases.push_back({ suite,

--- a/include/mls/core_types.h
+++ b/include/mls/core_types.h
@@ -126,19 +126,12 @@ struct ParentHashExtension
 /// NodeType, ParentNode, and KeyPackage
 ///
 
-enum class NodeType : uint8_t
-{
-  leaf = 0x00,
-  parent = 0x01,
-};
-
 struct ParentNode
 {
   HPKEPublicKey public_key;
   std::vector<LeafIndex> unmerged_leaves;
   bytes parent_hash;
 
-  static const NodeType type;
   TLS_SERIALIZABLE(public_key, unmerged_leaves, parent_hash)
   TLS_TRAITS(tls::pass, tls::vector<4>, tls::vector<1>)
 };
@@ -180,7 +173,6 @@ struct KeyPackage
   bool verify_extension_support(const ExtensionList& ext_list) const;
   bool verify() const;
 
-  static const NodeType type;
   TLS_SERIALIZABLE(version,
                    cipher_suite,
                    init_key,

--- a/include/mls/credential.h
+++ b/include/mls/credential.h
@@ -10,7 +10,8 @@ namespace mls {
 //     x509(1),
 //     (255)
 // } CredentialType;
-struct CredentialType {
+struct CredentialType
+{
   enum struct selector : uint8_t
   {
     basic = 0,

--- a/include/mls/credential.h
+++ b/include/mls/credential.h
@@ -10,10 +10,15 @@ namespace mls {
 //     x509(1),
 //     (255)
 // } CredentialType;
-enum struct CredentialType : uint8_t
-{
-  basic = 0,
-  x509 = 1,
+struct CredentialType {
+  enum struct selector : uint8_t
+  {
+    basic = 0,
+    x509 = 1,
+  };
+
+  template<typename T>
+  static const selector type;
 };
 
 // struct {
@@ -34,8 +39,6 @@ struct BasicCredential
 
   TLS_SERIALIZABLE(identity, public_key)
   TLS_TRAITS(tls::vector<2>, tls::pass)
-
-  static const CredentialType type;
 };
 
 struct X509Credential
@@ -55,8 +58,6 @@ struct X509Credential
 
   // TODO(rlb) This should be const or exposed via a method
   std::vector<CertData> der_chain;
-
-  static const CredentialType type;
 
 private:
   SignaturePublicKey _public_key;
@@ -84,7 +85,7 @@ operator==(const X509Credential& lhs, const X509Credential& rhs);
 class Credential
 {
 public:
-  CredentialType type() const;
+  CredentialType::selector type() const;
   SignaturePublicKey public_key() const;
   bool valid_for(const SignaturePrivateKey& priv) const;
 

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -139,36 +139,34 @@ private:
 ///
 /// Proposals & Commit
 ///
+struct ProposalType {
+  enum struct selector : uint8_t
+  {
+    invalid = 0,
+    add = 1,
+    update = 2,
+    remove = 3,
+  };
 
-enum struct ProposalType : uint8_t
-{
-  invalid = 0,
-  add = 1,
-  update = 2,
-  remove = 3,
+  template<typename T>
+  static const selector type;
 };
 
 struct Add
 {
   KeyPackage key_package;
-
-  static const ProposalType type;
   TLS_SERIALIZABLE(key_package)
 };
 
 struct Update
 {
   KeyPackage key_package;
-
-  static const ProposalType type;
   TLS_SERIALIZABLE(key_package)
 };
 
 struct Remove
 {
   LeafIndex removed;
-
-  static const ProposalType type;
   TLS_SERIALIZABLE(removed)
 };
 
@@ -178,21 +176,25 @@ struct Remove
 //     application(2),
 //     (255)
 // } ContentType;
-enum struct ContentType : uint8_t
-{
-  invalid = 0,
-  application = 1,
-  proposal = 2,
-  commit = 3,
+struct ContentType {
+  enum struct selector : uint8_t
+  {
+    invalid = 0,
+    application = 1,
+    proposal = 2,
+    commit = 3,
+  };
+
+  template<typename T>
+  static const selector type;
 };
 
 struct Proposal
 {
   std::variant<Add, Update, Remove> content;
 
-  ProposalType proposal_type() const;
+  ProposalType::selector proposal_type() const;
 
-  static const ContentType type;
   TLS_SERIALIZABLE(content)
   TLS_TRAITS(tls::variant<ProposalType>)
 };
@@ -237,8 +239,6 @@ struct Commit
 struct ApplicationData
 {
   bytes data;
-
-  static const ContentType type;
   TLS_SERIALIZABLE(data)
   TLS_TRAITS(tls::vector<4>)
 };
@@ -248,7 +248,6 @@ struct CommitData
   Commit commit;
   bytes confirmation;
 
-  static const ContentType type;
   TLS_SERIALIZABLE(commit, confirmation)
   TLS_TRAITS(tls::pass, tls::vector<1>)
 };
@@ -287,7 +286,7 @@ struct MLSPlaintext
   MLSPlaintext(bytes group_id,
                epoch_t epoch,
                Sender sender,
-               ContentType content_type,
+               ContentType::selector content_type,
                bytes authenticated_data,
                const bytes& content);
 
@@ -341,7 +340,7 @@ struct MLSCiphertext
 {
   bytes group_id;
   epoch_t epoch;
-  ContentType content_type;
+  ContentType::selector content_type;
   bytes sender_data_nonce;
   bytes encrypted_sender_data;
   bytes authenticated_data;

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -139,7 +139,8 @@ private:
 ///
 /// Proposals & Commit
 ///
-struct ProposalType {
+struct ProposalType
+{
   enum struct selector : uint8_t
   {
     invalid = 0,
@@ -176,7 +177,8 @@ struct Remove
 //     application(2),
 //     (255)
 // } ContentType;
-struct ContentType {
+struct ContentType
+{
   enum struct selector : uint8_t
   {
     invalid = 0,

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -146,7 +146,7 @@ protected:
   void apply(LeafIndex target, const Update& update, const bytes& leaf_secret);
   void apply(const Remove& remove);
   std::vector<LeafIndex> apply(const std::vector<MLSPlaintext>& pts,
-                               ProposalType required_type);
+                               ProposalType::selector required_type);
   std::tuple<bool, bool, std::vector<LeafIndex>> apply(const Commit& commit);
 
   // Compute a proposal ID

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -8,6 +8,17 @@
 
 namespace mls {
 
+struct NodeType {
+  enum class selector : uint8_t
+  {
+    leaf = 0x00,
+    parent = 0x01,
+  };
+
+  template<typename T>
+  static const selector type;
+};
+
 struct Node
 {
   std::variant<KeyPackage, ParentNode> node;

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -8,7 +8,8 @@
 
 namespace mls {
 
-struct NodeType {
+struct NodeType
+{
   enum class selector : uint8_t
   {
     leaf = 0x00,

--- a/lib/tls_syntax/test/tls_syntax.cpp
+++ b/lib/tls_syntax/test/tls_syntax.cpp
@@ -11,7 +11,8 @@ enum struct IntType : uint16_t
   uint16 = 0xBBBB,
 };
 
-struct IntSelector {
+struct IntSelector
+{
   using selector = IntType;
 
   template<typename T>

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -31,8 +31,6 @@ ExtensionList::has(ExtensionType type) const
 /// NodeType, ParentNode, and KeyPackage
 ///
 
-const NodeType KeyPackage::type = NodeType::leaf;
-
 KeyPackage::KeyPackage()
   : version(ProtocolVersion::mls10)
   , cipher_suite{ CipherSuite::ID::unknown }

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -5,16 +5,18 @@
 namespace mls {
 
 ///
-/// BasicCredential
+/// CredentialType
 ///
 
-const CredentialType BasicCredential::type = CredentialType::basic;
+template<>
+const CredentialType::selector CredentialType::type<BasicCredential> = CredentialType::selector::basic;
+
+template<>
+const CredentialType::selector CredentialType::type<X509Credential> = CredentialType::selector::x509;
 
 ///
 /// X509Credential
 ///
-
-const CredentialType X509Credential::type = CredentialType::x509;
 
 using hpke::Certificate; // NOLINT(misc-unused-using-decls)
 using hpke::Signature;   // NOLINT(misc-unused-using-decls)
@@ -96,14 +98,14 @@ operator==(const X509Credential& lhs, const X509Credential& rhs)
 /// Credential
 ///
 
-CredentialType
+CredentialType::selector
 Credential::type() const
 {
   switch (_cred.index()) {
     case 0:
-      return CredentialType::basic;
+      return CredentialType::selector::basic;
     case 1:
-      return CredentialType::x509;
+      return CredentialType::selector::x509;
   }
 
   throw std::bad_variant_access();

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -9,10 +9,12 @@ namespace mls {
 ///
 
 template<>
-const CredentialType::selector CredentialType::type<BasicCredential> = CredentialType::selector::basic;
+const CredentialType::selector CredentialType::type<BasicCredential> =
+  CredentialType::selector::basic;
 
 template<>
-const CredentialType::selector CredentialType::type<X509Credential> = CredentialType::selector::x509;
+const CredentialType::selector CredentialType::type<X509Credential> =
+  CredentialType::selector::x509;
 
 ///
 /// X509Credential

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -148,13 +148,16 @@ Welcome::group_info_key_nonce(const bytes& epoch_secret) const
 // MLSPlaintext
 
 template<>
-const ProposalType::selector ProposalType::type<Add> = ProposalType::selector::add;
+const ProposalType::selector ProposalType::type<Add> =
+  ProposalType::selector::add;
 
 template<>
-const ProposalType::selector ProposalType::type<Update> = ProposalType::selector::update;
+const ProposalType::selector ProposalType::type<Update> =
+  ProposalType::selector::update;
 
 template<>
-const ProposalType::selector ProposalType::type<Remove> = ProposalType::selector::remove;
+const ProposalType::selector ProposalType::type<Remove> =
+  ProposalType::selector::remove;
 
 ProposalType::selector
 Proposal::proposal_type() const
@@ -167,13 +170,16 @@ Proposal::proposal_type() const
 }
 
 template<>
-const ContentType::selector ContentType::type<Proposal> = ContentType::selector::proposal;
+const ContentType::selector ContentType::type<Proposal> =
+  ContentType::selector::proposal;
 
 template<>
-const ContentType::selector ContentType::type<CommitData> = ContentType::selector::commit;
+const ContentType::selector ContentType::type<CommitData> =
+  ContentType::selector::commit;
 
 template<>
-const ContentType::selector ContentType::type<ApplicationData> = ContentType::selector::application;
+const ContentType::selector ContentType::type<ApplicationData> =
+  ContentType::selector::application;
 
 MLSPlaintext::MLSPlaintext(bytes group_id_in,
                            epoch_t epoch_in,

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -147,25 +147,38 @@ Welcome::group_info_key_nonce(const bytes& epoch_secret) const
 
 // MLSPlaintext
 
-const ProposalType Add::type = ProposalType::add;
-const ProposalType Update::type = ProposalType::update;
-const ProposalType Remove::type = ProposalType::remove;
+template<>
+const ProposalType::selector ProposalType::type<Add> = ProposalType::selector::add;
 
-ProposalType
+template<>
+const ProposalType::selector ProposalType::type<Update> = ProposalType::selector::update;
+
+template<>
+const ProposalType::selector ProposalType::type<Remove> = ProposalType::selector::remove;
+
+ProposalType::selector
 Proposal::proposal_type() const
 {
-  static auto get_type = [](auto&& v) -> ProposalType { return v.type; };
+  static auto get_type = [](auto&& v) {
+    using type = typename std::decay<decltype(v)>::type;
+    return ProposalType::template type<type>;
+  };
   return std::visit(get_type, content);
 }
 
-const ContentType Proposal::type = ContentType::proposal;
-const ContentType CommitData::type = ContentType::commit;
-const ContentType ApplicationData::type = ContentType::application;
+template<>
+const ContentType::selector ContentType::type<Proposal> = ContentType::selector::proposal;
+
+template<>
+const ContentType::selector ContentType::type<CommitData> = ContentType::selector::commit;
+
+template<>
+const ContentType::selector ContentType::type<ApplicationData> = ContentType::selector::application;
 
 MLSPlaintext::MLSPlaintext(bytes group_id_in,
                            epoch_t epoch_in,
                            Sender sender_in,
-                           ContentType content_type_in,
+                           ContentType::selector content_type_in,
                            bytes authenticated_data_in,
                            const bytes& content_in)
   : group_id(std::move(group_id_in))
@@ -176,19 +189,19 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
 {
   tls::istream r(content_in);
   switch (content_type_in) {
-    case ContentType::application: {
+    case ContentType::selector::application: {
       auto& application_data = content.emplace<ApplicationData>();
       r >> application_data;
       break;
     }
 
-    case ContentType::proposal: {
+    case ContentType::selector::proposal: {
       auto& proposal = content.emplace<Proposal>();
       r >> proposal;
       break;
     }
 
-    case ContentType::commit: {
+    case ContentType::selector::commit: {
       auto& commit_data = content.emplace<CommitData>();
       r >> commit_data;
       break;

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -417,7 +417,8 @@ State::find_proposal(const ProposalID& id)
 }
 
 std::vector<LeafIndex>
-State::apply(const std::vector<MLSPlaintext>& pts, ProposalType::selector required_type)
+State::apply(const std::vector<MLSPlaintext>& pts,
+             ProposalType::selector required_type)
 {
   auto locations = std::vector<LeafIndex>{};
   for (const auto& pt : pts) {

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -417,7 +417,7 @@ State::find_proposal(const ProposalID& id)
 }
 
 std::vector<LeafIndex>
-State::apply(const std::vector<MLSPlaintext>& pts, ProposalType required_type)
+State::apply(const std::vector<MLSPlaintext>& pts, ProposalType::selector required_type)
 {
   auto locations = std::vector<LeafIndex>{};
   for (const auto& pt : pts) {
@@ -428,12 +428,12 @@ State::apply(const std::vector<MLSPlaintext>& pts, ProposalType required_type)
     }
 
     switch (proposal_type) {
-      case ProposalType::add: {
+      case ProposalType::selector::add: {
         locations.push_back(apply(std::get<Add>(proposal)));
         break;
       }
 
-      case ProposalType::update: {
+      case ProposalType::selector::update: {
         auto& update = std::get<Update>(proposal);
         auto sender = LeafIndex(pt.sender.sender);
         if (sender != _index) {
@@ -451,7 +451,7 @@ State::apply(const std::vector<MLSPlaintext>& pts, ProposalType required_type)
         break;
       }
 
-      case ProposalType::remove: {
+      case ProposalType::selector::remove: {
         const auto& remove = std::get<Remove>(proposal);
         apply(remove);
         locations.push_back(remove.removed);
@@ -482,9 +482,9 @@ State::apply(const Commit& commit)
                    return maybe_pt.value();
                  });
 
-  auto update_locations = apply(pts, ProposalType::update);
-  auto remove_locations = apply(pts, ProposalType::remove);
-  auto joiner_locations = apply(pts, ProposalType::add);
+  auto update_locations = apply(pts, ProposalType::selector::update);
+  auto remove_locations = apply(pts, ProposalType::selector::remove);
+  auto joiner_locations = apply(pts, ProposalType::selector::add);
 
   auto has_updates = !update_locations.empty();
   auto has_removes = !remove_locations.empty();
@@ -579,7 +579,7 @@ State::update_epoch_secrets(const bytes& update_secret)
 static bytes
 content_aad(const bytes& group_id,
             uint32_t epoch,
-            ContentType content_type,
+            ContentType::selector content_type,
             const bytes& authenticated_data,
             const bytes& sender_data_nonce,
             const bytes& encrypted_sender_data)
@@ -602,7 +602,7 @@ content_aad(const bytes& group_id,
 static bytes
 sender_data_aad(const bytes& group_id,
                 uint32_t epoch,
-                ContentType content_type,
+                ContentType::selector content_type,
                 const bytes& sender_data_nonce)
 {
   tls::ostream w;
@@ -672,16 +672,16 @@ State::encrypt(const MLSPlaintext& pt)
   // Pull from the key schedule
   uint32_t generation = 0;
   KeyAndNonce keys;
-  ContentType content_type;
+  ContentType::selector content_type;
   if (std::holds_alternative<ApplicationData>(pt.content)) {
     std::tie(generation, keys) = _keys.application_keys.next(_index);
-    content_type = ContentType::application;
+    content_type = ContentType::selector::application;
   } else if (std::holds_alternative<Proposal>(pt.content)) {
     std::tie(generation, keys) = _keys.handshake_keys.next(_index);
-    content_type = ContentType::proposal;
+    content_type = ContentType::selector::proposal;
   } else if (std::holds_alternative<CommitData>(pt.content)) {
     std::tie(generation, keys) = _keys.handshake_keys.next(_index);
-    content_type = ContentType::commit;
+    content_type = ContentType::selector::commit;
   } else {
     throw InvalidParameterError("Unknown content type");
   }
@@ -763,13 +763,13 @@ State::decrypt(const MLSCiphertext& ct)
   KeyAndNonce keys;
   switch (ct.content_type) {
     // TODO(rlb) Enable decryption of proposal / commit
-    case ContentType::application:
+    case ContentType::selector::application:
       keys = _keys.application_keys.get(sender, generation);
       _keys.application_keys.erase(sender, generation);
       break;
 
-    case ContentType::proposal:
-    case ContentType::commit:
+    case ContentType::selector::proposal:
+    case ContentType::selector::commit:
       keys = _keys.handshake_keys.get(sender, generation);
       _keys.handshake_keys.erase(sender, generation);
       break;

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -10,7 +10,8 @@ template<>
 const NodeType::selector NodeType::type<KeyPackage> = NodeType::selector::leaf;
 
 template<>
-const NodeType::selector NodeType::type<ParentNode> = NodeType::selector::parent;
+const NodeType::selector NodeType::type<ParentNode> =
+  NodeType::selector::parent;
 
 ///
 /// Node

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -3,10 +3,14 @@
 namespace mls {
 
 ///
-/// ParentNode
+/// NodeType
 ///
 
-const NodeType ParentNode::type = NodeType::parent;
+template<>
+const NodeType::selector NodeType::type<KeyPackage> = NodeType::selector::leaf;
+
+template<>
+const NodeType::selector NodeType::type<ParentNode> = NodeType::selector::parent;
 
 ///
 /// Node

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -146,8 +146,9 @@ TEST_CASE("Messages Interop")
 
     // MLSCiphertext
     MLSCiphertext ciphertext{
-      tv.group_id, tv.epoch,  ContentType::selector::application, tv.random, tv.random,
-      tv.random,   tv.random,
+      tv.group_id, tv.epoch,  ContentType::selector::application,
+      tv.random,   tv.random, tv.random,
+      tv.random,
     };
     tls_round_trip(tc.ciphertext, ciphertext, true);
   }

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -115,14 +115,14 @@ TEST_CASE("Messages Interop")
 
     // Proposals
     auto add_prop = Proposal{ Add{ key_package } };
-    CHECK(add_prop.proposal_type() == ProposalType::add);
+    CHECK(add_prop.proposal_type() == ProposalType::selector::add);
 
     auto add_hs = MLSPlaintext{ tv.group_id, tv.epoch, tv.sender, add_prop };
     add_hs.signature = tv.random;
     tls_round_trip(tc.add_proposal, add_hs, true);
 
     auto update_prop = Proposal{ Update{ key_package } };
-    CHECK(update_prop.proposal_type() == ProposalType::update);
+    CHECK(update_prop.proposal_type() == ProposalType::selector::update);
 
     auto update_hs =
       MLSPlaintext{ tv.group_id, tv.epoch, tv.sender, update_prop };
@@ -130,7 +130,7 @@ TEST_CASE("Messages Interop")
     tls_round_trip(tc.update_proposal, update_hs, true);
 
     auto remove_prop = Proposal{ Remove{ LeafIndex(tv.sender.sender) } };
-    CHECK(remove_prop.proposal_type() == ProposalType::remove);
+    CHECK(remove_prop.proposal_type() == ProposalType::selector::remove);
 
     auto remove_hs =
       MLSPlaintext{ tv.group_id, tv.epoch, tv.sender, remove_prop };
@@ -146,7 +146,7 @@ TEST_CASE("Messages Interop")
 
     // MLSCiphertext
     MLSCiphertext ciphertext{
-      tv.group_id, tv.epoch,  ContentType::application, tv.random, tv.random,
+      tv.group_id, tv.epoch,  ContentType::selector::application, tv.random, tv.random,
       tv.random,   tv.random,
     };
     tls_round_trip(tc.ciphertext, ciphertext, true);


### PR DESCRIPTION
Currently, for a type to be used within a `tls::variant`, it needs to define what type enum value it has within that variant.  In addition to being kind of dirty, this means that a type can only be included in one variant.  This PR delegates the enum-to-type mapping to a separate class.  The class MUST define an inner type `selector` and a static template `type<T>` that provides the enum value for a given type.  That is, it must have the following form:

```C++
class VariantType {
  enum struct selector { /* ... */ };
  // or using selector = ...

  template<typename T>
  static const selector type;
};
```

The benefit of this change can be seen in the `tls-syntax` library test, where before it needed custom `Uint8` and `Uint16` types, and now it can just use `std::variant<uint8_t, uint16_t>` directly.

The main annoyance here is that you have to either have the enum type scoped within the selector type or have a separate type.  In the MLS changes here, I've gone with the former approach, which causes a bunch of extra `::selector` references.  It might be possible to streamline those out with some more usage of `std::visit`.