### PR TITLE
Make variant mapping more streamlined and compatible

### DIFF
--- a/cmd/test_gen/main.cpp
+++ b/cmd/test_gen/main.cpp
@@ -371,7 +371,7 @@ generate_messages()
 
     // Construct an MLSCiphertext
     auto ciphertext = MLSCiphertext{
-      tv.group_id, tv.epoch,  ContentType::selector::application,
+      tv.group_id, tv.epoch,  ContentType::application,
       tv.random,   tv.random, tv.random,
     };
 

--- a/include/mls/credential.h
+++ b/include/mls/credential.h
@@ -5,23 +5,6 @@
 
 namespace mls {
 
-// enum {
-//     basic(0),
-//     x509(1),
-//     (255)
-// } CredentialType;
-struct CredentialType
-{
-  enum struct selector : uint8_t
-  {
-    basic = 0,
-    x509 = 1,
-  };
-
-  template<typename T>
-  static const selector type;
-};
-
 // struct {
 //     opaque identity<0..2^16-1>;
 //     SignaturePublicKey public_key;
@@ -76,6 +59,17 @@ operator>>(tls::istream& str, X509Credential& obj);
 bool
 operator==(const X509Credential& lhs, const X509Credential& rhs);
 
+// enum {
+//     basic(0),
+//     x509(1),
+//     (255)
+// } CredentialType;
+enum struct CredentialType : uint8_t
+{
+  basic = 0,
+  x509 = 1,
+};
+
 // struct {
 //     CredentialType credential_type;
 //     select (credential_type) {
@@ -89,7 +83,7 @@ operator==(const X509Credential& lhs, const X509Credential& rhs);
 class Credential
 {
 public:
-  CredentialType::selector type() const;
+  CredentialType type() const;
   SignaturePublicKey public_key() const;
   bool valid_for(const SignaturePrivateKey& priv) const;
 
@@ -113,3 +107,12 @@ private:
 };
 
 } // namespace mls
+
+namespace tls {
+
+using namespace mls;
+
+TLS_VARIANT_MAP(CredentialType, BasicCredential, basic)
+TLS_VARIANT_MAP(CredentialType, X509Credential, x509)
+
+} // namespace TLS

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -164,10 +164,10 @@ struct Remove
 
 enum struct ProposalType : uint8_t
 {
-    invalid = 0,
-    add = 1,
-    update = 2,
-    remove = 3,
+  invalid = 0,
+  add = 1,
+  update = 2,
+  remove = 3,
 };
 
 struct Proposal
@@ -228,10 +228,10 @@ struct GroupContext;
 
 enum struct ContentType : uint8_t
 {
-    invalid = 0,
-    application = 1,
-    proposal = 2,
-    commit = 3,
+  invalid = 0,
+  application = 1,
+  proposal = 2,
+  commit = 3,
 };
 
 enum struct SenderType : uint8_t

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -149,7 +149,7 @@ protected:
   void apply(LeafIndex target, const Update& update, const bytes& leaf_secret);
   void apply(const Remove& remove);
   std::vector<LeafIndex> apply(const std::vector<MLSPlaintext>& pts,
-                               ProposalType::selector required_type);
+                               ProposalType required_type);
   std::tuple<bool, bool, std::vector<LeafIndex>> apply(const Commit& commit);
 
   // Compute a proposal ID

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -10,8 +10,8 @@ namespace mls {
 
 enum struct NodeType : uint8_t
 {
-    leaf = 0x00,
-    parent = 0x01,
+  leaf = 0x00,
+  parent = 0x01,
 };
 
 struct Node

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -8,16 +8,10 @@
 
 namespace mls {
 
-struct NodeType
+enum struct NodeType : uint8_t
 {
-  enum class selector : uint8_t
-  {
     leaf = 0x00,
     parent = 0x01,
-  };
-
-  template<typename T>
-  static const selector type;
 };
 
 struct Node
@@ -167,3 +161,12 @@ private:
 };
 
 } // namespace mls
+
+namespace tls {
+
+using namespace mls;
+
+TLS_VARIANT_MAP(NodeType, KeyPackage, leaf)
+TLS_VARIANT_MAP(NodeType, ParentNode, parent)
+
+} // namespace tls

--- a/lib/tls_syntax/include/tls/tls_syntax.h
+++ b/lib/tls_syntax/include/tls/tls_syntax.h
@@ -392,34 +392,37 @@ struct vector
 };
 
 // Variant encoding
