### PR TITLE
[feat][CI] Update clang-format-action version

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -14,4 +14,4 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: check clang-format
-      uses: jidicula/clang-format-action@master
+      uses: jidicula/clang-format-action@v2.0.0


### PR DESCRIPTION
Related to jidicula/clang-format-action#18

**Why this change was necessary**
The `master` branch of `clang-format-action` is set to be deleted
on January 15. Additionally, the workflow version in that branch
does **not** support C++ files.

**What this change does**
 - Updates the CI style workflow to point to the earliest version of
`clang-format-action` supporting C++ files.

**Any side-effects?**
~Style checks may fail now that C++ files are being checked.~ Looks ok after the checks were run.

**Additional context/notes/links**
 - https://github.com/jidicula/clang-format-action/releases/tag/v2.0.0