### PR TITLE
Add external join to interop client

### DIFF
--- a/cmd/interop/src/mls_client_impl.cpp
+++ b/cmd/interop/src/mls_client_impl.cpp
@@ -137,8 +137,9 @@ MLSClientImpl::PublicGroupState(ServerContext* /* context */,
                                 const PublicGroupStateRequest* request,
                                 PublicGroupStateResponse* response)
 {
-  return state_wrap(
-    request, [=](auto& state) { return public_group_state(state, request, response); });
+  return state_wrap(request, [=](auto& state) {
+    return public_group_state(state, request, response);
+  });
 }
 
 // Operations using a group state
@@ -433,9 +434,9 @@ MLSClientImpl::external_join(const ExternalJoinRequest* request,
   auto kp =
     mls::KeyPackage(pgs.cipher_suite, init_priv.public_key, cred, sig_priv, {});
 
-  auto leaf_secret =
-    mls::random_bytes(pgs.cipher_suite.secret_size());
-  auto [commit, state] = mls::State::external_join(leaf_secret, sig_priv, kp, pgs);
+  auto leaf_secret = mls::random_bytes(pgs.cipher_suite.secret_size());
+  auto [commit, state] =
+    mls::State::external_join(leaf_secret, sig_priv, kp, pgs);
   auto commit_data = tls::marshal(commit);
   auto state_id = store_state(std::move(state), request->encrypt_handshake());
 
@@ -569,9 +570,10 @@ MLSClientImpl::handle_commit(CachedState& entry,
 }
 
 Status
-MLSClientImpl::handle_external_commit(CachedState& entry,
-                                      const HandleExternalCommitRequest* request,
-                                      HandleExternalCommitResponse* response)
+MLSClientImpl::handle_external_commit(
+  CachedState& entry,
+  const HandleExternalCommitRequest* request,
+  HandleExternalCommitResponse* response)
 {
   auto commit_data = string_to_bytes(request->commit());
   auto commit = tls::get<mls::MLSPlaintext>(commit_data);

--- a/cmd/interop/src/mls_client_impl.cpp
+++ b/cmd/interop/src/mls_client_impl.cpp
@@ -114,6 +114,14 @@ MLSClientImpl::JoinGroup(ServerContext* /* context */,
   return catch_wrap([=]() { return join_group(request, response); });
 }
 
+Status
+MLSClientImpl::ExternalJoin(ServerContext* /* context */,
+                            const ExternalJoinRequest* request,
+                            ExternalJoinResponse* response)
+{
+  return catch_wrap([=]() { return external_join(request, response); });
+}
+
 // Access information from a group state
 Status
 MLSClientImpl::StateAuth(ServerContext* /* context */,
@@ -122,6 +130,15 @@ MLSClientImpl::StateAuth(ServerContext* /* context */,
 {
   return state_wrap(
     request, [=](auto& state) { return state_auth(state, request, response); });
+}
+
+Status
+MLSClientImpl::PublicGroupState(ServerContext* /* context */,
+                                const PublicGroupStateRequest* request,
+                                PublicGroupStateResponse* response)
+{
+  return state_wrap(
+    request, [=](auto& state) { return public_group_state(state, request, response); });
 }
 
 // Operations using a group state
@@ -151,6 +168,16 @@ MLSClientImpl::HandleCommit(ServerContext* /* context */,
 {
   return state_wrap(request, [=](auto& state) {
     return handle_commit(state, request, response);
+  });
+}
+
+Status
+MLSClientImpl::HandleExternalCommit(ServerContext* /* context */,
+                                    const HandleExternalCommitRequest* request,
+                                    HandleExternalCommitResponse* response)
+{
+  return state_wrap(request, [=](auto& state) {
+    return handle_external_commit(state, request, response);
   });
 }
 
@@ -345,7 +372,7 @@ MLSClientImpl::create_group(const CreateGroupRequest* request,
     mls::KeyPackage(cipher_suite, init_priv.public_key, cred, sig_priv, {});
 
   auto state =
-    mls::State(group_id, cipher_suite, init_priv, sig_priv, key_package);
+    mls::State(group_id, cipher_suite, init_priv, sig_priv, key_package, {});
   auto state_id = store_state(std::move(state), request->encrypt_handshake());
 
   response->set_state_id(state_id);
@@ -393,6 +420,30 @@ MLSClientImpl::join_group(const JoinGroupRequest* request,
   return Status::OK;
 }
 
+Status
+MLSClientImpl::external_join(const ExternalJoinRequest* request,
+                             ExternalJoinResponse* response)
+{
+  auto pgs_data = string_to_bytes(request->public_group_state());
+  auto pgs = tls::get<mls::PublicGroupState>(pgs_data);
+
+  auto init_priv = mls::HPKEPrivateKey::generate(pgs.cipher_suite);
+  auto sig_priv = mls::SignaturePrivateKey::generate(pgs.cipher_suite);
+  auto cred = mls::Credential::basic({}, sig_priv.public_key);
+  auto kp =
+    mls::KeyPackage(pgs.cipher_suite, init_priv.public_key, cred, sig_priv, {});
+
+  auto leaf_secret =
+    mls::random_bytes(pgs.cipher_suite.secret_size());
+  auto [commit, state] = mls::State::external_join(leaf_secret, sig_priv, kp, pgs);
+  auto commit_data = tls::marshal(commit);
+  auto state_id = store_state(std::move(state), request->encrypt_handshake());
+
+  response->set_state_id(state_id);
+  response->set_commit(bytes_to_string(commit_data));
+  return Status::OK;
+}
+
 // Access information from a group state
 Status
 MLSClientImpl::state_auth(CachedState& entry,
@@ -401,6 +452,16 @@ MLSClientImpl::state_auth(CachedState& entry,
 {
   auto secret = entry.state.authentication_secret();
   response->set_state_auth_secret(bytes_to_string(secret));
+  return Status::OK;
+}
+
+Status
+MLSClientImpl::public_group_state(CachedState& entry,
+                                  const PublicGroupStateRequest* /* request */,
+                                  PublicGroupStateResponse* response)
+{
+  auto pgs = tls::marshal(entry.state.public_group_state());
+  response->set_public_group_state(bytes_to_string(pgs));
   return Status::OK;
 }
 
@@ -496,6 +557,24 @@ MLSClientImpl::handle_commit(CachedState& entry,
   }
 
   auto commit = entry.unmarshal(request->commit());
+  auto should_be_next = entry.state.handle(commit);
+  if (!should_be_next) {
+    throw std::runtime_error("Commit failed to produce a new state");
+  }
+
+  auto& next = opt::get(should_be_next);
+  auto next_id = store_state(std::move(next), entry.encrypt_handshake);
+  response->set_state_id(next_id);
+  return Status::OK;
+}
+
+Status
+MLSClientImpl::handle_external_commit(CachedState& entry,
+                                      const HandleExternalCommitRequest* request,
+                                      HandleExternalCommitResponse* response)
+{
+  auto commit_data = string_to_bytes(request->commit());
+  auto commit = tls::get<mls::MLSPlaintext>(commit_data);
   auto should_be_next = entry.state.handle(commit);
   if (!should_be_next) {
     throw std::runtime_error("Commit failed to produce a new state");

--- a/cmd/interop/src/mls_client_impl.h
+++ b/cmd/interop/src/mls_client_impl.h
@@ -38,11 +38,17 @@ class MLSClientImpl final : public MLSClient::Service
   Status JoinGroup(ServerContext* context,
                    const JoinGroupRequest* request,
                    JoinGroupResponse* response) override;
+  Status ExternalJoin(ServerContext* context,
+                      const ExternalJoinRequest* request,
+                      ExternalJoinResponse* response) override;
 
   // Access information from a group state
   Status StateAuth(ServerContext* context,
                    const StateAuthRequest* request,
                    StateAuthResponse* response) override;
+  Status PublicGroupState(ServerContext* context,
+                          const PublicGroupStateRequest* request,
+                          PublicGroupStateResponse* response) override;
 
   // Operations using a group state
   Status AddProposal(ServerContext* context,
@@ -54,6 +60,9 @@ class MLSClientImpl final : public MLSClient::Service
   Status HandleCommit(ServerContext* context,
                       const HandleCommitRequest* request,
                       HandleCommitResponse* response) override;
+  Status HandleExternalCommit(ServerContext* context,
+                              const HandleExternalCommitRequest* request,
+                              HandleExternalCommitResponse* response) override;
 
 private:
   // Wrapper for methods that rely on state
@@ -108,11 +117,16 @@ private:
                             CreateKeyPackageResponse* response);
   Status join_group(const JoinGroupRequest* request,
                     JoinGroupResponse* response);
+  Status external_join(const ExternalJoinRequest* request,
+                       ExternalJoinResponse* response);
 
   // Access information from a group state
   Status state_auth(CachedState& entry,
                     const StateAuthRequest* request,
                     StateAuthResponse* response);
+  Status public_group_state(CachedState& entry,
+                            const PublicGroupStateRequest* request,
+                            PublicGroupStateResponse* response);
 
   // Operations on a running group
   Status add_proposal(CachedState& entry,
@@ -124,4 +138,7 @@ private:
   Status handle_commit(CachedState& entry,
                        const HandleCommitRequest* request,
                        HandleCommitResponse* response);
+  Status handle_external_commit(CachedState& entry,
+                                const HandleExternalCommitRequest* request,
+                                HandleExternalCommitResponse* response);
 };


### PR DESCRIPTION
Updates the interop client to expose external join functions.  Corresponding mls-implementations PR is https://github.com/mlswg/mls-implementations/pull/41.