### PR TITLE
Test vector bugs

### DIFF
--- a/cmd/interop/src/mlspp_client.cpp
+++ b/cmd/interop/src/mlspp_client.cpp
@@ -186,7 +186,8 @@ class MLSClientImpl final : public MLSClient::Service
 };
 
 json
-make_sample(uint64_t type) {
+make_sample(uint64_t type)
+{
   auto suite = mls::CipherSuite::ID::X25519_AES128GCM_SHA256_Ed25519;
   auto n = 5;
   switch (type) {
@@ -214,7 +215,8 @@ make_sample(uint64_t type) {
 }
 
 void
-print_sample(uint64_t type) {
+print_sample(uint64_t type)
+{
   auto j = make_sample(type);
   if (j.is_null()) {
     std::cout << "Invalid test vector type" << std::endl;

--- a/cmd/interop/src/mlspp_client.cpp
+++ b/cmd/interop/src/mlspp_client.cpp
@@ -185,12 +185,58 @@ class MLSClientImpl final : public MLSClient::Service
   }
 };
 
-DEFINE_uint64(port, 50001, "Port to listen on");
+json
+make_sample(uint64_t type) {
+  auto suite = mls::CipherSuite::ID::X25519_AES128GCM_SHA256_Ed25519;
+  auto n = 5;
+  switch (type) {
+    case TestVectorType::TREE_MATH:
+      return mls_vectors::TreeMathTestVector::create(n);
+
+    case TestVectorType::ENCRYPTION:
+      return mls_vectors::EncryptionTestVector::create(suite, n, n);
+
+    case TestVectorType::KEY_SCHEDULE:
+      return mls_vectors::KeyScheduleTestVector::create(suite, n);
+
+    case TestVectorType::TRANSCRIPT:
+      return mls_vectors::TranscriptTestVector::create(suite);
+
+    case TestVectorType::TREEKEM:
+      return mls_vectors::TreeKEMTestVector::create(suite, n);
+
+    case TestVectorType::MESSAGES:
+      return mls_vectors::MessagesTestVector::create();
+
+    default:
+      return nullptr;
+  }
+}
+
+void
+print_sample(uint64_t type) {
+  auto j = make_sample(type);
+  if (j.is_null()) {
+    std::cout << "Invalid test vector type" << std::endl;
+    return;
+  }
+
+  std::cout << j.dump(2) << std::endl;
+}
+
+#define NO_SAMPLE 0xffffffffffffffff
+DEFINE_uint64(sample, NO_SAMPLE, "Generate a sample JSON file (by enum value)");
+DEFINE_uint64(port, 50001, "Listen for gRPC on this port");
 
 int
 main(int argc, char* argv[])
 {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (FLAGS_sample != NO_SAMPLE) {
+    print_sample(FLAGS_sample);
+    return 0;
+  }
 
   auto service = MLSClientImpl{};
   auto server_address = (std::stringstream{} << "0.0.0.0:" << FLAGS_port).str();

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -548,7 +548,7 @@ TreeKEMTestVector::create(CipherSuite suite, size_t n_leaves)
   tv.tree_hash_before = pub.root_hash();
   tv.my_key_package = test_kp;
   tv.my_path_secret = path_secret;
-  tv.root_secret_after_update = add_priv.update_secret;
+  tv.root_secret_after_add = add_priv.update_secret;
 
   // Do a second update that the test participant should be able to process
   auto update_secret = random_bytes(suite.secret_size());

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -60,7 +60,7 @@ HashRatchet::HashRatchet(CipherSuite suite_in,
   , next_secret(std::move(base_secret_in))
   , next_generation(0)
   , key_size(suite.hpke().aead.key_size)
-  , nonce_size(suite.hpke().aead.key_size)
+  , nonce_size(suite.hpke().aead.nonce_size)
   , secret_size(suite.secret_size())
 {}
 

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -150,6 +150,7 @@ TreeKEMPrivateKey::implant(NodeIndex start,
 
   path_secrets[r] = secret;
   private_key_cache.erase(n);
+  update_secret = secret;
 }
 
 std::optional<HPKEPrivateKey>


### PR DESCRIPTION
A couple of bugs that I noticed while looking at test vectors:

* TreeKEM was not properly setting `update_secret` on `TreeKEMPrivateKey`
* Nonces were being derived to `key_size` not `nonce_size`
* Key schedule test vectors were capturing behavior specific to mlspp (we initialize a whole key schedule epoch for the one-member group, even though this is not visible to other participants)