### PR TITLE
add move semantics

### DIFF
--- a/include/mls/session.h
+++ b/include/mls/session.h
@@ -29,6 +29,8 @@ private:
 class PendingJoin
 {
 public:
+  PendingJoin(PendingJoin&& other);
+  PendingJoin& operator=(PendingJoin&& other);
   ~PendingJoin();
   bytes key_package() const;
   Session complete(const bytes& welcome) const;
@@ -44,8 +46,8 @@ private:
 class Session
 {
 public:
-  Session(const Session& other);
-  Session& operator=(const Session& other);
+  Session(Session&& other);
+  Session& operator=(Session&& other);
   ~Session();
 
   // Settings

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -100,6 +100,11 @@ PendingJoin::Inner::create(CipherSuite suite,
   return PendingJoin(inner.release());
 }
 
+PendingJoin::PendingJoin(PendingJoin&& other) = default;
+
+PendingJoin&
+PendingJoin::operator=(PendingJoin&& other) = default;
+
 PendingJoin::~PendingJoin() = default;
 
 PendingJoin::PendingJoin(Inner* inner_in)
@@ -207,18 +212,10 @@ Session::Inner::for_epoch(epoch_t epoch)
   throw MissingStateError("No state for epoch");
 }
 
-Session::Session(const Session& other)
-  : inner(std::make_unique<Inner>(*other.inner))
-{}
+Session::Session(Session&& other) = default;
 
 Session&
-Session::operator=(const Session& other)
-{
-  if (&other != this) {
-    inner = std::make_unique<Inner>(*other.inner);
-  }
-  return *this;
-}
+Session::operator=(Session&& other) = default;
 
 Session::~Session() = default;
 

--- a/test/session.cpp
+++ b/test/session.cpp
@@ -56,7 +56,7 @@ protected:
     // Initial add is different
     if (sessions.empty()) {
       auto creator = client.begin_session(group_id);
-      sessions.emplace_back(creator);
+      sessions.emplace_back(std::move(creator));
       return;
     }
 
@@ -74,9 +74,9 @@ protected:
 
     // Add-in-place vs. add-at-edge
     if (index == sessions.size()) {
-      sessions.emplace_back(next);
+      sessions.emplace_back(std::move(next));
     } else if (index < sessions.size()) {
-      sessions[index] = next;
+      sessions[index] = std::move(next);
     } else {
       throw InvalidParameterError("Index too large for group");
     }


### PR DESCRIPTION
PendingJoin had neither move nor copy so could not be easily used.
Move seams like the right choice so add that only.
Change Session from copy to move to be consistent.