+template<typename Ts, typename Tv>
+constexpr Ts
+variant_map();
+
+#define TLS_VARIANT_MAP(EnumType, MappedType, enum_value) \
+  template<> \
+  constexpr EnumType \
+  variant_map<EnumType, MappedType>() \
+  { \
+    return EnumType::enum_value; \
+  }
+
 template<typename Ts>
 struct variant
 {
-  template<size_t I = 0, typename... Tp>
-  static inline typename std::enable_if<I == sizeof...(Tp), void>::type
-  write_variant(tls::ostream&, const var::variant<Tp...>&)
-  {
-    throw WriteError("Empty variant");
-  }
-
-  template<size_t I = 0, typename... Tp>
-    static inline typename std::enable_if <
-    I<sizeof...(Tp), void>::type write_variant(tls::ostream& str,
-                                               const var::variant<Tp...>& v)
-  {
-    using Tc = var::variant_alternative_t<I, var::variant<Tp...>>;
-    if (var::holds_alternative<Tc>(v)) {
-      str << Ts::template type<Tc> << get<Tc>(v);
-      return;
-    }
-
-    write_variant<I + 1, Tp...>(str, v);
-  }
+  template<typename... Tp>
+  static inline Ts type(const var::variant<Tp...>& data) {
+    static const auto get_type = [](const auto& v) {
+      return variant_map<Ts, std::decay_t<decltype(v)>>();
+    };
+    return var::visit(get_type, data);
+  };
 
   template<typename... Tp>
   static ostream& encode(ostream& str, const var::variant<Tp...>& data)
   {
-    write_variant(str, data);
+    const auto write_variant = [&str](auto&& v) {
+      using Tv = std::decay_t<decltype(v)>;
+      str << variant_map<Ts, Tv>() << v;
+    };
+    var::visit(write_variant, data);
     return str;
   }
 
@@ -437,7 +440,7 @@ struct variant
                                               var::variant<Tp...>& v)
   {
     using Tc = var::variant_alternative_t<I, var::variant<Tp...>>;
-    if (Ts::template type<Tc> == target_type) {
+    if (variant_map<Ts, Tc>() == target_type) {
       str >> v.template emplace<I>();
       return;
     }
@@ -448,7 +451,7 @@ struct variant
   template<typename... Tp>
   static istream& decode(istream& str, var::variant<Tp...>& data)
   {
-    typename Ts::selector target_type;
+    Ts target_type;
     str >> target_type;
     read_variant(str, target_type, data);
     return str;

--- a/lib/tls_syntax/include/tls/tls_syntax.h
+++ b/lib/tls_syntax/include/tls/tls_syntax.h
@@ -413,7 +413,7 @@ struct variant
       return variant_map<Ts, std::decay_t<decltype(v)>>();
     };
     return var::visit(get_type, data);
-  };
+  }
 
   template<typename... Tp>
   static ostream& encode(ostream& str, const var::variant<Tp...>& data)

--- a/lib/tls_syntax/include/tls/tls_syntax.h
+++ b/lib/tls_syntax/include/tls/tls_syntax.h
@@ -396,19 +396,19 @@ template<typename Ts, typename Tv>
 constexpr Ts
 variant_map();
 
