### PR TITLE
SFrame parameter negotiation

### DIFF
--- a/include/mls/core_types.h
+++ b/include/mls/core_types.h
@@ -17,22 +17,28 @@ enum class ProtocolVersion : uint8_t
 
 extern const std::array<ProtocolVersion, 1> all_supported_versions;
 
-struct ExtensionType
-{
-  static constexpr uint16_t capabilities = 1;
-  static constexpr uint16_t lifetime = 2;
-  static constexpr uint16_t key_id = 3;
-  static constexpr uint16_t parent_hash = 4;
-  static constexpr uint16_t ratchet_tree = 5;
-};
-
 struct Extension
 {
-  uint16_t type;
+  using Type = uint16_t;
+
+  Type type;
   bytes data;
 
   TLS_SERIALIZABLE(type, data)
   TLS_TRAITS(tls::pass, tls::vector<2>)
+};
+
+struct ExtensionType
+{
+  static constexpr Extension::Type capabilities = 1;
+  static constexpr Extension::Type lifetime = 2;
+  static constexpr Extension::Type key_id = 3;
+  static constexpr Extension::Type parent_hash = 4;
+  static constexpr Extension::Type ratchet_tree = 5;
+
+  // XXX(RLB) There is no IANA-registered type for this extension yet, so we use
+  // a value from the vendor-specific space
+  static constexpr Extension::Type sframe_parameters = 0xff02;
 };
 
 struct ExtensionList

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -18,6 +18,26 @@ struct RatchetTreeExtension
   TLS_SERIALIZABLE(tree)
 };
 
