### PR TITLE
Remove manual variant iteration

### DIFF
--- a/include/mls/common.h
+++ b/include/mls/common.h
@@ -23,6 +23,13 @@ uint64_t
 seconds_since_epoch();
 
 ///
+/// Easy construction of overloaded lambdas
+///
+
+template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+///
 /// Auto-generate equality and inequality operators for TLS-serializable things
 ///
 

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -308,6 +308,8 @@ struct MLSPlaintext
   MLSPlaintext(bytes group_id, epoch_t epoch, Sender sender, Proposal proposal);
   MLSPlaintext(bytes group_id, epoch_t epoch, Sender sender, Commit commit);
 
+  ContentType::selector content_type() const;
+
   bytes to_be_signed(const GroupContext& context) const;
   void sign(const CipherSuite& suite,
             const GroupContext& context,

--- a/include/version.h
+++ b/include/version.h
@@ -1,0 +1,5 @@
+#pragma once
+
+/* Global version strings */
+extern const char VERSION[];
+extern const char HASHVAR[];

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -266,19 +266,22 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
   , decrypted(false)
 {}
 
+ContentType::selector
+MLSPlaintext::content_type() const
+{
+  static const auto get_content_type = overloaded{
+    [](const ApplicationData&) { return ContentType::selector::application; },
+    [](const Proposal&) { return ContentType::selector::proposal; },
+    [](const Commit&) { return ContentType::selector::commit; },
+  };
+  return std::visit(get_content_type, content);
+}
+
 bytes
 MLSPlaintext::marshal_content(size_t padding_size) const
 {
   tls::ostream w;
-  if (std::holds_alternative<ApplicationData>(content)) {
-    w << std::get<ApplicationData>(content);
-  } else if (std::holds_alternative<Proposal>(content)) {
-    w << std::get<Proposal>(content);
-  } else if (std::holds_alternative<Commit>(content)) {
-    w << std::get<Commit>(content);
-  } else {
-    throw InvalidParameterError("Unknown content type");
-  }
+  std::visit([&](auto&& inner_content) { w << inner_content; }, content);
 
   bytes padding(padding_size, 0);
   tls::vector<2>::encode(w, signature);


### PR DESCRIPTION
C++17 provides `std::visit` to automatically branch over variant alternatives.  This PR changes the manual branches we had before to use `std::visit`.