### PR TITLE
fix initialization-order-fiasco of static variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(mlspp
 )
 
 option(CLANG_TIDY "Perform linting with clang-tidy" OFF)
+option(ADDRESS_SANITIZER "Enable address sanitizer" OFF)
 
 ###
 ### Global Config
@@ -24,6 +25,14 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
   endif()
 elseif(MSVC)
   add_compile_options(/W4 /WX)
+endif()
+
+if (ADDRESS_SANITIZER)
+  set (CMAKE_C_FLAGS              "${CMAKE_C_FLAGS} -fsanitize=address")
+  set (CMAKE_CXX_FLAGS            "${CMAKE_CXX_FLAGS} -fsanitize=address")
+  set (CMAKE_EXE_LINKER_FLAGS     "${CMAKE_EXE_LINKER_FLAGS}    -fsanitize=address")
+  set (CMAKE_SHARED_LINKER_FLAGS  "${CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address")
+  set (CMAKE_MODULE_LINKER_FLAGS  "${CMAKE_MODULE_LINKER_FLAGS} -fsanitize=address")
 endif()
 
 if(CLANG_TIDY)

--- a/lib/hpke/include/hpke/digest.h
+++ b/lib/hpke/include/hpke/digest.h
@@ -30,10 +30,6 @@ private:
   const size_t output_size;
 
   explicit Digest(ID id);
-  friend Digest make_digest(ID id);
-
-  template<Digest::ID id>
-  static const Digest instance;
 };
 
 } // namespace hpke

--- a/lib/hpke/src/digest.cpp
+++ b/lib/hpke/src/digest.cpp
@@ -25,43 +25,28 @@ openssl_digest_type(Digest::ID digest)
   }
 }
 
-Digest
-make_digest(Digest::ID id)
-{
-  return Digest(id);
-}
-
-template<>
-const Digest Digest::instance<Digest::ID::SHA256> =
-  make_digest(Digest::ID::SHA256);
-
-template<>
-const Digest Digest::instance<Digest::ID::SHA384> =
-  make_digest(Digest::ID::SHA384);
-
-template<>
-const Digest Digest::instance<Digest::ID::SHA512> =
-  make_digest(Digest::ID::SHA512);
-
 template<>
 const Digest&
 Digest::get<Digest::ID::SHA256>()
 {
-  return Digest::instance<Digest::ID::SHA256>;
+  static const Digest instance(Digest::ID::SHA256);
+  return instance;
 }
 
 template<>
 const Digest&
 Digest::get<Digest::ID::SHA384>()
 {
-  return Digest::instance<Digest::ID::SHA384>;
+  static const Digest instance(Digest::ID::SHA384);
+  return instance;
 }
 
 template<>
 const Digest&
 Digest::get<Digest::ID::SHA512>()
 {
-  return Digest::instance<Digest::ID::SHA512>;
+  static const Digest instance(Digest::ID::SHA512);
+  return instance;
 }
 
 Digest::Digest(Digest::ID id_in)

--- a/lib/hpke/src/group.cpp
+++ b/lib/hpke/src/group.cpp
@@ -144,9 +144,6 @@ struct ECKeyGroup : public EVPGroup
     , curve_nid(group_to_nid(group_id))
   {}
 
-  template<Group::ID id>
-  static const ECKeyGroup instance;
-
   std::unique_ptr<Group::PrivateKey> derive_key_pair(
     const bytes& suite_id,
     const bytes& ikm) const override
@@ -297,18 +294,6 @@ private:
   }
 };
 
-template<>
-const ECKeyGroup ECKeyGroup::instance<Group::ID::P256> =
-  ECKeyGroup(Group::ID::P256, KDF::get<KDF::ID::HKDF_SHA256>());
-
-template<>
-const ECKeyGroup ECKeyGroup::instance<Group::ID::P384> =
-  ECKeyGroup(Group::ID::P384, KDF::get<KDF::ID::HKDF_SHA384>());
-
-template<>
-const ECKeyGroup ECKeyGroup::instance<Group::ID::P521> =
-  ECKeyGroup(Group::ID::P521, KDF::get<KDF::ID::HKDF_SHA512>());
-
 ///
 /// DH over "raw" curves
 ///
@@ -405,22 +390,6 @@ private:
   }
 };
 
-template<>
-const RawKeyGroup RawKeyGroup::instance<Group::ID::X25519> =
-  RawKeyGroup(Group::ID::X25519, KDF::get<KDF::ID::HKDF_SHA256>());
-
-template<>
-const RawKeyGroup RawKeyGroup::instance<Group::ID::Ed25519> =
-  RawKeyGroup(Group::ID::Ed25519, KDF::get<KDF::ID::HKDF_SHA256>());
-
-template<>
-const RawKeyGroup RawKeyGroup::instance<Group::ID::X448> =
-  RawKeyGroup(Group::ID::X448, KDF::get<KDF::ID::HKDF_SHA512>());
-
-template<>
-const RawKeyGroup RawKeyGroup::instance<Group::ID::Ed448> =
-  RawKeyGroup(Group::ID::Ed448, KDF::get<KDF::ID::HKDF_SHA512>());
-
 ///
 /// General DH group
 ///
