### PR TITLE
Fix CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,9 +26,8 @@ jobs:
     - name: dependencies (macos)
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
-        brew uninstall openssl
-        brew install pkgconfig doctest
         brew reinstall openssl@1.1
+        brew install pkgconfig doctest
         brew install llvm
         ln -s "/usr/local/opt/llvm/bin/clang-format" "/usr/local/bin/clang-format"
         ln -s "/usr/local/opt/llvm/bin/clang-tidy" "/usr/local/bin/clang-tidy"
@@ -37,7 +36,8 @@ jobs:
     - name: dependencies (ubuntu)
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-        brew install pkgconfig doctest
+        brew install pkgconfig
+        brew install --build-from-source doctest
 
     - name: configure to use clang-tidy
       run: make tidy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,7 @@ jobs:
       if: ${{ matrix.os == 'macos-latest' }}
       run: |
         brew reinstall openssl@1.1
-        brew install pkgconfig doctest
-        brew install llvm
+        brew install pkgconfig doctest llvm
         ln -s "/usr/local/opt/llvm/bin/clang-format" "/usr/local/bin/clang-format"
         ln -s "/usr/local/opt/llvm/bin/clang-tidy" "/usr/local/bin/clang-tidy"
 

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -22,10 +22,8 @@ jobs:
     
     - name: dependencies
       run: |
-        brew uninstall openssl
-        brew install pkgconfig doctest
         brew reinstall openssl@1.1
-        brew install llvm
+        brew install pkgconfig doctest llvm
         ln -s "/usr/local/opt/llvm/bin/clang-format" "/usr/local/bin/clang-format"
         ln -s "/usr/local/opt/llvm/bin/clang-tidy" "/usr/local/bin/clang-tidy"
 

--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ Conventions
   * `X_key` is the public key of an asymmetric key pair
   * `X_priv` is the private key of an asymmetric key pair
   * `X_secret` is a symmetric secret
+


### PR DESCRIPTION
The CI builds seem to have been broken by some changes in the GitHub runners.  This PR updates the build scripts so that they work on the new runners.

It seems like this is a consequence of running on `ubuntu-latest` and `macos-latest`.  We should consider pinning versions.