### PR TITLE
Export targets for consumption elsewhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,3 +85,11 @@ add_subdirectory(test)
 ###
 
 add_subdirectory(cmd)
+
+
+###
+### Exports
+###
+set(CMAKE_EXPORT_PACKAGE_REGISTRY ON)
+export(TARGETS mlspp tls_syntax hpke bytes NAMESPACE MLSPP:: FILE MLSPPConfig.cmake)
+export(PACKAGE MLSPP)

--- a/include/mls/common.h
+++ b/include/mls/common.h
@@ -26,8 +26,13 @@ seconds_since_epoch();
 /// Easy construction of overloaded lambdas
 ///
 
-template<class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
-template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+template<class... Ts>
+struct overloaded : Ts...
+{
+  using Ts::operator()...;
+};
+template<class... Ts>
+overloaded(Ts...)->overloaded<Ts...>;
 
 ///
 /// Auto-generate equality and inequality operators for TLS-serializable things

--- a/include/mls/common.h
+++ b/include/mls/common.h
@@ -31,8 +31,13 @@ struct overloaded : Ts...
 {
   using Ts::operator()...;
 };
-template<class... Ts>
-overloaded(Ts...)->overloaded<Ts...>;
+
+// clang-format off
+// XXX(RLB): For some reason, different versions of clang-format disagree on how
+// this should be formatted.  Probably because it's new syntax with C++17?
+// Exempting it from clang-format for now.
+template<class... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+// clang-format on
 
 ///
 /// Auto-generate equality and inequality operators for TLS-serializable things

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -702,7 +702,9 @@ State::encrypt(const MLSPlaintext& pt)
 {
   // Pull from the key schedule
   static const auto get_key_type = overloaded{
-    [](const ApplicationData&) { return GroupKeySource::RatchetType::application; },
+    [](const ApplicationData&) {
+      return GroupKeySource::RatchetType::application;
+    },
     [](const Proposal&) { return GroupKeySource::RatchetType::handshake; },
     [](const Commit&) { return GroupKeySource::RatchetType::handshake; },
   };

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -20,9 +20,11 @@ const NodeType::selector NodeType::type<ParentNode> =
 const HPKEPublicKey&
 Node::public_key() const
 {
-  static const auto get_key = overloaded {
+  static const auto get_key = overloaded{
     [](const KeyPackage& kp) -> const HPKEPublicKey& { return kp.init_key; },
-    [](const ParentNode& node) -> const HPKEPublicKey& { return node.public_key; },
+    [](const ParentNode& node) -> const HPKEPublicKey& {
+      return node.public_key;
+    },
   };
   return std::visit(get_key, node);
 }


### PR DESCRIPTION
With this change, MLSPP registers itself in the local package directory (`~/.cmake/packages` on macOS/Linux).  It can then be included with `find_package(MLSPP)` in projects that depend on it.  This is not a replacement for #138 (as that will be necessary for longer-term maintainability), but is a slightly nicer approach for codevelopment, since no install step is needed.  The dependent library will pick up changes as soon as the dependency is rebuilt.