### PR TITLE
External commit

### DIFF
--- a/include/mls/core_types.h
+++ b/include/mls/core_types.h
@@ -70,6 +70,7 @@ struct ExtensionList
   }
 
   bool has(uint16_t type) const;
+  ExtensionList for_group() const;
 
   TLS_SERIALIZABLE(extensions)
   TLS_TRAITS(tls::vector<2>)

--- a/include/mls/crypto.h
+++ b/include/mls/crypto.h
@@ -107,6 +107,10 @@ struct HPKEPublicKey
                          const bytes& aad,
                          const bytes& pt) const;
 
+  std::tuple<bytes, bytes> do_export(CipherSuite suite,
+                                     const std::string& label,
+                                     size_t size) const;
+
   TLS_SERIALIZABLE(data)
   TLS_TRAITS(tls::vector<2>)
 };
@@ -125,6 +129,11 @@ struct HPKEPrivateKey
   bytes decrypt(CipherSuite suite,
                 const bytes& aad,
                 const HPKECiphertext& ct) const;
+
+  bytes do_export(CipherSuite suite,
+                  const bytes& kem_output,
+                  const std::string& label,
+                  size_t size) const;
 
   TLS_SERIALIZABLE(data, public_key)
   TLS_TRAITS(tls::vector<2>, tls::pass)

--- a/include/mls/key_schedule.h
+++ b/include/mls/key_schedule.h
@@ -106,11 +106,14 @@ public:
 
   KeyScheduleEpoch() = default;
 
-  // Full initializer, used by joiner
+  // Full initializer, used by invited joiner
   KeyScheduleEpoch(CipherSuite suite_in,
                    const bytes& joiner_secret,
                    const bytes& psk_secret,
                    const bytes& context);
+
+  // Ciphersuite-only initializer, used by external joiner
+  KeyScheduleEpoch(CipherSuite suite_in);
 
   // Initial epoch
   KeyScheduleEpoch(CipherSuite suite_in,
@@ -124,9 +127,14 @@ public:
                    const bytes& psk_secret,
                    const bytes& context);
 
-  // Advance to the next epoch
+  static std::tuple<bytes, bytes> external_init(
+    CipherSuite suite,
+    const HPKEPublicKey& external_pub);
+  bytes receive_external_init(const bytes& kem_output) const;
+
   KeyScheduleEpoch next(const bytes& commit_secret,
                         const bytes& psk_secret,
+                        const std::optional<bytes>& force_init_secret,
                         const bytes& context) const;
 
   GroupKeySource encryption_keys(LeafCount size) const;

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -443,6 +443,7 @@ enum struct SenderType : uint8_t
   member = 1,
   preconfigured = 2,
   new_member = 3,
+  external_joiner = 4,
 };
 
 struct Sender

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -167,7 +167,7 @@ protected:
     const bytes& leaf_secret,
     const std::vector<Proposal>& extra_proposals,
     const std::optional<KeyPackage>& joiner_key_package,
-    const std::optional<HPKEPublicKey>& external_init_key) const;
+    const std::optional<HPKEPublicKey>& external_pub) const;
 
   // Ratchet the key schedule forward and sign the commit that caused the
   // transition

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -6,7 +6,6 @@
 #include "mls/treekem.h"
 #include <list>
 #include <optional>
-#include <set>
 #include <vector>
 
 namespace mls {
@@ -64,6 +63,16 @@ public:
         SignaturePrivateKey sig_priv,
         const KeyPackage& kp,
         const Welcome& welcome);
+
+  // Join a group from outside
+  // XXX(RLB) For full generality, this should be capable of covering other
+  // proposals, and would need to return a Welcome as well as an MLSPlaintext,
+  // to cover any additional participants added in the Commit.
+  static std::tuple<MLSPlaintext, State> external_join(
+    const bytes& leaf_secret,
+    SignaturePrivateKey sig_priv,
+    const KeyPackage& kp,
+    const PublicGroupState& pgs);
 
   ///
   /// Message factories
@@ -150,10 +159,22 @@ protected:
   // Assemble a group context for this state
   GroupContext group_context() const;
 
+  // Assemble a preliminary, unjoined group state
+  State(SignaturePrivateKey sig_priv, const PublicGroupState& pgs);
+
+  // Form a commit that can be either internal or external
+  std::tuple<MLSPlaintext, Welcome, State> commit(
+    const bytes& leaf_secret,
+    const std::vector<Proposal>& extra_proposals,
+    const std::optional<KeyPackage>& joiner_key_package,
+    const std::optional<HPKEPublicKey>& external_init_key) const;
+
   // Ratchet the key schedule forward and sign the commit that caused the
   // transition
