### PR TITLE
Allow applications to set extensions in KeyPackages

### DIFF
--- a/cmd/api_example/main.cpp
+++ b/cmd/api_example/main.cpp
@@ -15,7 +15,11 @@ create_client(CipherSuite suite, const std::string& name)
   auto id = bytes(name.begin(), name.end());
   auto sig_priv = SignaturePrivateKey::generate(suite);
   auto cred = Credential::basic(id, sig_priv.public_key);
-  return Client(suite, sig_priv, cred);
+
+  auto ext_list = ExtensionList{};
+  ext_list.add(ExtensionType::key_id, bytes(name.begin(), name.end()));
+
+  return Client(suite, sig_priv, cred, {{ ext_list }});
 }
 
 static void

--- a/cmd/api_example/main.cpp
+++ b/cmd/api_example/main.cpp
@@ -9,7 +9,7 @@
 
 using namespace mls;
 
-static mls::Client
+static Client
 create_client(CipherSuite suite, const std::string& name)
 {
   auto id = bytes(name.begin(), name.end());
@@ -48,7 +48,7 @@ int
 main() // NOLINT(bugprone-exception-escape)
 {
   const auto suite =
-    mls::CipherSuite{ mls::CipherSuite::ID::X25519_AES128GCM_SHA256_Ed25519 };
+    CipherSuite{ CipherSuite::ID::X25519_AES128GCM_SHA256_Ed25519 };
 
   ////////// DRAMATIS PERSONAE ///////////
 

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -250,7 +250,7 @@ generate_treekem()
       auto sig_priv =
         SignaturePrivateKey::derive(suite, tv.init_secrets[j].data);
       auto cred = Credential::basic(context, sig_priv.public_key);
-      auto kp = KeyPackage{ suite, init_priv.public_key, cred, sig_priv };
+      auto kp = KeyPackage{ suite, init_priv.public_key, cred, sig_priv, std::nullopt };
 
       auto index = tree.add_leaf(kp);
       tree.encap(
@@ -311,7 +311,7 @@ generate_messages()
     // Construct KeyPackage
     auto ext_list =
       ExtensionList{ { { ExtensionType::lifetime, bytes(8, 0) } } };
-    auto key_package = KeyPackage{ suite, dh_priv.public_key, cred, sig_priv };
+    auto key_package = KeyPackage{ suite, dh_priv.public_key, cred, sig_priv, std::nullopt };
     key_package.extensions = ext_list;
     key_package.signature = tv.random;
 

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -311,8 +311,7 @@ generate_messages()
     // Construct KeyPackage
     auto ext_list =
       ExtensionList{ { { ExtensionType::lifetime, bytes(8, 0) } } };
-    auto key_package = KeyPackage{ suite, dh_priv.public_key, cred, sig_priv, std::nullopt };
-    key_package.extensions = ext_list;
+    auto key_package = KeyPackage{ suite, dh_priv.public_key, cred, sig_priv, {{ ext_list }} };
     key_package.signature = tv.random;
 
     // Construct UpdatePath

--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -250,7 +250,8 @@ generate_treekem()
       auto sig_priv =
         SignaturePrivateKey::derive(suite, tv.init_secrets[j].data);
       auto cred = Credential::basic(context, sig_priv.public_key);
-      auto kp = KeyPackage{ suite, init_priv.public_key, cred, sig_priv, std::nullopt };
+      auto kp =
+        KeyPackage{ suite, init_priv.public_key, cred, sig_priv, std::nullopt };
 
       auto index = tree.add_leaf(kp);
       tree.encap(
@@ -311,7 +312,8 @@ generate_messages()
     // Construct KeyPackage
     auto ext_list =
       ExtensionList{ { { ExtensionType::lifetime, bytes(8, 0) } } };
-    auto key_package = KeyPackage{ suite, dh_priv.public_key, cred, sig_priv, {{ ext_list }} };
+    auto key_package =
+      KeyPackage{ suite, dh_priv.public_key, cred, sig_priv, { { ext_list } } };
     key_package.signature = tv.random;
 
     // Construct UpdatePath

--- a/include/mls/core_types.h
+++ b/include/mls/core_types.h
@@ -17,18 +17,18 @@ enum class ProtocolVersion : uint8_t
 
 extern const std::array<ProtocolVersion, 1> all_supported_versions;
 
-enum struct ExtensionType : uint16_t
+struct ExtensionType
 {
-  supported_versions = 1,
-  supported_ciphersuites = 2,
-  lifetime = 3,
-  key_id = 4,
-  parent_hash = 5,
+  static const uint16_t supported_versions = 1;
+  static const uint16_t supported_ciphersuites = 2;
+  static const uint16_t lifetime = 3;
+  static const uint16_t key_id = 4;
+  static const uint16_t parent_hash = 5;
 };
 
 struct Extension
 {
-  ExtensionType type;
+  uint16_t type;
   bytes data;
 
   TLS_SERIALIZABLE(type, data)
@@ -46,18 +46,10 @@ struct ExtensionList
   inline void add(const T& obj)
   {
     auto data = tls::marshal(obj);
-
-    auto curr = std::find_if(
-      extensions.begin(), extensions.end(), [&](const Extension& ext) -> bool {
-        return ext.type == T::type;
-      });
-    if (curr != extensions.end()) {
-      curr->data = std::move(data);
-      return;
-    }
-
-    extensions.push_back({ T::type, std::move(data) });
+    add(static_cast<uint16_t>(T::type), std::move(data));
   }
+
+  void add(uint16_t type, bytes data);
 
   template<typename T>
   std::optional<T> find() const
@@ -71,7 +63,7 @@ struct ExtensionList
     return std::nullopt;
   }
 
-  bool has(ExtensionType type) const;
+  bool has(uint16_t type) const;
 
   TLS_SERIALIZABLE(extensions)
   TLS_TRAITS(tls::vector<2>)
@@ -81,7 +73,7 @@ struct SupportedVersionsExtension
 {
   std::vector<ProtocolVersion> versions;
 
-  static const ExtensionType type;
+  static const uint16_t type;
   TLS_SERIALIZABLE(versions)
   TLS_TRAITS(tls::vector<1>)
 };
@@ -90,7 +82,7 @@ struct SupportedCipherSuitesExtension
 {
   std::vector<CipherSuite::ID> cipher_suites;
 
-  static const ExtensionType type;
+  static const uint16_t type;
   TLS_SERIALIZABLE(cipher_suites)
   TLS_TRAITS(tls::vector<1>)
 };
@@ -100,7 +92,7 @@ struct LifetimeExtension
   uint64_t not_before;
   uint64_t not_after;
 
-  static const ExtensionType type;
+  static const uint16_t type;
   TLS_SERIALIZABLE(not_before, not_after)
 };
 
@@ -108,7 +100,7 @@ struct KeyIDExtension
 {
   bytes key_id;
 
-  static const ExtensionType type;
+  static const uint16_t type;
   TLS_SERIALIZABLE(key_id)
   TLS_TRAITS(tls::vector<2>)
 };
@@ -117,7 +109,7 @@ struct ParentHashExtension
 {
   bytes parent_hash;
 
-  static const ExtensionType type;
+  static const uint16_t type;
   TLS_SERIALIZABLE(parent_hash)
   TLS_TRAITS(tls::vector<1>)
 };

--- a/include/mls/core_types.h
+++ b/include/mls/core_types.h
@@ -147,6 +147,7 @@ struct ParentNode
 struct KeyPackageOpts
 {
   // TODO: Things to change in a KeyPackage
+  ExtensionList extensions;
 };
 
 struct KeyPackage
@@ -162,7 +163,8 @@ struct KeyPackage
   KeyPackage(CipherSuite suite_in,
              HPKEPublicKey init_key_in,
              Credential credential_in,
-             const SignaturePrivateKey& sig_priv_in);
+             const SignaturePrivateKey& sig_priv_in,
+             const std::optional<KeyPackageOpts>& opts_in);
 
   bytes hash() const;
 

--- a/include/mls/session.h
+++ b/include/mls/session.h
@@ -73,7 +73,7 @@ public:
   bytes do_export(const std::string& label,
                   const bytes& context,
                   size_t size) const;
-  std::vector<Credential> roster() const;
+  std::vector<KeyPackage> roster() const;
 
   // Application message protection
   bytes protect(const bytes& plaintext);

--- a/include/mls/session.h
+++ b/include/mls/session.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <mls/common.h>
+#include <mls/core_types.h>
 #include <mls/credential.h>
 #include <mls/crypto.h>
 
@@ -14,7 +15,8 @@ class Client
 public:
   Client(CipherSuite suite_in,
          SignaturePrivateKey sig_priv_in,
-         Credential cred_in);
+         Credential cred_in,
+         std::optional<KeyPackageOpts> opts_in);
 
   Session begin_session(const bytes& group_id) const;
 
@@ -24,6 +26,7 @@ private:
   const CipherSuite suite;
   const SignaturePrivateKey sig_priv;
   const Credential cred;
+  const std::optional<KeyPackageOpts> opts;
 };
 
 class PendingJoin

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -91,7 +91,7 @@ public:
                   const bytes& context,
                   size_t size) const;
   // Ordered list of credentials from non-blank leaves
