### PR TITLE
Update CI workflows master->main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,10 @@ name: Build and Test
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -3,10 +3,10 @@ name: Build for older MacOS
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -3,10 +3,10 @@ name: Check Formatting
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
Fixing #176 broke CI triggers that were tied to `master`.  This PR just points them to `main` instead.