### PR TITLE
drop app- label prefix in HashRatchet

### DIFF
--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -68,11 +68,11 @@ std::tuple<uint32_t, KeyAndNonce>
 HashRatchet::next()
 {
   auto key = derive_tree_secret(
-    suite, next_secret, "app-key", node, next_generation, key_size);
+    suite, next_secret, "key", node, next_generation, key_size);
   auto nonce = derive_tree_secret(
-    suite, next_secret, "app-nonce", node, next_generation, nonce_size);
+    suite, next_secret, "nonce", node, next_generation, nonce_size);
   auto secret = derive_tree_secret(
-    suite, next_secret, "app-secret", node, next_generation, secret_size);
+    suite, next_secret, "secret", node, next_generation, secret_size);
 
   auto generation = next_generation;
 


### PR DESCRIPTION
The labels here have an `app-` prefix that shouldn't be there.