-#define TLS_VARIANT_MAP(EnumType, MappedType, enum_value) \
-  template<> \
-  constexpr EnumType \
-  variant_map<EnumType, MappedType>() \
-  { \
-    return EnumType::enum_value; \
+#define TLS_VARIANT_MAP(EnumType, MappedType, enum_value)                      \
+  template<>                                                                   \
+  constexpr EnumType variant_map<EnumType, MappedType>()                       \
+  {                                                                            \
+    return EnumType::enum_value;                                               \
   }
 
 template<typename Ts>
 struct variant
 {
   template<typename... Tp>
-  static inline Ts type(const var::variant<Tp...>& data) {
+  static inline Ts type(const var::variant<Tp...>& data)
+  {
     static const auto get_type = [](const auto& v) {
       return variant_map<Ts, std::decay_t<decltype(v)>>();
     };

--- a/lib/tls_syntax/test/tls_syntax.cpp
+++ b/lib/tls_syntax/test/tls_syntax.cpp
@@ -13,8 +13,8 @@ enum struct IntType : uint16_t
 
 namespace tls {
 
-TLS_VARIANT_MAP(IntType, uint8_t, uint8);
-TLS_VARIANT_MAP(IntType, uint16_t, uint16);
+TLS_VARIANT_MAP(IntType, uint8_t, uint8)
+TLS_VARIANT_MAP(IntType, uint16_t, uint16)
 
 } // namespace tls
 

--- a/lib/tls_syntax/test/tls_syntax.cpp
+++ b/lib/tls_syntax/test/tls_syntax.cpp
@@ -11,19 +11,12 @@ enum struct IntType : uint16_t
   uint16 = 0xBBBB,
 };
 
-struct IntSelector
-{
-  using selector = IntType;
+namespace tls {
 
-  template<typename T>
-  static const IntType type;
-};
+TLS_VARIANT_MAP(IntType, uint8_t, uint8);
+TLS_VARIANT_MAP(IntType, uint16_t, uint16);
 
-template<>
-const IntType IntSelector::type<uint8_t> = IntType::uint8;
-
-template<>
-const IntType IntSelector::type<uint16_t> = IntType::uint16;
+} // namespace tls
 
 // A struct to test struct encoding and traits
 struct ExampleStruct
@@ -39,7 +32,7 @@ struct ExampleStruct
              tls::pass,
              tls::pass,
              tls::vector<2>,
-             tls::variant<IntSelector>)
+             tls::variant<IntType>)
 };
 
 static bool

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -128,7 +128,7 @@ KeyPackage::verify() const
   auto tbs = to_be_signed();
   auto identity_key = credential.public_key();
 
