### PR TITLE
Library pkgconfig generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,27 @@
 cmake_minimum_required(VERSION 3.12)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
+
+
+###
+###  Semantic versioning
+###
+include ( GetGitRevisionDescription )
+git_describe(VERSION --tags)
+get_git_head_revision(REFSPEC HASHVAR)
+
+string(REGEX REPLACE "^v([0-9]+)\\..*" "\\1" MLSPP_VERSION_MAJOR "${VERSION}")
+string(REGEX REPLACE "^v[0-9]+\\.([0-9]+).*" "\\1" MLSPP_VERSION_MINOR "${VERSION}")
+string(REGEX REPLACE "^v[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" MLSPP_VERSION_PATCH "${VERSION}")
+string(REGEX REPLACE "^v[0-9]+\\.[0-9]+\\.[0-9]+(.*)" "\\1" MLSPP_VERSION_SHA1 "${VERSION}")
+mark_as_advanced(MLSPP_VERSION_MAJOR MLSPP_VERSION_MINOR MLSPP_VERSION_PATCH)
+set ( MLSPP_VERSION "${MLSPP_VERSION_MAJOR}.${MLSPP_VERSION_MINOR}.${MLSPP_VERSION_PATCH}" )
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/version.c.in
+        ${CMAKE_CURRENT_BINARY_DIR}/version.cpp)
+set(version_file "${CMAKE_CURRENT_BINARY_DIR}/version.cpp")
 
 project(mlspp
-  VERSION 0.1
-  LANGUAGES CXX
+        VERSION "${MLSPP_VERSION}"
+        LANGUAGES CXX
 )
 
 option(CLANG_TIDY "Perform linting with clang-tidy" OFF)
@@ -52,6 +71,16 @@ endif()
 add_subdirectory(lib)
 
 # External libraries
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  find_package(OpenSSL)
+  IF (${OpenSSL_FOUND})
+    MESSAGE(STATUS "Found OpenSSL on Darwin")
+  ELSE (${OpenSSL_FOUND})
+    MESSAGE(STATUS "Could not locate OpenSSL on Darwin. Setting OPENSSL_ROOT_DIR to /usr/local/opt/openssl")
+    set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
+  ENDIF (${OpenSSL_FOUND})
+endif()
+
 find_package(OpenSSL 1.1 REQUIRED)
 
 ###
@@ -73,6 +102,28 @@ target_include_directories(${LIB_NAME}
   PRIVATE
     ${OPENSSL_INCLUDE_DIR}
 )
+
+###
+###  Library packaging and install
+###
+#include ( CPack )
+set ( dist_dir    ${CMAKE_BINARY_DIR}/dist )
+set ( prefix      ${CMAKE_INSTALL_PREFIX} )
+set ( exec_prefix ${CMAKE_INSTALL_PREFIX}/bin )
+set ( libdir      ${CMAKE_INSTALL_PREFIX}/lib )
+set ( includedir  ${CMAKE_INSTALL_PREFIX}/include )
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libmlspp.pc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/libmlspp.pc @ONLY)
+install (FILES ${CMAKE_CURRENT_BINARY_DIR}/libmlspp.pc DESTINATION lib/pkgconfig )
+
+install ( TARGETS ${LIB_NAME}
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION bin)
+
+
+add_subdirectory(include)
+
 
 ###
 ### Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,17 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 ###  Semantic versioning
 ###
 include ( GetGitRevisionDescription )
-git_describe(VERSION --tags)
+#git_describe(VERSION)
+git_get_exact_tag(VERSION)
+if(NOT VERSION)
+  message("No Git tag version found setting v0.0.0")
+  set(VERSION "v0.0.0")
+endif(NOT VERSION)
+
+
+message( ${VERSION})
+
+
 get_git_head_revision(REFSPEC HASHVAR)
 
 string(REGEX REPLACE "^v([0-9]+)\\..*" "\\1" MLSPP_VERSION_MAJOR "${VERSION}")

--- a/README.md
+++ b/README.md
@@ -31,3 +31,35 @@ Conventions
   * `X_key` is the public key of an asymmetric key pair
   * `X_priv` is the private key of an asymmetric key pair
   * `X_secret` is a symmetric secret
