### PR TITLE
Support macOS back to 10.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
   PKG_CONFIG_PATH: /usr/local/opt/openssl/lib/pkgconfig
+  MACOSX_DEPLOYMENT_TARGET: 10.11
 
 jobs:
   build:

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -11,20 +11,16 @@ on:
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
   PKG_CONFIG_PATH: /usr/local/opt/openssl/lib/pkgconfig
+  MACOSX_DEPLOYMENT_TARGET: 10.11
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-      fail-fast: false
+    runs-on: macos-latest
     
     steps:
     - uses: actions/checkout@v1
     
-    - name: dependencies (macos)
-      if: ${{ matrix.os == 'macos-latest' }}
+    - name: dependencies
       run: |
         brew uninstall openssl
         brew install pkgconfig doctest
@@ -33,21 +29,5 @@ jobs:
         ln -s "/usr/local/opt/llvm/bin/clang-format" "/usr/local/bin/clang-format"
         ln -s "/usr/local/opt/llvm/bin/clang-tidy" "/usr/local/bin/clang-tidy"
 
-  
-    - name: dependencies (ubuntu)
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: |
-        brew install pkgconfig doctest
-
-    - name: configure to use clang-tidy
-      run: make tidy
-
-    - name: build
-      run: make everything
-
-    - name: generate test vectors
-      run: make gen
-
-    - name: run tests
-      run: make test-all
-
+    - name: build the library
+      run: make

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Build for older MacOS
 
 on:
   push:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   add_compile_options(-Wall -pedantic -Wextra -Werror -Wmissing-declarations)
-  check_cxx_compiler_flag(-Wextra-semi COMPILER_SUPPORTS_EXTRA_SEMI_WARNING)
-  if (COMPILER_SUPPORTS_EXTRA_SEMI_WARNING)
-      add_compile_options("-Wextra-semi")
-  endif()
 elseif(MSVC)
   add_compile_options(/W4 /WX)
 endif()
@@ -53,6 +49,30 @@ add_subdirectory(lib)
 
 # External libraries
 find_package(OpenSSL 1.1 REQUIRED)