+struct SFrameParameters
+{
+  uint16_t cipher_suite;
+  uint8_t epoch_bits;
+
+  static const uint16_t type;
+  TLS_SERIALIZABLE(cipher_suite, epoch_bits)
+};
+
+struct SFrameCapabilities
+{
+  std::vector<uint16_t> cipher_suites;
+
+  bool compatible(const SFrameParameters& params) const;
+
+  static const uint16_t type;
+  TLS_SERIALIZABLE(cipher_suites)
+  TLS_TRAITS(tls::vector<1>)
+};
+
 struct MAC
 {
   bytes mac_value;

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -56,7 +56,8 @@ public:
         CipherSuite suite,
         const HPKEPrivateKey& init_priv,
         SignaturePrivateKey sig_priv,
-        const KeyPackage& key_package);
+        const KeyPackage& key_package,
+        const ExtensionList& extensions);
 
   // Initialize a group from a Welcome
   State(const HPKEPrivateKey& init_priv,
@@ -93,6 +94,8 @@ public:
   epoch_t epoch() const { return _epoch; }
   LeafIndex index() const { return _index; }
   CipherSuite cipher_suite() const { return _suite; }
+  const ExtensionList& extensions() const { return _extensions; }
+
   bytes do_export(const std::string& label,
                   const bytes& context,
                   size_t size) const;

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -57,7 +57,7 @@ public:
         const HPKEPrivateKey& init_priv,
         SignaturePrivateKey sig_priv,
         const KeyPackage& key_package,
-        const ExtensionList& extensions);
+        ExtensionList extensions);
 
   // Initialize a group from a Welcome
   State(const HPKEPrivateKey& init_priv,

--- a/lib/hpke/src/certificate.cpp
+++ b/lib/hpke/src/certificate.cpp
@@ -206,9 +206,16 @@ struct Certificate::ParsedCertificate
         return Signature::ID::Ed448;
       case EVP_PKEY_EC: {
         auto key_size = EVP_PKEY_bits(X509_get0_pubkey(x509));
-        return (key_size == 256)   ? Signature::ID::P256_SHA256
-               : (key_size == 384) ? Signature::ID::P384_SHA384
-                                   : Signature::ID::P521_SHA512;
+        switch (key_size) {
+          case 256:
+            return Signature::ID::P256_SHA256;
+          case 384:
+            return Signature::ID::P384_SHA384;
+          case 521:
+            return Signature::ID::P521_SHA512;
+          default:
+            throw std::runtime_error("Unknown curve");
+        }
       }
       case EVP_PKEY_RSA:
         return Signature::ID::RSA_SHA256;

--- a/lib/hpke/src/certificate.cpp
+++ b/lib/hpke/src/certificate.cpp
@@ -161,10 +161,9 @@ struct Certificate::ParsedCertificate
         return Signature::ID::Ed448;
       case EVP_PKEY_EC: {
         auto key_size = EVP_PKEY_bits(X509_get0_pubkey(x509));
-        return (key_size == 256)
-                 ? Signature::ID::P256_SHA256
-                 : (key_size == 384) ? Signature::ID::P384_SHA384
-                                     : Signature::ID::P521_SHA512;
+        return (key_size == 256)   ? Signature::ID::P256_SHA256
+               : (key_size == 384) ? Signature::ID::P384_SHA384
+                                   : Signature::ID::P521_SHA512;
       }
       case EVP_PKEY_RSA:
         return Signature::ID::RSA_SHA256;

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -8,6 +8,16 @@ namespace mls {
 // Extensions
 
 const uint16_t RatchetTreeExtension::type = ExtensionType::ratchet_tree;
+const uint16_t SFrameParameters::type = ExtensionType::sframe_parameters;
+const uint16_t SFrameCapabilities::type = ExtensionType::sframe_parameters;
+
+bool
+SFrameCapabilities::compatible(const SFrameParameters& params) const
+{
+  const auto begin = cipher_suites.begin();
+  const auto end = cipher_suites.end();
+  return std::find(begin, end, params.cipher_suite) != end;
+}
 
 // PublicGroupState
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -149,8 +149,8 @@ Session::Inner::begin(const bytes& group_id,
                       const SignaturePrivateKey& sig_priv,
                       const KeyPackage& key_package)
 {
-  auto state =
-    State(group_id, key_package.cipher_suite, init_priv, sig_priv, key_package);
+  auto state = State(
+    group_id, key_package.cipher_suite, init_priv, sig_priv, key_package, {});
   auto inner = std::make_unique<Inner>(state);
   return Session(inner.release());
 }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -13,13 +13,13 @@ State::State(bytes group_id,
              const HPKEPrivateKey& init_priv,
              SignaturePrivateKey sig_priv,
              const KeyPackage& key_package,
-             const ExtensionList& extensions)
+             ExtensionList extensions)
   : _suite(suite)
   , _group_id(std::move(group_id))
   , _epoch(0)
   , _tree(suite)
   , _transcript_hash(suite)
-  , _extensions(extensions)
+  , _extensions(std::move(extensions))
   , _index(0)
   , _identity_priv(std::move(sig_priv))
 {
@@ -93,7 +93,7 @@ State::State(const HPKEPrivateKey& init_priv,
   static const auto copy_to_group = std::set<Extension::Type>{
     ExtensionType::sframe_parameters,
   };
-  for (auto ext : group_info.extensions.extensions) {
+  for (const auto& ext : group_info.extensions.extensions) {
     if (copy_to_group.count(ext.type) > 0) {
       _extensions.add(ext.type, ext.data);
     }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1,5 +1,7 @@
 #include <mls/state.h>
 
+#include <set>
+
 namespace mls {
 
 ///
@@ -10,12 +12,14 @@ State::State(bytes group_id,
              CipherSuite suite,
              const HPKEPrivateKey& init_priv,
              SignaturePrivateKey sig_priv,
-             const KeyPackage& key_package)
+             const KeyPackage& key_package,
+             const ExtensionList& extensions)
   : _suite(suite)
   , _group_id(std::move(group_id))
   , _epoch(0)
   , _tree(suite)
   , _transcript_hash(suite)
+  , _extensions(extensions)
   , _index(0)
   , _identity_priv(std::move(sig_priv))
 {
@@ -85,6 +89,15 @@ State::State(const HPKEPrivateKey& init_priv,
 
   _transcript_hash.confirmed = group_info.confirmed_transcript_hash;
   _transcript_hash.update_interim(group_info.confirmation_tag);
+
+  static const auto copy_to_group = std::set<Extension::Type>{
+    ExtensionType::sframe_parameters,
+  };
+  for (auto ext : group_info.extensions.extensions) {
+    if (copy_to_group.count(ext.type) > 0) {
+      _extensions.add(ext.type, ext.data);
+    }
+  }
 
   // Construct TreeKEM private key from partrs provided
   auto maybe_index = _tree.find(kp);

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -97,7 +97,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person")
 TEST_CASE_FIXTURE(StateTest, "SFrame Parameter Negotiation")
 {
   // Set the SFrame parameters for the group
-  auto specified_params = SFrameParameters{ 1, 4 };
+  auto specified_params = SFrameParameters{ 1, 8 };
   auto group_extensions = ExtensionList{};
   group_extensions.add(specified_params);
 
@@ -119,7 +119,7 @@ TEST_CASE_FIXTURE(StateTest, "SFrame Parameter Negotiation")
 
   auto decoded_capabilities =
     key_packages[1].extensions.find<SFrameCapabilities>();
-  REQUIRE(!!decoded_capabilities);
+  REQUIRE(decoded_capabilities);
   REQUIRE(opt::get(decoded_capabilities) == compatible_capabilities);
   REQUIRE(opt::get(decoded_capabilities).compatible(specified_params));
 
@@ -138,8 +138,8 @@ TEST_CASE_FIXTURE(StateTest, "SFrame Parameter Negotiation")
   // Check that both participants have the  correct SFrame parameters
   auto first_params = first1.extensions().find<SFrameParameters>();
   auto second_params = second0.extensions().find<SFrameParameters>();
-  REQUIRE(!!first_params);
-  REQUIRE(!!second_params);
+  REQUIRE(first_params);
+  REQUIRE(second_params);
   REQUIRE(opt::get(first_params) == specified_params);
   REQUIRE(opt::get(first_params) == opt::get(second_params));
 }


### PR DESCRIPTION
Implements SFrame parameter negotiation as specified in the [corresponding spec PR](https://github.com/bifurcation/sframe-mls/pull/3).  

Note that this is the first extension we have that is copied into the group state.  Currently application-defined extensions cannot be auto-copied over from the GroupInfo to the GroupContext.  The application would have to manually call `state.extensions().add(custom_extension)`, and even that is currently impossible because the `extensions()` method is `const`.  We might want to consider having a better story for application-defined extensions.