-  if (CredentialType::selector::x509 == credential.type()) {
+  if (CredentialType::x509 == credential.type()) {
     const auto& cred = credential.get<X509Credential>();
     if (cred._signature_scheme !=
         tls_signature_scheme(cipher_suite.get().sig.id)) {

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -5,18 +5,6 @@
 namespace mls {
 
 ///
-/// CredentialType
-///
-
-template<>
-const CredentialType::selector CredentialType::type<BasicCredential> =
-  CredentialType::selector::basic;
-
-template<>
-const CredentialType::selector CredentialType::type<X509Credential> =
-  CredentialType::selector::x509;
-
-///
 /// X509Credential
 ///
 
@@ -101,16 +89,22 @@ operator==(const X509Credential& lhs, const X509Credential& rhs)
 /// Credential
 ///
 
-CredentialType::selector
+CredentialType
 Credential::type() const
 {
+#if 0
   static const auto get_type = overloaded{
     [](const BasicCredential& /* unused */) {
-      return CredentialType::selector::basic;
+      return CredentialType::basic;
     },
     [](const X509Credential& /* unused */) {
-      return CredentialType::selector::x509;
+      return CredentialType::x509;
     },
+  };
+#endif
+
+  static const auto get_type = [](const auto& v) {
+    return tls::variant_map<CredentialType, std::decay_t<decltype(v)>>();
   };
   return var::visit(get_type, _cred);
 }

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -92,21 +92,7 @@ operator==(const X509Credential& lhs, const X509Credential& rhs)
 CredentialType
 Credential::type() const
 {
-#if 0
-  static const auto get_type = overloaded{
-    [](const BasicCredential& /* unused */) {
-      return CredentialType::basic;
-    },
-    [](const X509Credential& /* unused */) {
-      return CredentialType::x509;
-    },
-  };
-#endif
-
-  static const auto get_type = [](const auto& v) {
-    return tls::variant_map<CredentialType, std::decay_t<decltype(v)>>();
-  };
-  return var::visit(get_type, _cred);
+  return tls::variant<CredentialType>::type(_cred);
 }
 
 SignaturePublicKey

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -242,9 +242,7 @@ ContentType
 MLSPlaintext::content_type() const
 {
   static const auto get_content_type = overloaded{
-    [](const ApplicationData& /*unused*/) {
-      return ContentType::application;
-    },
+    [](const ApplicationData& /*unused*/) { return ContentType::application; },
     [](const Proposal& /*unused*/) { return ContentType::proposal; },
     [](const Commit& /*unused*/) { return ContentType::commit; },
   };

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -151,40 +151,11 @@ Welcome::group_info_key_nonce(CipherSuite suite,
 }
 
 // MLSPlaintext
-
-template<>
-const ProposalType::selector ProposalType::type<Add> =
-  ProposalType::selector::add;
-
-template<>
-const ProposalType::selector ProposalType::type<Update> =
-  ProposalType::selector::update;
-
-template<>
-const ProposalType::selector ProposalType::type<Remove> =
-  ProposalType::selector::remove;
-
-ProposalType::selector
+ProposalType
 Proposal::proposal_type() const
 {
-  static auto get_type = [](auto&& v) {
-    using type = typename std::decay<decltype(v)>::type;
-    return ProposalType::template type<type>;
-  };
-  return var::visit(get_type, content);
+  return tls::variant<ProposalType>::type(content);
 }
-
-template<>
-const ContentType::selector ContentType::type<Proposal> =
-  ContentType::selector::proposal;
-
-template<>
-const ContentType::selector ContentType::type<Commit> =
-  ContentType::selector::commit;
-
-template<>
-const ContentType::selector ContentType::type<ApplicationData> =
-  ContentType::selector::application;
 
 MLSPlaintext::MLSPlaintext()
   : epoch(0)
@@ -194,7 +165,7 @@ MLSPlaintext::MLSPlaintext()
 MLSPlaintext::MLSPlaintext(bytes group_id_in,
                            epoch_t epoch_in,
                            Sender sender_in,
-                           ContentType::selector content_type_in,
+                           ContentType content_type_in,
                            bytes authenticated_data_in,
                            const bytes& content_in)
   : group_id(std::move(group_id_in))
@@ -206,19 +177,19 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
 {
   tls::istream r(content_in);
   switch (content_type_in) {
-    case ContentType::selector::application: {
+    case ContentType::application: {
       auto& application_data = content.emplace<ApplicationData>();
       r >> application_data;
       break;
     }
 
-    case ContentType::selector::proposal: {
+    case ContentType::proposal: {
       auto& proposal = content.emplace<Proposal>();
       r >> proposal;
       break;
     }
 
-    case ContentType::selector::commit: {
+    case ContentType::commit: {
       auto& commit = content.emplace<Commit>();
       r >> commit;
       break;
@@ -267,15 +238,15 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
   , decrypted(false)
 {}
 
-ContentType::selector
+ContentType
 MLSPlaintext::content_type() const
 {
   static const auto get_content_type = overloaded{
     [](const ApplicationData& /*unused*/) {
-      return ContentType::selector::application;
+      return ContentType::application;
     },
-    [](const Proposal& /*unused*/) { return ContentType::selector::proposal; },
-    [](const Commit& /*unused*/) { return ContentType::selector::commit; },
+    [](const Proposal& /*unused*/) { return ContentType::proposal; },
+    [](const Commit& /*unused*/) { return ContentType::commit; },
   };
   return var::visit(get_content_type, content);
 }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -428,8 +428,7 @@ State::find_proposal(const ProposalID& id)
 }
 
 std::vector<LeafIndex>
-State::apply(const std::vector<MLSPlaintext>& pts,
-             ProposalType required_type)
+State::apply(const std::vector<MLSPlaintext>& pts, ProposalType required_type)
 {
   auto locations = std::vector<LeafIndex>{};
   for (const auto& pt : pts) {

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -429,7 +429,7 @@ State::find_proposal(const ProposalID& id)
 
 std::vector<LeafIndex>
 State::apply(const std::vector<MLSPlaintext>& pts,
-             ProposalType::selector required_type)
+             ProposalType required_type)
 {
   auto locations = std::vector<LeafIndex>{};
   for (const auto& pt : pts) {
@@ -440,12 +440,12 @@ State::apply(const std::vector<MLSPlaintext>& pts,
     }
 
     switch (proposal_type) {
-      case ProposalType::selector::add: {
+      case ProposalType::add: {
         locations.push_back(apply(var::get<Add>(proposal)));
         break;
       }
 
-      case ProposalType::selector::update: {
+      case ProposalType::update: {
         auto& update = var::get<Update>(proposal);
         auto sender = LeafIndex(pt.sender.sender);
         if (sender != _index) {
@@ -463,7 +463,7 @@ State::apply(const std::vector<MLSPlaintext>& pts,
         break;
       }
 
-      case ProposalType::selector::remove: {
+      case ProposalType::remove: {
         const auto& remove = var::get<Remove>(proposal);
         apply(remove);
         locations.push_back(remove.removed);
@@ -494,9 +494,9 @@ State::apply(const Commit& commit)
                    return opt::get(maybe_pt);
                  });
 
-  auto update_locations = apply(pts, ProposalType::selector::update);
-  auto remove_locations = apply(pts, ProposalType::selector::remove);
-  auto joiner_locations = apply(pts, ProposalType::selector::add);
+  auto update_locations = apply(pts, ProposalType::update);
+  auto remove_locations = apply(pts, ProposalType::remove);
+  auto joiner_locations = apply(pts, ProposalType::add);
 
   auto has_updates = !update_locations.empty();
   auto has_removes = !remove_locations.empty();
@@ -657,7 +657,7 @@ struct MLSCiphertextContentAAD
 {
   const bytes& group_id;
   const epoch_t epoch;
-  const ContentType::selector content_type;
+  const ContentType content_type;
   const bytes& authenticated_data;
 
   TLS_SERIALIZABLE(group_id, epoch, content_type, authenticated_data)
@@ -706,7 +706,7 @@ struct MLSSenderDataAAD
 {
   const bytes& group_id;
   const epoch_t epoch;
-  const ContentType::selector content_type;
+  const ContentType content_type;
 
   TLS_SERIALIZABLE(group_id, epoch, content_type)
   TLS_TRAITS(tls::vector<1>, tls::pass, tls::pass)
@@ -795,7 +795,7 @@ State::decrypt(const MLSCiphertext& ct)
 
   // Pull from the key schedule
   auto key_type = GroupKeySource::RatchetType::handshake;
-  if (ct.content_type == ContentType::selector::application) {
+  if (ct.content_type == ContentType::application) {
     key_type = GroupKeySource::RatchetType::application;
   }
 

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -3,17 +3,6 @@
 namespace mls {
 
 ///
-/// NodeType
-///
-
-template<>
-const NodeType::selector NodeType::type<KeyPackage> = NodeType::selector::leaf;
-
-template<>
-const NodeType::selector NodeType::type<ParentNode> =
-  NodeType::selector::parent;
-
-///
 /// Node
 ///
 

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -117,7 +117,7 @@ TEST_CASE("Messages Interop")
 
     // Proposals
     auto add_prop = Proposal{ Add{ key_package } };
-    CHECK(add_prop.proposal_type() == ProposalType::selector::add);
+    CHECK(add_prop.proposal_type() == ProposalType::add);
 
     auto add_hs = MLSPlaintext{ tv.group_id, tv.epoch, tv.sender, add_prop };
     add_hs.signature = tv.random;
@@ -125,7 +125,7 @@ TEST_CASE("Messages Interop")
     tls_round_trip(tc.add_proposal, add_hs, true);
 
     auto update_prop = Proposal{ Update{ key_package } };
-    CHECK(update_prop.proposal_type() == ProposalType::selector::update);
+    CHECK(update_prop.proposal_type() == ProposalType::update);
 
     auto update_hs =
       MLSPlaintext{ tv.group_id, tv.epoch, tv.sender, update_prop };
@@ -134,7 +134,7 @@ TEST_CASE("Messages Interop")
     tls_round_trip(tc.update_proposal, update_hs, true);
 
     auto remove_prop = Proposal{ Remove{ LeafIndex(tv.sender.sender) } };
-    CHECK(remove_prop.proposal_type() == ProposalType::selector::remove);
+    CHECK(remove_prop.proposal_type() == ProposalType::remove);
 
     auto remove_hs =
       MLSPlaintext{ tv.group_id, tv.epoch, tv.sender, remove_prop };
@@ -155,7 +155,7 @@ TEST_CASE("Messages Interop")
 
     // MLSCiphertext
     MLSCiphertext ciphertext{
-      tv.group_id, tv.epoch,  ContentType::selector::application,
+      tv.group_id, tv.epoch,  ContentType::application,
       tv.random,   tv.random, tv.random,
     };
     tls_round_trip(tc.ciphertext, ciphertext, true);


### PR DESCRIPTION
The variant selection introduced in #117 was nice in that it detached variant selection from the selected types, but it still required the awkward `::selector` construction.  And it turns out that some older compilers are unhappy with the template variable `type`, leading to undefined symbol errors if `type` is specialized in a .cpp file and duplicate symbol errors if specialized in .h.

This PR introduces an alternative approach based on an explicit `variant_map<Ts, Tv>` function, where `Ts` is the selector enum type and `Tv` is the mapped type.  This means that the mapping is detached from *both* the selector enum and the mapped type.

The main drawback is that the required boilerplate now needs to be defined in `namespace tls`.  So we end up with blocks of the following form at the bottom of some headers:

```C++
namespace tls {

using namespace mls;

TLS_VARIANT_MAP(CredentialType, BasicCredential, basic)
TLS_VARIANT_MAP(CredentialType, X509Credential, x509)

} // namespace tls
```