-  std::vector<Credential> roster() const;
+  std::vector<KeyPackage> roster() const;
 
   ///
   /// General encryption and decryption

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -41,7 +41,8 @@ static const uint64_t default_not_after = 0xffffffffffffffff;
 KeyPackage::KeyPackage(CipherSuite suite_in,
                        HPKEPublicKey init_key_in,
                        Credential credential_in,
-                       const SignaturePrivateKey& sig_priv_in)
+                       const SignaturePrivateKey& sig_priv_in,
+                       const std::optional<KeyPackageOpts>& opts_in)
   : version(ProtocolVersion::mls10)
   , cipher_suite(suite_in)
   , init_key(std::move(init_key_in))
@@ -55,7 +56,7 @@ KeyPackage::KeyPackage(CipherSuite suite_in,
   // TODO(RLB) Set non-eternal lifetimes
   extensions.add(LifetimeExtension{ default_not_before, default_not_after });
 
-  sign(sig_priv_in, std::nullopt);
+  sign(sig_priv_in, opts_in);
 }
 
 bytes

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -9,16 +9,31 @@ const std::array<ProtocolVersion, 1> all_supported_versions = {
   ProtocolVersion::mls10
 };
 
-const ExtensionType SupportedVersionsExtension::type =
+const uint16_t SupportedVersionsExtension::type =
   ExtensionType::supported_versions;