+
+# mpark-variant fetched from GitHub
+include( ExternalProject )
+find_package( Git REQUIRED )
+set( VARIANT_LITE_URL https://github.com/mpark/variant.git )
+set_directory_properties( PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/third_party )
+
+ExternalProject_Add(
+    mpark-variant-extern
+    GIT_REPOSITORY ${VARIANT_LITE_URL}
+    TIMEOUT 10
+    UPDATE_COMMAND ${GIT_EXECUTABLE} pull
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    LOG_DOWNLOAD ON
+   )
+
+ExternalProject_Get_Property( mpark-variant-extern SOURCE_DIR )
+set( VARIANT_LITE_INCLUDE_DIR ${SOURCE_DIR}/include CACHE INTERNAL "Include folder for mpark-variant" )
+
+add_library( mpark-variant INTERFACE )
+add_dependencies(mpark-variant mpark-variant-extern)
+target_include_directories( mpark-variant INTERFACE ${VARIANT_LITE_INCLUDE_DIR} )
 
 ###
 ### Library Config
@@ -91,5 +111,5 @@ add_subdirectory(cmd)
 ### Exports
 ###
 set(CMAKE_EXPORT_PACKAGE_REGISTRY ON)
-export(TARGETS mlspp tls_syntax hpke bytes NAMESPACE MLSPP:: FILE MLSPPConfig.cmake)
+export(TARGETS mlspp tls_syntax hpke bytes mpark-variant NAMESPACE MLSPP:: FILE MLSPPConfig.cmake)
 export(PACKAGE MLSPP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,12 +53,12 @@ find_package(OpenSSL 1.1 REQUIRED)
 # mpark-variant fetched from GitHub
 include( ExternalProject )
 find_package( Git REQUIRED )
-set( VARIANT_LITE_URL https://github.com/mpark/variant.git )
+set( MPARK_VARIANT_URL https://github.com/mpark/variant.git )
 set_directory_properties( PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/third_party )
 
 ExternalProject_Add(
     mpark-variant-extern
-    GIT_REPOSITORY ${VARIANT_LITE_URL}
+    GIT_REPOSITORY ${MPARK_VARIANT_URL}
     TIMEOUT 10
     UPDATE_COMMAND ${GIT_EXECUTABLE} pull
     CONFIGURE_COMMAND ""
@@ -68,11 +68,11 @@ ExternalProject_Add(
    )
 
 ExternalProject_Get_Property( mpark-variant-extern SOURCE_DIR )
-set( VARIANT_LITE_INCLUDE_DIR ${SOURCE_DIR}/include CACHE INTERNAL "Include folder for mpark-variant" )
+set( MPARK_VARIANT_INCLUDE_DIR ${SOURCE_DIR}/include CACHE INTERNAL "Include folder for mpark-variant" )
 
 add_library( mpark-variant INTERFACE )
 add_dependencies(mpark-variant mpark-variant-extern)
-target_include_directories( mpark-variant INTERFACE ${VARIANT_LITE_INCLUDE_DIR} )
+target_include_directories( mpark-variant INTERFACE ${MPARK_VARIANT_INCLUDE_DIR} )
 
 ###
 ### Library Config

--- a/cmd/api_example/main.cpp
+++ b/cmd/api_example/main.cpp
@@ -43,7 +43,7 @@ verify_roster(const std::vector<std::string>& roster, const Session& session)
       throw std::runtime_error("Missing KeyID extensions");
     }
 
-    auto name_data = get(key_id).key_id;
+    auto name_data = opt::get(key_id).key_id;
     auto name = std::string(name_data.begin(), name_data.end());
     if (roster[i] != name) {
       throw std::runtime_error("Roster mismatch");

--- a/cmd/api_example/main.cpp
+++ b/cmd/api_example/main.cpp
@@ -43,7 +43,7 @@ verify_roster(const std::vector<std::string>& roster, const Session& session)
       throw std::runtime_error("Missing KeyID extensions");
     }
 
-    auto name_data = key_id.value().key_id;
+    auto name_data = get(key_id).key_id;
     auto name = std::string(name_data.begin(), name_data.end());
     if (roster[i] != name) {
       throw std::runtime_error("Roster mismatch");

--- a/include/mls/common.h
+++ b/include/mls/common.h
@@ -6,10 +6,14 @@
 #include <stdexcept>
 #include <vector>
 
+// Expose the bytes library globally
 #include <bytes/bytes.h>
 using namespace bytes_ns;
 
-#include <tls/tls_syntax.h>
+// Expose the compatibility library globally
+#include <tls/compat.h>
+namespace var = tls::var;
+namespace opt = tls::opt;
 
 namespace mls {
 

--- a/include/mls/credential.h
+++ b/include/mls/credential.h
@@ -96,7 +96,7 @@ public:
   template<typename T>
   const T& get() const
   {
-    return std::get<T>(_cred);
+    return var::get<T>(_cred);
   }
 
   static Credential basic(const bytes& identity,
@@ -109,7 +109,7 @@ public:
   TLS_TRAITS(tls::variant<CredentialType>)
 
 private:
-  std::variant<BasicCredential, X509Credential> _cred;
+  var::variant<BasicCredential, X509Credential> _cred;
 };
 
 } // namespace mls

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -198,7 +198,7 @@ struct ContentType
 
 struct Proposal
 {
-  std::variant<Add, Update, Remove> content;
+  var::variant<Add, Update, Remove> content;
 
   ProposalType::selector proposal_type() const;
 
@@ -282,7 +282,7 @@ struct MLSPlaintext
   epoch_t epoch;
   Sender sender;
   bytes authenticated_data;
-  std::variant<ApplicationData, Proposal, Commit> content;
+  var::variant<ApplicationData, Proposal, Commit> content;
 
   bytes signature;
   std::optional<MAC> confirmation_tag;

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -7,7 +7,6 @@
 #include "mls/treekem.h"
 #include <optional>
 #include <tls/tls_syntax.h>
-#include <variant>
 
 namespace mls {
 

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -38,13 +38,19 @@ struct OptionalNode
 
   bool blank() const { return !node.has_value(); }
 
-  KeyPackage& key_package() { return var::get<KeyPackage>(opt::get(node).node); }
+  KeyPackage& key_package()
+  {
+    return var::get<KeyPackage>(opt::get(node).node);
+  }
   const KeyPackage& key_package() const
   {
     return var::get<KeyPackage>(opt::get(node).node);
   }
 
-  ParentNode& parent_node() { return var::get<ParentNode>(opt::get(node).node); }
+  ParentNode& parent_node()
+  {
+    return var::get<ParentNode>(opt::get(node).node);
+  }
   const ParentNode& parent_node() const
   {
     return var::get<ParentNode>(opt::get(node).node);

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -22,7 +22,7 @@ struct NodeType
 
 struct Node
 {
-  std::variant<KeyPackage, ParentNode> node;
+  var::variant<KeyPackage, ParentNode> node;
 
   const HPKEPublicKey& public_key() const;
   bytes parent_hash() const;
@@ -38,16 +38,16 @@ struct OptionalNode
 
   bool blank() const { return !node.has_value(); }
 
-  KeyPackage& key_package() { return std::get<KeyPackage>(get(node).node); }
+  KeyPackage& key_package() { return var::get<KeyPackage>(opt::get(node).node); }
   const KeyPackage& key_package() const
   {
-    return std::get<KeyPackage>(get(node).node);
+    return var::get<KeyPackage>(opt::get(node).node);
   }
 
-  ParentNode& parent_node() { return std::get<ParentNode>(get(node).node); }
+  ParentNode& parent_node() { return var::get<ParentNode>(opt::get(node).node); }
   const ParentNode& parent_node() const
   {
-    return std::get<ParentNode>(get(node).node);
+    return var::get<ParentNode>(opt::get(node).node);
   }
 
   void set_leaf_hash(CipherSuite suite, NodeIndex index);

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -38,16 +38,16 @@ struct OptionalNode
 
   bool blank() const { return !node.has_value(); }
 
-  KeyPackage& key_package() { return std::get<KeyPackage>(node.value().node); }
+  KeyPackage& key_package() { return std::get<KeyPackage>(get(node).node); }
   const KeyPackage& key_package() const
   {
-    return std::get<KeyPackage>(node.value().node);
+    return std::get<KeyPackage>(get(node).node);
   }
 
-  ParentNode& parent_node() { return std::get<ParentNode>(node.value().node); }
+  ParentNode& parent_node() { return std::get<ParentNode>(get(node).node); }
   const ParentNode& parent_node() const
   {
-    return std::get<ParentNode>(node.value().node);
+    return std::get<ParentNode>(get(node).node);
   }
 
   void set_leaf_hash(CipherSuite suite, NodeIndex index);

--- a/lib/tls_syntax/CMakeLists.txt
+++ b/lib/tls_syntax/CMakeLists.txt
@@ -8,6 +8,8 @@ file(GLOB_RECURSE LIB_HEADERS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/inc
 file(GLOB_RECURSE LIB_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
 
 add_library(${CURRENT_LIB_NAME} ${LIB_HEADERS} ${LIB_SOURCES})
+add_dependencies(${CURRENT_LIB_NAME} mpark-variant)
+target_link_libraries(${CURRENT_LIB_NAME} mpark-variant)
 target_include_directories(${CURRENT_LIB_NAME}
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
 )

--- a/lib/tls_syntax/include/tls/compat.h
+++ b/lib/tls_syntax/include/tls/compat.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <optional>
+
+#include <mpark/variant.hpp>
+
+namespace tls {
+
+// To balance backward-compatibility with macOS 10.11 with forward-compatibility
+// with future versions of C++, we use `mpark::variant`, but import it into
+// `namespace std`.
+namespace var = mpark;
+
+// In a similar vein, we provide our own safe accessors for std::optional, since
+// std::optional::value() is not available on macOS 10.11.
+namespace opt {
+
+template<typename T>
+T&
+get(std::optional<T>& opt)
+{
+  if (!opt) {
+    throw std::runtime_error("bad_optional_access");
+  }
+  return *opt;
+}
+
+template<typename T>
+const T&
+get(const std::optional<T>& opt)
+{
+  if (!opt) {
+    throw std::runtime_error("bad_optional_access");
+  }
+  return *opt;
+}
+
+} // namespace opt
+} // namespace tls

--- a/lib/tls_syntax/include/tls/tls_syntax.h
+++ b/lib/tls_syntax/include/tls/tls_syntax.h
@@ -28,7 +28,8 @@ using mpark::visit;
 // In a similar vein, we provide our own safe accessors for std::optional, since
 // std::optional::value() is not available on macOS 10.11.
 template<typename T>
-T& get(std::optional<T>& opt)
+T&
+get(std::optional<T>& opt)
 {
   if (!opt) {
     throw std::runtime_error("bad_optional_access");
@@ -37,7 +38,8 @@ T& get(std::optional<T>& opt)
 }
 
 template<typename T>
-const T& get(const std::optional<T>& opt)
+const T&
+get(const std::optional<T>& opt)
 {
   if (!opt) {
     throw std::runtime_error("bad_optional_access");

--- a/lib/tls_syntax/include/tls/tls_syntax.h
+++ b/lib/tls_syntax/include/tls/tls_syntax.h
@@ -7,7 +7,7 @@
 #include <stdexcept>
 #include <vector>
 
-// To balance backward-compatibility with MacOS 10.11 with forward-compatibility
+// To balance backward-compatibility with macOS 10.11 with forward-compatibility
 // with future versions of C++, we use `mpark::variant`, but import it into
 // `namespace std`.
 //
@@ -23,6 +23,26 @@ using mpark::holds_alternative;
 using mpark::variant;
 using mpark::variant_alternative_t;
 using mpark::visit;
+}
+
+// In a similar vein, we provide our own safe accessors for std::optional, since
+// std::optional::value() is not available on macOS 10.11.
+template<typename T>
+T& get(std::optional<T>& opt)
+{
+  if (!opt) {
+    throw std::runtime_error("bad_optional_access");
+  }
+  return *opt;
+}
+
+template<typename T>
+const T& get(const std::optional<T>& opt)
+{
+  if (!opt) {
+    throw std::runtime_error("bad_optional_access");
+  }
+  return *opt;
 }
 
 namespace tls {
@@ -94,11 +114,11 @@ template<typename T>
 tls::ostream&
 operator<<(tls::ostream& out, const std::optional<T>& opt)
 {
-  if (!opt.has_value()) {
+  if (!opt) {
     return out << uint8_t(0);
   }
 
-  return out << uint8_t(1) << opt.value();
+  return out << uint8_t(1) << get(opt);
 }
 
 // Enum writer
@@ -184,7 +204,7 @@ operator>>(tls::istream& in, std::optional<T>& opt)
 
     case 1:
       opt.emplace();
-      return in >> opt.value();
+      return in >> get(opt);
 
     default:
       throw std::invalid_argument("Malformed optional");

--- a/lib/tls_syntax/include/tls/tls_syntax.h
+++ b/lib/tls_syntax/include/tls/tls_syntax.h
@@ -5,12 +5,26 @@
 #include <map>
 #include <optional>
 #include <stdexcept>
-#include <variant>
 #include <vector>
 
-// Note: Different namespace because this is TLS-generic (might
-// want to pull it out later).  Also, avoids confusables ending up
-// in the global namespace, e.g., vector, istream, ostream.
+// To balance backward-compatibility with MacOS 10.11 with forward-compatibility
+// with future versions of C++, we use `mpark::variant`, but import it into
+// `namespace std`.
+//
+// XXX(RLB) For some reason, `using namespace mpark` did not work here.  I have
+// manually added what is needed for mlspp right now, but this list might need
+// to be updated in the future.
+#include <mpark/variant.hpp>
+namespace std {
+using mpark::bad_variant_access;
+using mpark::get;
+using mpark::get_if;
+using mpark::holds_alternative;
+using mpark::variant;
+using mpark::variant_alternative_t;
+using mpark::visit;
+}
+
 namespace tls {
 
 // For indicating no min or max in vector definitions
@@ -411,7 +425,7 @@ struct variant
   {
     using Tc = std::variant_alternative_t<I, std::variant<Tp...>>;
     if (std::holds_alternative<Tc>(v)) {
-      str << Ts::template type<Tc> << std::get<I>(v);
+      str << Ts::template type<Tc> << std::get<Tc>(v);
       return;
     }
 

--- a/lib/tls_syntax/test/tls_syntax.cpp
+++ b/lib/tls_syntax/test/tls_syntax.cpp
@@ -32,7 +32,7 @@ struct ExampleStruct
   std::array<uint32_t, 4> b{ 0, 0, 0, 0 };
   std::optional<uint8_t> c;
   std::vector<uint8_t> d;
-  std::variant<uint8_t, uint16_t> e;
+  tls::var::variant<uint8_t, uint16_t> e;
 
   TLS_SERIALIZABLE(a, b, c, d, e)
   TLS_TRAITS(tls::pass,

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -92,7 +92,7 @@ KeyPackage::sign(const SignaturePrivateKey& sig_priv,
 {
   if (opts) {
     // Fill in application-provided extensions
-    for (const auto& ext : get(opts).extensions.extensions) {
+    for (const auto& ext : opt::get(opts).extensions.extensions) {
       extensions.add(ext.type, ext.data);
     }
   }
@@ -109,7 +109,7 @@ KeyPackage::verify_expiry(uint64_t now) const
     return false;
   }
 
-  auto& lt = get(maybe_lt);
+  auto& lt = opt::get(maybe_lt);
   return lt.not_before <= now && now <= lt.not_after;
 }
 
@@ -184,7 +184,7 @@ UpdatePath::parent_hash_valid(CipherSuite suite) const
     return !phe;
   }
 
-  return phe && get(phe).parent_hash == ph[0];
+  return phe && opt::get(phe).parent_hash == ph[0];
 }
 
 void
@@ -196,7 +196,7 @@ UpdatePath::sign(CipherSuite suite,
   // Make a copy of the options that we can modify
   auto opts = KeyPackageOpts{};
   if (maybe_opts) {
-    opts = get(maybe_opts);
+    opts = opt::get(maybe_opts);
   }
 
   // Add a ParentHash extension

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -90,9 +90,9 @@ void
 KeyPackage::sign(const SignaturePrivateKey& sig_priv,
                  const std::optional<KeyPackageOpts>& opts)
 {
-  if (opts.has_value()) {
+  if (opts) {
     // Fill in application-provided extensions
-    for (const auto& ext : opts.value().extensions.extensions) {
+    for (const auto& ext : get(opts).extensions.extensions) {
       extensions.add(ext.type, ext.data);
     }
   }
@@ -105,11 +105,11 @@ bool
 KeyPackage::verify_expiry(uint64_t now) const
 {
   auto maybe_lt = extensions.find<LifetimeExtension>();
-  if (!maybe_lt.has_value()) {
+  if (!maybe_lt) {
     return false;
   }
 
-  auto& lt = maybe_lt.value();
+  auto& lt = get(maybe_lt);
   return lt.not_before <= now && now <= lt.not_after;
 }
 
@@ -181,10 +181,10 @@ UpdatePath::parent_hash_valid(CipherSuite suite) const
 
   // If there are no nodes to hash, then ParentHash MUST be omitted
   if (ph.empty()) {
-    return !phe.has_value();
+    return !phe;
   }
 
-  return phe.has_value() && phe.value().parent_hash == ph[0];
+  return phe && get(phe).parent_hash == ph[0];
 }
 
 void
@@ -195,8 +195,8 @@ UpdatePath::sign(CipherSuite suite,
 {
   // Make a copy of the options that we can modify
   auto opts = KeyPackageOpts{};
-  if (maybe_opts.has_value()) {
-    opts = maybe_opts.value();
+  if (maybe_opts) {
+    opts = get(maybe_opts);
   }
 
   // Add a ParentHash extension

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -165,7 +165,7 @@ UpdatePath::parent_hashes(CipherSuite suite) const
 {
   auto ph = std::vector<bytes>(nodes.size());
   auto last_hash = bytes{};
-  for (int i = nodes.size() - 1; i >= 0; i--) {
+  for (int i = static_cast<int>(nodes.size()) - 1; i >= 0; i--) {
     auto parent = ParentNode{ nodes[i].public_key, {}, last_hash };
     last_hash = parent.hash(suite);
     ph[i] = last_hash;

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -104,27 +104,25 @@ operator==(const X509Credential& lhs, const X509Credential& rhs)
 CredentialType::selector
 Credential::type() const
 {
-  switch (_cred.index()) {
-    case 0:
+  static const auto get_type = overloaded{
+    [](const BasicCredential& /* unused */) {
       return CredentialType::selector::basic;
-    case 1:
+    },
+    [](const X509Credential& /* unused */) {
       return CredentialType::selector::x509;
-  }
-
-  throw std::bad_variant_access();
+    },
+  };
+  return std::visit(get_type, _cred);
 }
 
 SignaturePublicKey
 Credential::public_key() const
 {
-  switch (_cred.index()) {
-    case 0:
-      return std::get<BasicCredential>(_cred).public_key;
-    case 1:
-      return std::get<X509Credential>(_cred).public_key();
-  }
-
-  throw std::bad_variant_access();
+  static const auto get_public_key = overloaded{
+    [](const BasicCredential& cred) { return cred.public_key; },
+    [](const X509Credential& cred) { return cred.public_key(); },
+  };
+  return std::visit(get_public_key, _cred);
 }
 
 bool

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -112,7 +112,7 @@ Credential::type() const
       return CredentialType::selector::x509;
     },
   };
-  return std::visit(get_type, _cred);
+  return var::visit(get_type, _cred);
 }
 
 SignaturePublicKey
@@ -122,7 +122,7 @@ Credential::public_key() const
     [](const BasicCredential& cred) { return cred.public_key; },
     [](const X509Credential& cred) { return cred.public_key(); },
   };
-  return std::visit(get_public_key, _cred);
+  return var::visit(get_public_key, _cred);
 }
 
 bool

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -230,11 +230,11 @@ HPKEPrivateKey::decrypt(CipherSuite suite,
   auto skR = suite.get().hpke.kem.deserialize_private(data);
   auto ctx = suite.get().hpke.setup_base_r(ct.kem_output, *skR, {});
   auto pt = ctx.open(aad, ct.ciphertext);
-  if (!pt.has_value()) {
+  if (!pt) {
     throw InvalidParameterError("HPKE decryption failure");
   }
 
-  return pt.value();
+  return get(pt);
 }
 
 HPKEPrivateKey::HPKEPrivateKey(bytes priv_data, bytes pub_data)

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -234,7 +234,7 @@ HPKEPrivateKey::decrypt(CipherSuite suite,
     throw InvalidParameterError("HPKE decryption failure");
   }
 
-  return get(pt);
+  return opt::get(pt);
 }
 
 HPKEPrivateKey::HPKEPrivateKey(bytes priv_data, bytes pub_data)

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -402,10 +402,11 @@ TreeKEMPublicKey::merge(LeafIndex from, const UpdatePath& path)
 
     auto parent_hash = bytes{};
     if (i < dp.size() - 1) {
-      parent_hash = ph[i+1];
+      parent_hash = ph[i + 1];
     }
 
-    node_at(n).node = { ParentNode{ path.nodes[i].public_key, {}, parent_hash } };
+    node_at(n).node = { ParentNode{
+      path.nodes[i].public_key, {}, parent_hash } };
   }
 
   clear_hash_path(from);

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -145,7 +145,7 @@ TEST_CASE_FIXTURE(StateTest, "Full Size Group")
         states[j] = new_state;
       } else {
         states[j].handle(add);
-        states[j] = get(states[j].handle(commit));
+        states[j] = opt::get(states[j].handle(commit));
       }
     }
 
@@ -211,7 +211,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Update Everyone in a Group")
         state = new_state;
       } else {
         state.handle(update);
-        state = get(state.handle(commit));
+        state = opt::get(state.handle(commit));
       }
     }
 
@@ -233,7 +233,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Remove Members from a Group")
         state = new_state;
       } else {
         state.handle(remove);
-        state = get(state.handle(commit));
+        state = opt::get(state.handle(commit));
       }
     }
 

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -145,7 +145,7 @@ TEST_CASE_FIXTURE(StateTest, "Full Size Group")
         states[j] = new_state;
       } else {
         states[j].handle(add);
-        states[j] = states[j].handle(commit).value();
+        states[j] = get(states[j].handle(commit));
       }
     }
 
@@ -211,7 +211,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Update Everyone in a Group")
         state = new_state;
       } else {
         state.handle(update);
-        state = state.handle(commit).value();
+        state = get(state.handle(commit));
       }
     }
 
@@ -233,7 +233,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Remove Members from a Group")
         state = new_state;
       } else {
         state.handle(remove);
-        state = state.handle(commit).value();
+        state =  get(state.handle(commit));
       }
     }
 

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -233,7 +233,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Remove Members from a Group")
         state = new_state;
       } else {
         state.handle(remove);
-        state =  get(state.handle(commit));
+        state = get(state.handle(commit));
       }
     }
 

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -105,7 +105,7 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Private Key")
   // but not the direct path in the middle
   auto priv_joiner =
     TreeKEMPrivateKey::joiner(suite, size, index, priv, intersect, random);
-  REQUIRE(priv_joiner.private_key(NodeIndex(4)).has_value());
+  REQUIRE(priv_joiner.private_key(NodeIndex(4)));
   REQUIRE(priv_joiner.path_secrets.find(NodeIndex(3)) !=
           priv_joiner.path_secrets.end());
   REQUIRE(priv_joiner.path_secrets.find(NodeIndex(7)) !=
@@ -127,12 +127,12 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Private Key")
   // private_key() generates and caches a private key where a path secret
   // exists, and returns nullopt where one doesn't
   auto priv_yes = priv_joiner.private_key(NodeIndex(3));
-  REQUIRE(priv_yes.has_value());
+  REQUIRE(priv_yes);
   REQUIRE(priv_joiner.private_key_cache.find(NodeIndex(3)) !=
           priv_joiner.private_key_cache.end());
 
   auto priv_no = priv_joiner.private_key(NodeIndex(1));
-  REQUIRE_FALSE(priv_no.has_value());
+  REQUIRE_FALSE(priv_no);
 }
 
 //        _
@@ -176,32 +176,32 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Public Key")
     REQUIRE(add_index == index);
 
     auto found = pub.find(kp_add);
-    REQUIRE(found.has_value());
-    REQUIRE(found.value() == index);
+    REQUIRE(found);
+    REQUIRE(found == index);
 
     auto found_kp = pub.key_package(index);
-    REQUIRE(found_kp.has_value());
-    REQUIRE(found_kp.value() == kp_add);
+    REQUIRE(found_kp);
+    REQUIRE(found_kp == kp_add);
 
     // Merge the direct path
     pub.merge(index, path);
     REQUIRE(pub.parent_hash_valid());
 
     found = pub.find(kp_path);
-    REQUIRE(found.has_value());
-    REQUIRE(found.value() == index);
+    REQUIRE(found);
+    REQUIRE(found == index);
     for (const auto& dpn : dp) {
-      REQUIRE(pub.node_at(dpn).node.has_value());
+      REQUIRE(pub.node_at(dpn).node);
     }
 
     found_kp = pub.key_package(index);
-    REQUIRE(found_kp.has_value());
-    REQUIRE(found_kp.value() == kp_path);
+    REQUIRE(found_kp);
+    REQUIRE(found_kp == kp_path);
   }
 
   // Remove a node and verify that the resolution comes out right
   pub.blank_path(removed);
-  REQUIRE_FALSE(pub.key_package(removed).has_value());
+  REQUIRE_FALSE(pub.key_package(removed));
   REQUIRE(root_resolution == pub.resolve(root));
 }
 

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -67,7 +67,7 @@ TEST_CASE_FIXTURE(TreeKEMTest, "Optional node hashes")
   auto parent = ParentNode{ init_priv.public_key, {}, {} };
   auto opt_parent = OptionalNode{ Node{ parent }, {} };
   REQUIRE_THROWS_AS(opt_parent.set_leaf_hash(suite, node_index),
-                    std::bad_variant_access);
+                    var::bad_variant_access);
 
   opt_parent.set_parent_hash(suite, node_index, child_hash, child_hash);
   REQUIRE_FALSE(opt_parent.hash.empty());
@@ -75,7 +75,7 @@ TEST_CASE_FIXTURE(TreeKEMTest, "Optional node hashes")
   auto opt_leaf = OptionalNode{ Node{ kp }, {} };
   REQUIRE_THROWS_AS(
     opt_leaf.set_parent_hash(suite, node_index, child_hash, child_hash),
-    std::bad_variant_access);
+    var::bad_variant_access);
 
   opt_leaf.set_leaf_hash(suite, node_index);
   REQUIRE_FALSE(opt_leaf.hash.empty());


### PR DESCRIPTION
Apple clang generally supports C++17, but disables certain features when the deployment target is earlier than 10.14.  Most significantly for this project:

* Features of `std::variant` that require `std::bad_variant_access`, including `std::get` and `std::visit`
* Features of `std::optional` that require `std::bad_optional_access`, most directly `std::optional::value`

We take a two-pronged approach here.  For `std::variant`, we replace the standard library wholesale, using https://github.com/mpark/variant.  For `std::optional`, we define a free function `get()` (by way of analogy to `std::get`) that provides checked access to the optional's contents.