### PR TITLE
Fix derive down

### DIFF
--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -163,7 +163,7 @@ SecretTree::get(LeafIndex sender)
     auto left = tree_math::left(curr_node);
     auto right = tree_math::right(curr_node, group_size);
 
-    auto& secret = secrets[node.val];
+    auto& secret = secrets[curr_node.val];
     secrets[left.val] =
       derive_tree_secret(suite, secret, "tree", left, 0, secret_size);
     secrets[right.val] =


### PR DESCRIPTION
This appears to be a typo. The input secret here should always come from the current node.