@@ -429,49 +398,66 @@ template<>
 const Group&
 Group::get<Group::ID::P256>()
 {
-  return ECKeyGroup::instance<Group::ID::P256>;
+  static const ECKeyGroup instance(Group::ID::P256,
+                                   KDF::get<KDF::ID::HKDF_SHA256>());
+
+  return instance;
 }
 
 template<>
 const Group&
 Group::get<Group::ID::P384>()
 {
-  return ECKeyGroup::instance<Group::ID::P384>;
+  static const ECKeyGroup instance(Group::ID::P384,
+                                   KDF::get<KDF::ID::HKDF_SHA384>());
+
+  return instance;
 }
 
 template<>
 const Group&
 Group::get<Group::ID::P521>()
 {
-  return ECKeyGroup::instance<Group::ID::P521>;
+  static const ECKeyGroup instance(Group::ID::P521,
+                                   KDF::get<KDF::ID::HKDF_SHA512>());
+
+  return instance;
 }
 
 template<>
 const Group&
 Group::get<Group::ID::X25519>()
 {
-  return RawKeyGroup::instance<Group::ID::X25519>;
+  static const RawKeyGroup instance(Group::ID::X25519,
+                                    KDF::get<KDF::ID::HKDF_SHA256>());
+  return instance;
 }
 
 template<>
 const Group&
 Group::get<Group::ID::Ed25519>()
 {
-  return RawKeyGroup::instance<Group::ID::Ed25519>;
+  static const RawKeyGroup instance(Group::ID::Ed25519,
+                                    KDF::get<KDF::ID::HKDF_SHA256>());
+  return instance;
 }
 
 template<>
 const Group&
 Group::get<Group::ID::X448>()
 {
-  return RawKeyGroup::instance<Group::ID::X448>;
+  static const RawKeyGroup instance(Group::ID::X448,
+                                    KDF::get<KDF::ID::HKDF_SHA512>());
+  return instance;
 }
 
 template<>
 const Group&
 Group::get<Group::ID::Ed448>()
 {
-  return RawKeyGroup::instance<Group::ID::Ed448>;
+  static const RawKeyGroup instance(Group::ID::Ed448,
+                                    KDF::get<KDF::ID::HKDF_SHA512>());
+  return instance;
 }
 
 size_t

--- a/lib/hpke/src/hkdf.cpp
+++ b/lib/hpke/src/hkdf.cpp
@@ -8,43 +8,28 @@
 
 namespace hpke {
 
-HKDF
-make_hkdf(const Digest& digest)
-{
-  return HKDF(digest);
-}
-
-template<>
-const HKDF HKDF::instance<Digest::ID::SHA256> =
-  make_hkdf(Digest::get<Digest::ID::SHA256>());
-
-template<>
-const HKDF HKDF::instance<Digest::ID::SHA384> =
-  make_hkdf(Digest::get<Digest::ID::SHA384>());
-
-template<>
-const HKDF HKDF::instance<Digest::ID::SHA512> =
-  make_hkdf(Digest::get<Digest::ID::SHA512>());
-
 template<>
 const HKDF&
 HKDF::get<Digest::ID::SHA256>()
 {
-  return HKDF::instance<Digest::ID::SHA256>;
+  static const HKDF instance(Digest::get<Digest::ID::SHA256>());
+  return instance;
 }
 
 template<>
 const HKDF&
 HKDF::get<Digest::ID::SHA384>()
 {
-  return HKDF::instance<Digest::ID::SHA384>;
+  static const HKDF instance(Digest::get<Digest::ID::SHA384>());
+  return instance;
 }
 
 template<>
 const HKDF&
 HKDF::get<Digest::ID::SHA512>()
 {
-  return HKDF::instance<Digest::ID::SHA512>;
+  static const HKDF instance(Digest::get<Digest::ID::SHA512>());
+  return instance;
 }
 
 static KDF::ID

--- a/lib/hpke/src/hkdf.h
+++ b/lib/hpke/src/hkdf.h
@@ -20,10 +20,6 @@ private:
   const Digest& digest;
 
   explicit HKDF(const Digest& digest_in);
-  friend HKDF make_hkdf(const Digest& digest);
-
-  template<Digest::ID digest_id>
-  static const HKDF instance;
 };
 
 } // namespace hpke

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -185,7 +185,7 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Public Key")
     found = pub.find(kp_path);
     REQUIRE(found.has_value());
     REQUIRE(found.value() == index);
-    for (const auto dpn : dp) {
+    for (const auto& dpn : dp) {
       REQUIRE(pub.node_at(dpn).node.has_value());
     }
 


### PR DESCRIPTION
Move static variables into functions to enabled defined
initialization order.

Add basic support for running with address sanitizer.

cmake -DADDRESS_SANITIZER=ON

run with ASAN_OPTIONS=check_initialization_order=1