-const ExtensionType SupportedCipherSuitesExtension::type =
+const uint16_t SupportedCipherSuitesExtension::type =
   ExtensionType::supported_ciphersuites;
-const ExtensionType LifetimeExtension::type = ExtensionType::lifetime;
-const ExtensionType KeyIDExtension::type = ExtensionType::key_id;
-const ExtensionType ParentHashExtension::type = ExtensionType::parent_hash;
+const uint16_t LifetimeExtension::type = ExtensionType::lifetime;
+const uint16_t KeyIDExtension::type = ExtensionType::key_id;
+const uint16_t ParentHashExtension::type = ExtensionType::parent_hash;
+
+void
+ExtensionList::add(uint16_t type, bytes data)
+{
+    auto curr = std::find_if(
+      extensions.begin(), extensions.end(), [&](const Extension& ext) -> bool {
+        return ext.type == type;
+      });
+    if (curr != extensions.end()) {
+      curr->data = std::move(data);
+      return;
+    }
+
+    extensions.push_back({ type, std::move(data) });
+}
 
 bool
-ExtensionList::has(ExtensionType type) const
+ExtensionList::has(uint16_t type) const
 {
   return std::any_of(
     extensions.begin(), extensions.end(), [&](const Extension& ext) -> bool {
@@ -69,8 +84,12 @@ void
 KeyPackage::sign(const SignaturePrivateKey& sig_priv,
                  const std::optional<KeyPackageOpts>& opts)
 {
-  // TODO(RLB): Apply opts
-  silence_unused(opts);
+  if (opts.has_value()) {
+    // Fill in application-provided extensions
+    for (const auto& ext : opts.value().extensions.extensions) {
+      extensions.add(ext.type, ext.data);
+    }
+  }
 
   auto tbs = to_be_signed();
   signature = sig_priv.sign(cipher_suite, tbs);

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -20,16 +20,16 @@ const uint16_t ParentHashExtension::type = ExtensionType::parent_hash;
 void
 ExtensionList::add(uint16_t type, bytes data)
 {
-    auto curr = std::find_if(
-      extensions.begin(), extensions.end(), [&](const Extension& ext) -> bool {
-        return ext.type == type;
-      });
-    if (curr != extensions.end()) {
-      curr->data = std::move(data);
-      return;
-    }
+  auto curr = std::find_if(
+    extensions.begin(), extensions.end(), [&](const Extension& ext) -> bool {
+      return ext.type == type;
+    });
+  if (curr != extensions.end()) {
+    curr->data = std::move(data);
+    return;
+  }
 
-    extensions.push_back({ type, std::move(data) });
+  extensions.push_back({ type, std::move(data) });
 }
 
 bool

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -92,7 +92,11 @@ PendingJoin::Inner::Inner(CipherSuite suite_in,
   : suite(suite_in)
   , init_priv(HPKEPrivateKey::generate(suite))
   , sig_priv(std::move(sig_priv_in))
-  , key_package(suite, init_priv.public_key, std::move(cred_in), sig_priv, opts_in)
+  , key_package(suite,
+                init_priv.public_key,
+                std::move(cred_in),
+                sig_priv,
+                opts_in)
 {}
 
 PendingJoin
@@ -101,8 +105,8 @@ PendingJoin::Inner::create(CipherSuite suite,
                            Credential cred,
                            const std::optional<KeyPackageOpts>& opts_in)
 {
-  auto inner =
-    std::make_unique<Inner>(suite, std::move(sig_priv), std::move(cred), opts_in);
+  auto inner = std::make_unique<Inner>(
+    suite, std::move(sig_priv), std::move(cred), opts_in);
   return PendingJoin(inner.release());
 }
 
@@ -350,7 +354,7 @@ Session::do_export(const std::string& label,
   return inner->history.front().do_export(label, context, size);
 }
 
-std::vector<Credential>
+std::vector<KeyPackage>
 Session::roster() const
 {
   return inner->history.front().roster();

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -20,11 +20,13 @@ struct PendingJoin::Inner
 
   Inner(CipherSuite suite_in,
         SignaturePrivateKey sig_priv_in,
-        Credential cred_in);
+        Credential cred_in,
+        const std::optional<KeyPackageOpts>& opts_in);
 
   static PendingJoin create(CipherSuite suite,
                             SignaturePrivateKey sig_priv,
-                            Credential cred);
+                            Credential cred,
+                            const std::optional<KeyPackageOpts>& opts_in);
 };
 
 struct Session::Inner
@@ -57,24 +59,26 @@ struct Session::Inner
 
 Client::Client(CipherSuite suite_in,
                SignaturePrivateKey sig_priv_in,
-               Credential cred_in)
+               Credential cred_in,
+               std::optional<KeyPackageOpts> opts_in)
   : suite(suite_in)
   , sig_priv(std::move(sig_priv_in))
   , cred(std::move(cred_in))
+  , opts(std::move(opts_in))
 {}
 
 Session
 Client::begin_session(const bytes& group_id) const
 {
   auto init_priv = HPKEPrivateKey::generate(suite);
-  auto kp = KeyPackage{ suite, init_priv.public_key, cred, sig_priv };
+  auto kp = KeyPackage{ suite, init_priv.public_key, cred, sig_priv, opts };
   return Session::Inner::begin(group_id, init_priv, sig_priv, kp);
 }
 
 PendingJoin
 Client::start_join() const
 {
-  return PendingJoin::Inner::create(suite, sig_priv, cred);
+  return PendingJoin::Inner::create(suite, sig_priv, cred, opts);
 }
 
 ///
@@ -83,20 +87,22 @@ Client::start_join() const
 
 PendingJoin::Inner::Inner(CipherSuite suite_in,
                           SignaturePrivateKey sig_priv_in,
-                          Credential cred_in)
+                          Credential cred_in,
+                          const std::optional<KeyPackageOpts>& opts_in)
   : suite(suite_in)
   , init_priv(HPKEPrivateKey::generate(suite))
   , sig_priv(std::move(sig_priv_in))
-  , key_package(suite, init_priv.public_key, std::move(cred_in), sig_priv)
+  , key_package(suite, init_priv.public_key, std::move(cred_in), sig_priv, opts_in)
 {}
 
 PendingJoin
 PendingJoin::Inner::create(CipherSuite suite,
                            SignaturePrivateKey sig_priv,
-                           Credential cred)
+                           Credential cred,
+                           const std::optional<KeyPackageOpts>& opts_in)
 {
   auto inner =
-    std::make_unique<Inner>(suite, std::move(sig_priv), std::move(cred));
+    std::make_unique<Inner>(suite, std::move(sig_priv), std::move(cred), opts_in);
   return PendingJoin(inner.release());
 }
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -613,23 +613,23 @@ State::do_export(const std::string& label,
   return _suite.expand_with_label(secret, "exporter", context_hash, size);
 }
 
