### PR TITLE
Fix copy-paste error for X25519 + ChaCha20 ciphersuite

### DIFF
--- a/lib/mls_vectors/include/mls_vectors/mls_vectors.h
+++ b/lib/mls_vectors/include/mls_vectors/mls_vectors.h
@@ -87,7 +87,6 @@ struct KeyScheduleTestVector
 
     bytes joiner_secret;
     bytes welcome_secret;
-    bytes epoch_secret;
     bytes init_secret;
 
     bytes sender_data_secret;

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -322,7 +322,6 @@ KeyScheduleTestVector::create(CipherSuite suite, uint32_t n_epochs)
 
       epoch.joiner_secret,
       welcome_secret,
-      epoch.epoch_secret,
       epoch.init_secret,
 
       epoch.sender_data_secret,
@@ -361,7 +360,6 @@ KeyScheduleTestVector::verify() const
 
     // Verify the rest of the epoch
     VERIFY_EQUAL("joiner secret", epoch.joiner_secret, tve.joiner_secret);
-    VERIFY_EQUAL("epoch secret", epoch.epoch_secret, tve.epoch_secret);
 
     auto welcome_secret = KeyScheduleEpoch::welcome_secret(
       cipher_suite, tve.joiner_secret, tve.psk_secret);

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -362,7 +362,6 @@ KeyScheduleTestVector::verify() const
     // Verify the rest of the epoch
     VERIFY_EQUAL("joiner secret", epoch.joiner_secret, tve.joiner_secret);
     VERIFY_EQUAL("epoch secret", epoch.epoch_secret, tve.epoch_secret);
-    VERIFY_EQUAL("init secret", epoch.init_secret, tve.init_secret);
 
     auto welcome_secret = KeyScheduleEpoch::welcome_secret(
       cipher_suite, tve.joiner_secret, tve.psk_secret);
@@ -382,6 +381,7 @@ KeyScheduleTestVector::verify() const
     VERIFY_EQUAL("membership key", epoch.membership_key, tve.membership_key);
     VERIFY_EQUAL(
       "resumption secret", epoch.resumption_secret, tve.resumption_secret);
+    VERIFY_EQUAL("init secret", epoch.init_secret, tve.init_secret);
 
     VERIFY_EQUAL(
       "external pub", epoch.external_priv.public_key, tve.external_pub);

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -70,11 +70,11 @@ CipherSuite::get() const
 
   static const auto ciphers_X25519_CHACHA20POLY1305_SHA256_Ed25519 =
     CipherSuite::Ciphers{
-      HPKE(KEM::ID::DHKEM_X448_SHA512,
-           KDF::ID::HKDF_SHA512,
-           AEAD::ID::AES_256_GCM),
-      Digest::get<Digest::ID::SHA512>(),
-      Signature::get<Signature::ID::Ed448>(),
+      HPKE(KEM::ID::DHKEM_X25519_SHA256,
+           KDF::ID::HKDF_SHA256,
+           AEAD::ID::CHACHA20_POLY1305),
+      Digest::get<Digest::ID::SHA256>(),
+      Signature::get<Signature::ID::Ed25519>(),
     };
 
   static const auto ciphers_X448_AES256GCM_SHA512_Ed448 = CipherSuite::Ciphers{


### PR DESCRIPTION
Also removes the `epoch_secret` field from the key schedule test vectors, since we had agreed to remove it.