+
+Building, installing, linking etc
+----------------------------
+
+The usual "cmake dance" applies:
+```
+> mkdir build
+> cd build
+> cmake ..
+> make
+```
+
+It is possible to install the library 
+```
+> make install
+```
+
+There is no uninstall target, so use:
+```
+> xargs rm < install_manifest.txt
+```
+To get rid of most of the files (Some manual directory cleanup might be needed)
+
+Once installed there a pkgconfig file is installed so using this library from another cmake project could be done by:
+```
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(MLSPP REQUIRED libmlspp)
+...
+target_link_libraries(${TEST_APP_NAME} ${MLSPP_LIBRARY} ${LIB_NAME})
+
+```
+Note that only static version is build for now.

--- a/cmake/GetGitRevisionDescription.cmake
+++ b/cmake/GetGitRevisionDescription.cmake
@@ -228,8 +228,8 @@ function(git_describe_working_tree _var)
 			OUTPUT_VARIABLE out
 			ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 	if(NOT res EQUAL 0)
-		#set(out "${out}-${res}-NOTFOUND")
-		set(out "0")
+		set(out "${out}-${res}-NOTFOUND")
+		#set(out "0")
 	endif()
 
 	set(${_var}

--- a/cmake/GetGitRevisionDescription.cmake
+++ b/cmake/GetGitRevisionDescription.cmake
@@ -228,7 +228,8 @@ function(git_describe_working_tree _var)
 			OUTPUT_VARIABLE out
 			ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 	if(NOT res EQUAL 0)
-		set(out "${out}-${res}-NOTFOUND")
+		#set(out "${out}-${res}-NOTFOUND")
+		set(out "0")
 	endif()
 
 	set(${_var}

--- a/cmake/GetGitRevisionDescription.cmake
+++ b/cmake/GetGitRevisionDescription.cmake
@@ -1,0 +1,279 @@
+# - Returns a version string from Git
+#
+# These functions force a re-configure on each git commit so that you can
+# trust the values of the variables in your build system.
+#
+#  get_git_head_revision(<refspecvar> <hashvar> [<additional arguments to git describe> ...])
+#
+# Returns the refspec and sha hash of the current head revision
+#
+#  git_describe(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe on the source tree, and adjusting
+# the output so that it tests false if an error occurs.
+#
+#  git_describe_working_tree(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe on the working tree (--dirty option),
+# and adjusting the output so that it tests false if an error occurs.
+#
+#  git_get_exact_tag(<var> [<additional arguments to git describe> ...])
+#
+# Returns the results of git describe --exact-match on the source tree,
+# and adjusting the output so that it tests false if there was no exact
+# matching tag.
+#
+#  git_local_changes(<var>)
+#
+# Returns either "CLEAN" or "DIRTY" with respect to uncommitted changes.
+# Uses the return code of "git diff-index --quiet HEAD --".
+# Does not regard untracked files.
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2020 Ryan Pavlik <ryan.pavlik@gmail.com> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+#
+# Copyright 2009-2013, Iowa State University.
+# Copyright 2013-2020, Ryan Pavlik
+# Copyright 2013-2020, Contributors
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+if(__get_git_revision_description)
+	return()
+endif()
+set(__get_git_revision_description YES)
+
+# We must run the following at "include" time, not at function call time,
+# to find the path to this module rather than the path to a calling list file
+get_filename_component(_gitdescmoddir ${CMAKE_CURRENT_LIST_FILE} PATH)
+
+# Function _git_find_closest_git_dir finds the next closest .git directory
+# that is part of any directory in the path defined by _start_dir.
+# The result is returned in the parent scope variable whose name is passed
+# as variable _git_dir_var. If no .git directory can be found, the
+# function returns an empty string via _git_dir_var.
+#
+# Example: Given a path C:/bla/foo/bar and assuming C:/bla/.git exists and
+# neither foo nor bar contain a file/directory .git. This wil return
+# C:/bla/.git
+#
+function(_git_find_closest_git_dir _start_dir _git_dir_var)
+	set(cur_dir "${_start_dir}")
+	set(git_dir "${_start_dir}/.git")
+	while(NOT EXISTS "${git_dir}")
+		# .git dir not found, search parent directories
+		set(git_previous_parent "${cur_dir}")
+		get_filename_component(cur_dir ${cur_dir} DIRECTORY)
+		if(cur_dir STREQUAL git_previous_parent)
+			# We have reached the root directory, we are not in git
+			set(${_git_dir_var}
+					""
+					PARENT_SCOPE)
+			return()
+		endif()
+		set(git_dir "${cur_dir}/.git")
+	endwhile()
+	set(${_git_dir_var}
+			"${git_dir}"
+			PARENT_SCOPE)
+endfunction()
+
+function(get_git_head_revision _refspecvar _hashvar)
+	_git_find_closest_git_dir("${CMAKE_CURRENT_SOURCE_DIR}" GIT_DIR)
+
+	if(NOT "${GIT_DIR}" STREQUAL "")
+		file(RELATIVE_PATH _relative_to_source_dir "${CMAKE_SOURCE_DIR}"
+				"${GIT_DIR}")
+		if("${_relative_to_source_dir}" MATCHES "[.][.]")
+			# We've gone above the CMake root dir.
+			set(GIT_DIR "")
+		endif()
+	endif()
+	if("${GIT_DIR}" STREQUAL "")
+		set(${_refspecvar}
+				"GITDIR-NOTFOUND"
+				PARENT_SCOPE)
+		set(${_hashvar}
+				"GITDIR-NOTFOUND"
+				PARENT_SCOPE)
+		return()
+	endif()
+
+	# Check if the current source dir is a git submodule or a worktree.
+	# In both cases .git is a file instead of a directory.
+	#
+	if(NOT IS_DIRECTORY ${GIT_DIR})
+		# The following git command will return a non empty string that
+		# points to the super project working tree if the current
+		# source dir is inside a git submodule.
+		# Otherwise the command will return an empty string.
+		#
+		execute_process(
+				COMMAND "${GIT_EXECUTABLE}" rev-parse
+				--show-superproject-working-tree
+				WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+				OUTPUT_VARIABLE out
+				ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+		if(NOT "${out}" STREQUAL "")
+			# If out is empty, GIT_DIR/CMAKE_CURRENT_SOURCE_DIR is in a submodule
+			file(READ ${GIT_DIR} submodule)
+			string(REGEX REPLACE "gitdir: (.*)$" "\\1" GIT_DIR_RELATIVE
+					${submodule})
+			string(STRIP ${GIT_DIR_RELATIVE} GIT_DIR_RELATIVE)
+			get_filename_component(SUBMODULE_DIR ${GIT_DIR} PATH)
+			get_filename_component(GIT_DIR ${SUBMODULE_DIR}/${GIT_DIR_RELATIVE}
+					ABSOLUTE)
+			set(HEAD_SOURCE_FILE "${GIT_DIR}/HEAD")
+		else()
+			# GIT_DIR/CMAKE_CURRENT_SOURCE_DIR is in a worktree
+			file(READ ${GIT_DIR} worktree_ref)
+			# The .git directory contains a path to the worktree information directory
+			# inside the parent git repo of the worktree.
+			#
+			string(REGEX REPLACE "gitdir: (.*)$" "\\1" git_worktree_dir
+					${worktree_ref})
+			string(STRIP ${git_worktree_dir} git_worktree_dir)
+			_git_find_closest_git_dir("${git_worktree_dir}" GIT_DIR)
+			set(HEAD_SOURCE_FILE "${git_worktree_dir}/HEAD")
+		endif()
+	else()
+		set(HEAD_SOURCE_FILE "${GIT_DIR}/HEAD")
+	endif()
+	set(GIT_DATA "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/git-data")
+	if(NOT EXISTS "${GIT_DATA}")
+		file(MAKE_DIRECTORY "${GIT_DATA}")
+	endif()
+
+	if(NOT EXISTS "${HEAD_SOURCE_FILE}")
+		return()
+	endif()
+	set(HEAD_FILE "${GIT_DATA}/HEAD")
+	configure_file("${HEAD_SOURCE_FILE}" "${HEAD_FILE}" COPYONLY)
+
+	configure_file("${_gitdescmoddir}/GetGitRevisionDescription.cmake.in"
+			"${GIT_DATA}/grabRef.cmake" @ONLY)
+	include("${GIT_DATA}/grabRef.cmake")
+
+	set(${_refspecvar}
+			"${HEAD_REF}"
+			PARENT_SCOPE)
+	set(${_hashvar}
+			"${HEAD_HASH}"
+			PARENT_SCOPE)
+endfunction()
+
+function(git_describe _var)
+	if(NOT GIT_FOUND)
+		find_package(Git QUIET)
+	endif()
+	get_git_head_revision(refspec hash)
+	if(NOT GIT_FOUND)
+		set(${_var}
+				"GIT-NOTFOUND"
+				PARENT_SCOPE)
+		return()
+	endif()
+	if(NOT hash)
+		set(${_var}
+				"HEAD-HASH-NOTFOUND"
+				PARENT_SCOPE)
+		return()
+	endif()
+
+	# TODO sanitize
+	#if((${ARGN}" MATCHES "&&") OR
+	#	(ARGN MATCHES "||") OR
+	#	(ARGN MATCHES "\\;"))
+	#	message("Please report the following error to the project!")
+	#	message(FATAL_ERROR "Looks like someone's doing something nefarious with git_describe! Passed arguments ${ARGN}")
+	#endif()
+
+	#message(STATUS "Arguments to execute_process: ${ARGN}")
+
+	execute_process(
+			COMMAND "${GIT_EXECUTABLE}" describe --tags --always ${hash} ${ARGN}
+			WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+			RESULT_VARIABLE res
+			OUTPUT_VARIABLE out
+			ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if(NOT res EQUAL 0)
+		set(out "${out}-${res}-NOTFOUND")
+	endif()
+
+	set(${_var}
+			"${out}"
+			PARENT_SCOPE)
+endfunction()
+
+function(git_describe_working_tree _var)
+	if(NOT GIT_FOUND)
+		find_package(Git QUIET)
+	endif()
+	if(NOT GIT_FOUND)
+		set(${_var}
+				"GIT-NOTFOUND"
+				PARENT_SCOPE)
+		return()
+	endif()
+
+	execute_process(
+			COMMAND "${GIT_EXECUTABLE}" describe --dirty ${ARGN}
+			WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+			RESULT_VARIABLE res
+			OUTPUT_VARIABLE out
+			ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if(NOT res EQUAL 0)
+		set(out "${out}-${res}-NOTFOUND")
+	endif()
+
+	set(${_var}
+			"${out}"
+			PARENT_SCOPE)
+endfunction()
+
+function(git_get_exact_tag _var)
+	git_describe(out --exact-match ${ARGN})
+	set(${_var}
+			"${out}"
+			PARENT_SCOPE)
+endfunction()
+
+function(git_local_changes _var)
+	if(NOT GIT_FOUND)
+		find_package(Git QUIET)
+	endif()
+	get_git_head_revision(refspec hash)
+	if(NOT GIT_FOUND)
+		set(${_var}
+				"GIT-NOTFOUND"
+				PARENT_SCOPE)
+		return()
+	endif()
+	if(NOT hash)
+		set(${_var}
+				"HEAD-HASH-NOTFOUND"
+				PARENT_SCOPE)
+		return()
+	endif()
+
+	execute_process(
+			COMMAND "${GIT_EXECUTABLE}" diff-index --quiet HEAD --
+			WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+			RESULT_VARIABLE res
+			OUTPUT_VARIABLE out
+			ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+	if(res EQUAL 0)
+		set(${_var}
+				"CLEAN"
+				PARENT_SCOPE)
+	else()
+		set(${_var}
+				"DIRTY"
+				PARENT_SCOPE)
+	endif()
+endfunction()

--- a/cmake/GetGitRevisionDescription.cmake.in
+++ b/cmake/GetGitRevisionDescription.cmake.in
@@ -1,0 +1,41 @@
+#
+# Internal file for GetGitRevisionDescription.cmake
+#
+# Requires CMake 2.6 or newer (uses the 'function' command)
+#
+# Original Author:
+# 2009-2010 Ryan Pavlik <rpavlik@iastate.edu> <abiryan@ryand.net>
+# http://academic.cleardefinition.com
+# Iowa State University HCI Graduate Program/VRAC
+#
+# Copyright Iowa State University 2009-2010.
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+set(HEAD_HASH)
+
+file(READ "@HEAD_FILE@" HEAD_CONTENTS LIMIT 1024)
+
+string(STRIP "${HEAD_CONTENTS}" HEAD_CONTENTS)
+if(HEAD_CONTENTS MATCHES "ref")
+	# named branch
+	string(REPLACE "ref: " "" HEAD_REF "${HEAD_CONTENTS}")
+	if(EXISTS "@GIT_DIR@/${HEAD_REF}")
+		configure_file("@GIT_DIR@/${HEAD_REF}" "@GIT_DATA@/head-ref" COPYONLY)
+	else()
+		configure_file("@GIT_DIR@/packed-refs" "@GIT_DATA@/packed-refs" COPYONLY)
+		file(READ "@GIT_DATA@/packed-refs" PACKED_REFS)
+		if(${PACKED_REFS} MATCHES "([0-9a-z]*) ${HEAD_REF}")
+			set(HEAD_HASH "${CMAKE_MATCH_1}")
+		endif()
+	endif()
+else()
+	# detached HEAD
+	configure_file("@GIT_DIR@/HEAD" "@GIT_DATA@/head-ref" COPYONLY)
+endif()
+
+if(NOT HEAD_HASH)
+	file(READ "@GIT_DATA@/head-ref" HEAD_HASH LIMIT 1024)
+	string(STRIP "${HEAD_HASH}" HEAD_HASH)
+endif()

--- a/cmake/version.c.in
+++ b/cmake/version.c.in
@@ -1,0 +1,5 @@
+//the path to the version.h file is relative to your build directory.
+#include "../include/version.h"
+
+const char VERSION[] = "@MLSPP_VERSION@";
+const char HASHVAR[] = "@HASHVAR@";

--- a/cmd/api_example/CMakeLists.txt
+++ b/cmd/api_example/CMakeLists.txt
@@ -2,6 +2,6 @@ set(APP_NAME "api_example")
 
 file(GLOB APP_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
-add_executable(${APP_NAME} ${APP_SOURCES})
+add_executable(${APP_NAME} ${APP_SOURCES} ${version_file})
 add_dependencies(${APP_NAME} ${LIB_NAME})
-target_link_libraries(${APP_NAME} ${LIB_NAME} OpenSSL::Crypto)
+target_link_libraries(${APP_NAME} PRIVATE ${LIB_NAME} OpenSSL::Crypto)

--- a/cmd/api_example/main.cpp
+++ b/cmd/api_example/main.cpp
@@ -7,6 +7,8 @@
 #include <stdexcept>
 #include <string>
 
+#include "version.h"
+
 using namespace mls;
 
 static mls::Client
@@ -47,6 +49,9 @@ verify(const std::string& label, Session& alice, Session& bob)
 int
 main() // NOLINT(bugprone-exception-escape)
 {
+
+  std::cout << "Running library version:" << std::string(VERSION) << std::endl;
+  std::cout << "       git sha hash:" << std::string(HASHVAR) << std::endl;
   const auto suite =
     mls::CipherSuite{ mls::CipherSuite::ID::X25519_AES128GCM_SHA256_Ed25519 };
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,0 +1,2 @@
+install ( DIRECTORY ../include/mls DESTINATION include
+          PATTERN CMakeLists.txt EXCLUDE )

--- a/include/version.h
+++ b/include/version.h
@@ -1,0 +1,9 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+
+/* Global version strings */
+extern const char VERSION[];
+extern const char HASHVAR[];
+
+#endif /* VERSION_H */

--- a/include/version.h
+++ b/include/version.h
@@ -1,7 +1,5 @@
 #pragma once
 
-
 /* Global version strings */
 extern const char VERSION[];
 extern const char HASHVAR[];
-

--- a/include/version.h
+++ b/include/version.h
@@ -1,9 +1,7 @@
-#ifndef VERSION_H
-#define VERSION_H
+#pragma once
 
 
 /* Global version strings */
 extern const char VERSION[];
 extern const char HASHVAR[];
 
-#endif /* VERSION_H */

--- a/lib/hpke/CMakeLists.txt
+++ b/lib/hpke/CMakeLists.txt
@@ -3,6 +3,15 @@ set(CURRENT_LIB_NAME hpke)
 ###
 ### Dependencies
 ###
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    find_package(OpenSSL)
+    IF (${OpenSSL_FOUND})
+        MESSAGE(STATUS "Found OpenSSL on Darwin")
+    ELSE (${OpenSSL_FOUND})
+        MESSAGE(STATUS "Could not locate OpenSSL on Darwin. Setting OPENSSL_ROOT_DIR to /usr/local/opt/openssl")
+        set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl")
+    ENDIF (${OpenSSL_FOUND})
+endif()
 find_package(OpenSSL 1.1 REQUIRED)
 
 ###

--- a/libmlspp.pc.in
+++ b/libmlspp.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: mlspplib
+Description: MLS Implementation
+URL: https://github.com/cisco/mlspp
+Version: @MLSPP_VERSION@
+Libs: -L${libdir} -llibmlspp
+Cflags: -I${includedir}


### PR DESCRIPTION
Added:
- Install target (make install, from your build directory)
- Generate a pkgconfig file to make it easier to link against this library
- Simple semantic versioning and git sha hash to identify build