-std::vector<Credential>
+std::vector<KeyPackage>
 State::roster() const
 {
-  std::vector<Credential> creds(_tree.size().val);
-  uint32_t leaf_count = 0;
+  auto kps = std::vector<KeyPackage>(_tree.size().val);
+  auto leaf_count = uint32_t(0);
 
   for (uint32_t i = 0; i < _tree.size().val; i++) {
     const auto& kp = _tree.key_package(LeafIndex{ i });
     if (!kp.has_value()) {
       continue;
     }
-    creds.at(leaf_count) = kp->credential;
+    kps.at(leaf_count) = kp.value();
     leaf_count++;
   }
 
-  creds.resize(leaf_count);
-  return creds;
+  kps.resize(leaf_count);
+  return kps;
 }
 
 // struct {

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -76,8 +76,9 @@ TEST_CASE("Messages Interop")
     // KeyPackage
     auto ext_list =
       ExtensionList{ { { ExtensionType::lifetime, bytes(8, 0) } } };
-    auto key_package =
-      KeyPackage{ tc.cipher_suite, dh_priv.public_key, cred, sig_priv, {{ ext_list }} };
+    auto key_package = KeyPackage{
+      tc.cipher_suite, dh_priv.public_key, cred, sig_priv, { { ext_list } }
+    };
     key_package.signature = tv.random;
     tls_round_trip(tc.key_package, key_package, reproducible);
 

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -77,7 +77,8 @@ TEST_CASE("Messages Interop")
     auto ext_list =
       ExtensionList{ { { ExtensionType::lifetime, bytes(8, 0) } } };
     auto key_package =
