### PR TITLE
declare uint64_t instantiation of read_uint in .cpp file

### DIFF
--- a/lib/tls_syntax/src/tls_syntax.cpp
+++ b/lib/tls_syntax/src/tls_syntax.cpp
@@ -80,6 +80,9 @@ istream::read_uint(T& data, int length)
   return *this;
 }
 
+template class istream&
+istream::read_uint<uint64_t>(uint64_t& data, int length);
+
 istream&
 operator>>(istream& in, bool& data)
 {


### PR DESCRIPTION
read_uint with type uint64_t is used in tls_syntax.hpp but is
defined in .cpp, this change will ensure this version of the
template is instantiated so it can be linked from other modules.