### PR TITLE
Expose authentication_secret

### DIFF
--- a/cmd/api_example/main.cpp
+++ b/cmd/api_example/main.cpp
@@ -64,6 +64,10 @@ verify(const std::string& label, Session& alice, Session& bob)
     throw std::runtime_error(label + ": roster not equal");
   }
 
+  if (alice.authentication_secret() != bob.authentication_secret()) {
+    throw std::runtime_error(label + ": authenticaiton secret not equal");
+  }
+
   verify_send(label, alice, bob);
   verify_send(label, bob, alice);
 }

--- a/include/mls/session.h
+++ b/include/mls/session.h
@@ -74,6 +74,7 @@ public:
                   const bytes& context,
                   size_t size) const;
   std::vector<KeyPackage> roster() const;
+  bytes authentication_secret() const;
 
   // Application message protection
   bytes protect(const bytes& plaintext);

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -90,8 +90,11 @@ public:
   bytes do_export(const std::string& label,
                   const bytes& context,
                   size_t size) const;
+
   // Ordered list of credentials from non-blank leaves
   std::vector<KeyPackage> roster() const;
+
+  bytes authentication_secret() const;
 
   ///
   /// General encryption and decryption

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -361,6 +361,12 @@ Session::roster() const
 }
 
 bytes
+Session::authentication_secret() const
+{
+  return inner->history.front().authentication_secret();
+}
+
+bytes
 Session::protect(const bytes& plaintext)
 {
   auto ciphertext = inner->history.front().protect(plaintext);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -632,6 +632,12 @@ State::roster() const
   return kps;
 }
 
+bytes
+State::authentication_secret() const
+{
+  return _keys.authentication_secret;
+}
+
 // struct {
 //     opaque group_id<0..255>;
 //     uint64 epoch;

--- a/test/test_vectors.h
+++ b/test/test_vectors.h
@@ -399,22 +399,6 @@ struct MessagesTestVectors
 
 /////
 
-namespace mls {
-
-class TestState : public State
-{
-public:
-  TestState(const State& other)
-    : State(other)
-  {}
-
-  KeyScheduleEpoch keys() const { return _keys; }
-};
-
-} // namespace mls
-
-/////
-
 template<typename T>
 struct TestLoader
 {


### PR DESCRIPTION
This PR just takes the authentication secret that is already computed in the key schedule and adds APIs to access it via State and Session.  Also some drive-by cleanup in `test-vectors.h`.