-      KeyPackage{ tc.cipher_suite, dh_priv.public_key, cred, sig_priv };
+      KeyPackage{ tc.cipher_suite, dh_priv.public_key, cred, sig_priv, std::nullopt };
+    // TODO(RLB): Apply extensions via opts
     key_package.extensions = ext_list;
     key_package.signature = tv.random;
     tls_round_trip(tc.key_package, key_package, reproducible);

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -77,9 +77,7 @@ TEST_CASE("Messages Interop")
     auto ext_list =
       ExtensionList{ { { ExtensionType::lifetime, bytes(8, 0) } } };
     auto key_package =
-      KeyPackage{ tc.cipher_suite, dh_priv.public_key, cred, sig_priv, std::nullopt };
-    // TODO(RLB): Apply extensions via opts
-    key_package.extensions = ext_list;
+      KeyPackage{ tc.cipher_suite, dh_priv.public_key, cred, sig_priv, {{ ext_list }} };
     key_package.signature = tv.random;
     tls_round_trip(tc.key_package, key_package, reproducible);
 

--- a/test/session.cpp
+++ b/test/session.cpp
@@ -51,7 +51,7 @@ protected:
     auto id_priv = new_identity_key();
     auto init_priv = new_init_key();
     auto cred = Credential::basic(user_id, id_priv.public_key);
