### PR TITLE
fix signature scheme parse

### DIFF
--- a/lib/hpke/include/hpke/certificate.h
+++ b/lib/hpke/include/hpke/certificate.h
@@ -33,8 +33,8 @@ public:
   std::vector<std::string> dns_names() const;
   bytes hash() const;
 
-  const Signature::ID public_key_algorithm;
   const std::unique_ptr<Signature::PublicKey> public_key;
+  const Signature::ID public_key_algorithm;
   const bytes raw;
 };
 

--- a/lib/hpke/src/certificate.cpp
+++ b/lib/hpke/src/certificate.cpp
@@ -151,7 +151,7 @@ struct Certificate::ParsedCertificate
     x509.reset(other.x509.get());
   }
 
-  typed_unique_ptr<EVP_PKEY> public_key()
+  typed_unique_ptr<EVP_PKEY> public_key() const
   {
     return make_typed_unique<EVP_PKEY>(X509_get_pubkey(x509.get()));
   }

--- a/lib/hpke/src/certificate.cpp
+++ b/lib/hpke/src/certificate.cpp
@@ -206,11 +206,18 @@ signature_key(EVP_PKEY* pkey)
   return std::make_unique<EVPGroup::PublicKey>(pkey);
 }
 
+static Signature::ID
+signature_algorithm(EVP_PKEY* pkey)
+{
+  typed_unique_ptr<EVP_PKEY> key = make_typed_unique(pkey);
+  return evp_sig_to_hpke_sig(key.get());
+}
+
 Certificate::Certificate(const bytes& der)
   : parsed_cert(ParsedCertificate::parse(der))
   , public_key(signature_key(parsed_cert->public_key().release()))
   , public_key_algorithm(
-      evp_sig_to_hpke_sig(parsed_cert->public_key().release()))
+      signature_algorithm(parsed_cert->public_key().release()))
   , raw(der)
 {}
 
@@ -218,7 +225,7 @@ Certificate::Certificate(const Certificate& other)
   : parsed_cert(std::make_unique<ParsedCertificate>(*other.parsed_cert))
   , public_key(signature_key(parsed_cert->public_key().release()))
   , public_key_algorithm(
-      evp_sig_to_hpke_sig(parsed_cert->public_key().release()))
+      signature_algorithm(parsed_cert->public_key().release()))
   , raw(other.raw)
 {}
 

--- a/lib/hpke/src/certificate.cpp
+++ b/lib/hpke/src/certificate.cpp
@@ -188,6 +188,9 @@ evp_sig_to_hpke_sig(EVP_PKEY* pkey)
                                                    : Signature::ID::P521_SHA512;
     }
     case EVP_PKEY_RSA:
+      // It is not necessarily the case that RSA keys are used with SHA256, 
+      // but in practically all cases, it is.  Since the SubjectPublicKeyInfo
+      // key doesn't tell us any more information, we assume this is the case.
       return Signature::ID::RSA_SHA256;
     default:
       throw std::runtime_error("Unsupported signature algorithm");

--- a/lib/hpke/src/certificate.cpp
+++ b/lib/hpke/src/certificate.cpp
@@ -188,7 +188,7 @@ evp_sig_to_hpke_sig(EVP_PKEY* pkey)
                                                    : Signature::ID::P521_SHA512;
     }
     case EVP_PKEY_RSA:
-      // It is not necessarily the case that RSA keys are used with SHA256, 
+      // It is not necessarily the case that RSA keys are used with SHA256,
       // but in practically all cases, it is.  Since the SubjectPublicKeyInfo
       // key doesn't tell us any more information, we assume this is the case.
       return Signature::ID::RSA_SHA256;


### PR DESCRIPTION
Current cert sets cert's signature algo instead of public key algo. This pr fixes that issue. Thanks @pabuhler  for the unit test