-  MLSPlaintext ratchet_and_sign(const Commit& op,
+  MLSPlaintext ratchet_and_sign(const Sender& sender,
+                                const Commit& op,
                                 const bytes& update_secret,
+                                const std::optional<bytes>& force_init_secret,
                                 const GroupContext& prev_ctx);
 
   // Create an MLSPlaintext with a signature over some content
@@ -182,7 +203,8 @@ protected:
   friend bool operator!=(const State& lhs, const State& rhs);
 
   // Derive and set the secrets for an epoch, given some new entropy
-  void update_epoch_secrets(const bytes& commit_secret);
+  void update_epoch_secrets(const bytes& commit_secret,
+                            const std::optional<bytes>& force_init_secret);
 
   // Signature verification over a handshake message
   bool verify_internal(const MLSPlaintext& pt) const;

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -306,7 +306,8 @@ KeyScheduleTestVector::create(CipherSuite suite, uint32_t n_epochs)
 
     auto commit_secret = random_bytes(suite.secret_size());
     auto psk_secret = random_bytes(suite.secret_size());
-    epoch = epoch.next(commit_secret, psk_secret, ctx);
+    // TODO(RLB) Add Test case for externally-driven epoch change
+    epoch = epoch.next(commit_secret, psk_secret, std::nullopt, ctx);
 
     auto welcome_secret =
       KeyScheduleEpoch::welcome_secret(suite, epoch.joiner_secret, psk_secret);
@@ -356,7 +357,7 @@ KeyScheduleTestVector::verify() const
     group_context.confirmed_transcript_hash = tve.confirmed_transcript_hash;
     auto ctx = tls::marshal(group_context);
 
-    epoch = epoch.next(tve.commit_secret, tve.psk_secret, ctx);
+    epoch = epoch.next(tve.commit_secret, tve.psk_secret, std::nullopt, ctx);
 
     // Verify the rest of the epoch
     VERIFY_EQUAL("joiner secret", epoch.joiner_secret, tve.joiner_secret);

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -1,5 +1,7 @@
 #include "mls/core_types.h"
 
+#include <set>
+
 namespace mls {
 
 ///
@@ -37,6 +39,29 @@ ExtensionList::has(uint16_t type) const
     extensions.begin(), extensions.end(), [&](const Extension& ext) -> bool {
       return ext.type == type;
     });
+}
+
+static const std::set<Extension::Type>&
+group_types()
+{
+  static const auto group_types = std::set<Extension::Type>{
+    ExtensionType::sframe_parameters,
+  };
+  return group_types;
+}
+
+ExtensionList
+ExtensionList::for_group() const
+{
+  auto group_ext = ExtensionList{};
+  for (const auto& ext : extensions) {
+    if (!group_types().count(ext.type)) {
+      continue;
+    }
+
+    group_ext.extensions.push_back(ext);
+  }
+  return group_ext;
 }
 
 ///

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -55,7 +55,7 @@ ExtensionList::for_group() const
 {
   auto group_ext = ExtensionList{};
   for (const auto& ext : extensions) {
-    if (!group_types().count(ext.type)) {
+    if (group_types().count(ext.type) == 0) {
       continue;
     }
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -317,7 +317,8 @@ State::commit(const bytes& leaf_secret,
   // If this is an external commit, see where the new joiner ended up
   auto sender = Sender{ SenderType::member, _index.val };
   if (external_commit) {
-    auto it = std::find(joiners.begin(), joiners.end(), opt::get(joiner_key_package));
+    auto it =
+      std::find(joiners.begin(), joiners.end(), opt::get(joiner_key_package));
     if (it == joiners.end()) {
       throw InvalidParameterError("Joiner not added");
     }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1,7 +1,5 @@
 #include <mls/state.h>
 
-#include <set>
-
 namespace mls {
 
 ///
@@ -32,6 +30,39 @@ State::State(bytes group_id,
   _key_schedule =
     KeyScheduleEpoch(_suite, random_bytes(_suite.secret_size()), ctx);
   _keys = _key_schedule.encryption_keys(_tree.size());
+}
+
+State::State(SignaturePrivateKey sig_priv, const PublicGroupState& pgs)
+  : _suite(pgs.cipher_suite)
+  , _group_id(pgs.group_id)
+  , _epoch(pgs.epoch)
+  , _tree(pgs.cipher_suite)
+  , _transcript_hash(pgs.cipher_suite)
+  , _extensions(pgs.extensions.for_group())
+  , _key_schedule(pgs.cipher_suite)
+  , _index(0)
+  , _identity_priv(std::move(sig_priv))
+{
+  // Import the interim transcript hash
+  _transcript_hash.interim = pgs.interim_transcript_hash;
+
+  // Import the tree
+  auto maybe_tree_extn = pgs.extensions.find<RatchetTreeExtension>();
+  if (!maybe_tree_extn) {
+    throw InvalidParameterError("Ratchet tree not provided in GroupInfo");
+  }
+
+  _tree = opt::get(maybe_tree_extn).tree;
+  _tree.suite = _suite;
+  _tree.set_hash_all();
+
+  // The following are not set:
+  //    _transcript_hash.confirmed
+  //    _index
+  //    _tree_priv
+  //
+  // This ctor should only be used within external_commit, in which case these
+  // fields are populated by the subsequent commit()
 }
 
 // Initialize a group from a Welcome
@@ -90,14 +121,7 @@ State::State(const HPKEPrivateKey& init_priv,
   _transcript_hash.confirmed = group_info.confirmed_transcript_hash;
   _transcript_hash.update_interim(group_info.confirmation_tag);
 
-  static const auto copy_to_group = std::set<Extension::Type>{
-    ExtensionType::sframe_parameters,
-  };
-  for (const auto& ext : group_info.extensions.extensions) {
-    if (copy_to_group.count(ext.type) > 0) {
-      _extensions.add(ext.type, ext.data);
-    }
-  }
+  _extensions = group_info.extensions.for_group();
 
   // Construct TreeKEM private key from partrs provided
   auto maybe_index = _tree.find(kp);
@@ -126,6 +150,21 @@ State::State(const HPKEPrivateKey& init_priv,
   if (!verify_confirmation(group_info.confirmation_tag.mac_value)) {
     throw ProtocolError("Confirmation failed to verify");
   }
+}
+
+// Join a group from outside
+std::tuple<MLSPlaintext, State>
+State::external_join(const bytes& leaf_secret,
+                     SignaturePrivateKey sig_priv,
+                     const KeyPackage& kp,
+                     const PublicGroupState& pgs)
+{
+  auto initial_state = State(std::move(sig_priv), pgs);
+  auto add = initial_state.add_proposal(kp);
+  auto [commit_pt, welcome, state] =
+    initial_state.commit(leaf_secret, { add }, kp, pgs.external_pub);
+  silence_unused(welcome);
+  return { commit_pt, state };
 }
 
 ///
@@ -221,6 +260,15 @@ std::tuple<MLSPlaintext, Welcome, State>
 State::commit(const bytes& leaf_secret,
               const std::vector<Proposal>& extra_proposals) const
 {
+  return commit(leaf_secret, extra_proposals, std::nullopt, std::nullopt);
+}
+
+std::tuple<MLSPlaintext, Welcome, State>
+State::commit(const bytes& leaf_secret,
+              const std::vector<Proposal>& extra_proposals,
+              const std::optional<KeyPackage>& joiner_key_package,
+              const std::optional<HPKEPublicKey>& external_pub) const
+{
   // Construct a commit from cached proposals
   // TODO(rlb) ignore some proposals:
   // * Update after Update
@@ -247,13 +295,42 @@ State::commit(const bytes& leaf_secret,
     commit.proposals.push_back({ proposal });
   }
 
+  // If this is an external commit, insert an ExternalInit proposal
+  auto external_commit = bool(joiner_key_package) && bool(external_pub);
+  if (bool(joiner_key_package) != bool(external_pub)) {
+    throw InvalidParameterError("Malformed external commit parameters");
+  }
+
+  auto force_init_secret = std::optional<bytes>{};
+  if (external_commit) {
+    auto [enc, exported] =
+      KeyScheduleEpoch::external_init(_suite, opt::get(external_pub));
+    force_init_secret = exported;
+    commit.proposals.push_back({ Proposal{ ExternalInit{ enc } } });
+  }
+
   // Apply proposals
   State next = successor();
   auto proposals = must_resolve(commit.proposals, _index);
   auto [has_updates, has_removes, joiner_locations] = next.apply(proposals);
 
+  // If this is an external commit, see where the new joiner ended up
+  auto sender = Sender{ SenderType::member, _index.val };
+  if (external_commit) {
+    auto it = std::find(joiners.begin(), joiners.end(), opt::get(joiner_key_package));
+    if (it == joiners.end()) {
+      throw InvalidParameterError("Joiner not added");
+    }
+
+    auto pos = it - joiners.begin();
+    next._index = joiner_locations[pos];
+    sender = Sender{ SenderType::external_joiner, next._index.val };
+  }
+
   // KEM new entropy to the group and the new joiners
-  auto path_required = has_updates || has_removes || commit.proposals.empty();
+  auto no_proposals = commit.proposals.empty();
+  auto path_required =
+    has_updates || has_removes || no_proposals || external_commit;
   auto update_secret = _suite.zero();
   auto path_secrets =
     std::vector<std::optional<bytes>>(joiner_locations.size());
@@ -286,7 +363,8 @@ State::commit(const bytes& leaf_secret,
   }
 
   // Create the Commit message and advance the transcripts / key schedule
-  auto pt = next.ratchet_and_sign(commit, update_secret, group_context());
+  auto pt = next.ratchet_and_sign(
+    sender, commit, update_secret, force_init_secret, group_context());
 
   // Complete the GroupInfo and form the Welcome
   auto group_info = GroupInfo{
@@ -295,7 +373,7 @@ State::commit(const bytes& leaf_secret,
     next._extensions,       opt::get(pt.confirmation_tag),
   };
   group_info.extensions.add(RatchetTreeExtension{ next._tree });
-  group_info.sign(next._tree, _index, _identity_priv);
+  group_info.sign(next._tree, next._index, next._identity_priv);
 
   auto welcome =
     Welcome{ _suite, next._key_schedule.joiner_secret, {}, group_info };
@@ -320,19 +398,20 @@ State::group_context() const
 }
 
 MLSPlaintext
-State::ratchet_and_sign(const Commit& op,
+State::ratchet_and_sign(const Sender& sender,
+                        const Commit& op,
                         const bytes& update_secret,
+                        const std::optional<bytes>& force_init_secret,
                         const GroupContext& prev_ctx)
 {
   auto prev_key_schedule = _key_schedule;
 
-  auto sender = Sender{ SenderType::member, _index.val };
   auto pt = MLSPlaintext{ _group_id, _epoch, sender, op };
   pt.sign(_suite, prev_ctx, _identity_priv);
 
   _transcript_hash.update_confirmed(pt);
   _epoch += 1;
-  update_epoch_secrets(update_secret);
+  update_epoch_secrets(update_secret, force_init_secret);
 
   pt.confirmation_tag = { _key_schedule.confirmation_tag(
     _transcript_hash.confirmed) };
@@ -369,8 +448,13 @@ State::handle(const MLSPlaintext& pt)
     throw InvalidParameterError("Incorrect content type");
   }
 
-  if (pt.sender.sender_type != SenderType::member) {
-    throw ProtocolError("Commit must originate from within the group");
+  switch (pt.sender.sender_type) {
+    case SenderType::member:
+    case SenderType::external_joiner:
+      break;
+
+    default:
+      throw ProtocolError("Commit be either member or external_joiner");
   }
 
   auto sender = LeafIndex(pt.sender.sender);
@@ -386,6 +470,21 @@ State::handle(const MLSPlaintext& pt)
   auto [_has_updates, _has_removes, joiner_locations] = next.apply(proposals);
   silence_unused(_has_updates);
   silence_unused(_has_removes);
+
+  // If this is an external Commit, then it must have an ExternalInit proposal
+  auto force_init_secret = std::optional<bytes>{};
+  if (pt.sender.sender_type == SenderType::external_joiner) {
+    auto pos =
+      std::find_if(proposals.begin(), proposals.end(), [&](auto&& cached) {
+        return var::holds_alternative<ExternalInit>(cached.proposal.content);
+      });
+    if (pos == proposals.end()) {
+      throw ProtocolError("External commit without ExternalInit");
+    }
+
+    const auto& enc = var::get<ExternalInit>(pos->proposal.content).kem_output;
+    force_init_secret = _key_schedule.receive_external_init(enc);
+  }
 
   // Decapsulate and apply the UpdatePath, if provided
   // TODO(RLB) Verify that path is provided if required
@@ -411,7 +510,7 @@ State::handle(const MLSPlaintext& pt)
   // Update the transcripts and advance the key schedule
   next._transcript_hash.update(pt);
   next._epoch += 1;
-  next.update_epoch_secrets(update_secret);
+  next.update_epoch_secrets(update_secret, force_init_secret);
 
   // Verify the confirmation MAC
   if (!pt.confirmation_tag) {
@@ -613,7 +712,8 @@ operator!=(const State& lhs, const State& rhs)
 }
 
 void
-State::update_epoch_secrets(const bytes& commit_secret)
+State::update_epoch_secrets(const bytes& commit_secret,
+                            const std::optional<bytes>& force_init_secret)
 {
   auto ctx = tls::marshal(GroupContext{
     _group_id,
@@ -622,7 +722,8 @@ State::update_epoch_secrets(const bytes& commit_secret)
     _transcript_hash.confirmed,
     _extensions,
   });
-  _key_schedule = _key_schedule.next(commit_secret, _suite.zero(), ctx);
+  _key_schedule =
+    _key_schedule.next(commit_secret, _suite.zero(), force_init_secret, ctx);
   _keys = _key_schedule.encryption_keys(_tree.size());
 }
 
@@ -653,11 +754,33 @@ State::verify_internal(const MLSPlaintext& pt) const
 }
 
 bool
+State::verify_external_commit(const MLSPlaintext& pt) const
+{
+  // Content type MUST be commit
+  if (!var::holds_alternative<Commit>(pt.content)) {
+    throw ProtocolError("External Commit does not hold a commit");
+  }
+
+  const auto& commit = var::get<Commit>(pt.content);
+  if (!commit.path) {
+    throw ProtocolError("External Commit does not have a path");
+  }
+
+  // Verify with public key from update path leaf key package
+  const auto& kp = opt::get(commit.path).leaf_key_package;
+  const auto& pub = kp.credential.public_key();
+  return pt.verify(_suite, group_context(), pub);
+}
+
+bool
 State::verify(const MLSPlaintext& pt) const
 {
   switch (pt.sender.sender_type) {
     case SenderType::member:
       return verify_internal(pt);
+
+    case SenderType::external_joiner:
+      return verify_external_commit(pt);
 
     default:
       // TODO(RLB) Support other sender types
@@ -750,7 +873,7 @@ State::leaf_for_roster_entry(RosterIndex index) const
 
   for (auto i = LeafIndex{ 0 }; i < _tree.size(); i.val++) {
     const auto& kp = _tree.key_package(i);
-    if (!kp.has_value()) {
+    if (!kp) {
       continue;
     }
     if (non_blank_leaves == index.val) {

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -94,6 +94,24 @@ TEST_CASE_FIXTURE(StateTest, "Two Person")
   verify_group_functionality(group);
 }
 
+TEST_CASE_FIXTURE(StateTest, "External Join")
+{
+  // Initialize the creator's state
+  auto first0 = State{ group_id,          suite,           init_privs[0],
+                       identity_privs[0], key_packages[0], {} };
+  auto public_group_state = first0.public_group_state();
+
+  // Initialize the second participant as an external joiner
+  auto [commit, second0] = State::external_join(
+    fresh_secret(), identity_privs[1], key_packages[1], public_group_state);
+
+  // Creator processes the commit
+  auto first1 = opt::get(first0.handle(commit));
+
+  auto group = std::vector<State>{ first1, second0 };
+  verify_group_functionality(group);
+}
+
 TEST_CASE_FIXTURE(StateTest, "SFrame Parameter Negotiation")
 {
   // Set the SFrame parameters for the group


### PR DESCRIPTION
This PR implements an elaborated form of https://github.com/mlswg/mls-protocol/pull/406/.  It seems to work in that the following test passes:

```C++
TEST_CASE_FIXTURE(StateTest, "External Join")
{
  // Initialize the creator's state
  auto first0 =
    State{ group_id, suite, init_privs[0], identity_privs[0], key_packages[0] };
  auto group_key_package = first0.group_key_package();

  // Initialize the second participant as an external joiner
  auto [commit, second0] = State::external_join(
    fresh_secret(), identity_privs[1], key_packages[1], group_key_package);

  // Creator processes the commit
  auto first1 = first0.handle(commit).value();

  auto group = std::vector<State>{ first1, second0 };
  verify_group_functionality(group);
}
```

This work validates that external commits are implementable, and highlights a few things that need to be added to the PR to make it complete:
* Defining a new SenderType value for this purpose
* Defining the ExternalInit proposal type and its handling
* Defining the minimum requirements for an external commit:
    * Must have an Add proposal that adds the new member
    * Must have an ExternalInit proposal
    * Must have a path
* Defining how the signature on an external commit is validated
    * Here, we use the public key in Commit.path.leaf_key_package.credential, which ensures Commit.path is populated
    * You could also have it be a reference to the Add where the joiner is added, which would ensure that there's an Add proposal for the joiner