-    auto client = Client(suite, id_priv, cred);
+    auto client = Client(suite, id_priv, cred, std::nullopt);
 
     // Initial add is different
     if (sessions.empty()) {

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -16,7 +16,7 @@ public:
       auto credential = Credential::basic(user_id, identity_priv.public_key);
       auto init_priv = HPKEPrivateKey::derive(suite, init_secret);
       auto key_package =
-        KeyPackage{ suite, init_priv.public_key, credential, identity_priv };
+        KeyPackage{ suite, init_priv.public_key, credential, identity_priv, std::nullopt };
 
       init_privs.push_back(init_priv);
       identity_privs.push_back(identity_priv);

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -249,6 +249,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Roster Updates")
   // commit to new state
   auto [commit_1, welcome_1, new_state_1] = states[0].commit(fresh_secret());
   silence_unused(welcome_1);
+  silence_unused(commit_1);
   // roster should be 0, 2, 3, 4
   auto expected_creds = std::vector<Credential>{
     key_packages[0].credential,
@@ -269,6 +270,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Roster Updates")
   new_state_1.handle(remove_2);
   // commit to new state
   auto [commit_2, welcome_2, new_state_2] = new_state_1.commit(fresh_secret());
+  silence_unused(commit_2);
   silence_unused(welcome_2);
   // roster should be 0, 2, 4
   expected_creds = std::vector<Credential>{

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -275,7 +275,7 @@ struct TestTreeKEMPublicKey : public TreeKEMPublicKey
     auto init_pub = HPKEPrivateKey::derive(suite, secret).public_key;
     auto sig_priv = SignaturePrivateKey::derive(suite, secret);
     auto cred = Credential::basic({ 0, 1, 2, 3 }, sig_priv.public_key);
-    auto kp = KeyPackage{ suite, init_pub, cred, sig_priv };
+    auto kp = KeyPackage{ suite, init_pub, cred, sig_priv, std::nullopt };
 
     // Correct for non-determinism in the signature algorithm
     kp.signature = secret;

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -22,7 +22,8 @@ protected:
     auto init_priv = HPKEPrivateKey::generate(suite);
     auto sig_priv = SignaturePrivateKey::generate(suite);
     auto cred = Credential::basic({ 0, 1, 2, 3 }, sig_priv.public_key);
-    auto kp = KeyPackage{ suite, init_priv.public_key, cred, sig_priv, std::nullopt };
+    auto kp =
+      KeyPackage{ suite, init_priv.public_key, cred, sig_priv, std::nullopt };
     return std::make_tuple(init_priv, sig_priv, kp);
   }
 };
@@ -276,8 +277,9 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Interop")
       auto sig_priv =
         SignaturePrivateKey::derive(tc.cipher_suite, tv.init_secrets[j].data);
       auto cred = Credential::basic(context, sig_priv.public_key);
-      auto kp =
-        KeyPackage{ tc.cipher_suite, init_priv.public_key, cred, sig_priv, std::nullopt };
+      auto kp = KeyPackage{
+        tc.cipher_suite, init_priv.public_key, cred, sig_priv, std::nullopt
+      };
 
       auto index = tree.add_leaf(kp);
       tree.encap(

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -22,7 +22,7 @@ protected:
     auto init_priv = HPKEPrivateKey::generate(suite);
     auto sig_priv = SignaturePrivateKey::generate(suite);
     auto cred = Credential::basic({ 0, 1, 2, 3 }, sig_priv.public_key);
-    auto kp = KeyPackage{ suite, init_priv.public_key, cred, sig_priv };
+    auto kp = KeyPackage{ suite, init_priv.public_key, cred, sig_priv, std::nullopt };
     return std::make_tuple(init_priv, sig_priv, kp);
   }
 };
@@ -277,7 +277,7 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Interop")
         SignaturePrivateKey::derive(tc.cipher_suite, tv.init_secrets[j].data);
       auto cred = Credential::basic(context, sig_priv.public_key);
       auto kp =
-        KeyPackage{ tc.cipher_suite, init_priv.public_key, cred, sig_priv };
+        KeyPackage{ tc.cipher_suite, init_priv.public_key, cred, sig_priv, std::nullopt };
 
       auto index = tree.add_leaf(kp);
       tree.encap(


### PR DESCRIPTION
Some extensions are intended for application use (notably `key_id`), and applications might want to add vendor-defined extensions in the future.  This PR allows applications to add extensions to the KeyPackage created by the Session API, and exposes full KeyPackages in `Session::roster()` so that the application can inspect the KeyPackages (and extensions) of other participants.