### PR TITLE
remove using declaratives

### DIFF
--- a/include/mls/credential.h
+++ b/include/mls/credential.h
@@ -109,9 +109,7 @@ private:
 
 namespace tls {
 
-using namespace mls;
-
-TLS_VARIANT_MAP(CredentialType, BasicCredential, basic)
-TLS_VARIANT_MAP(CredentialType, X509Credential, x509)
+TLS_VARIANT_MAP(mls::CredentialType, mls::BasicCredential, basic)
+TLS_VARIANT_MAP(mls::CredentialType, mls::X509Credential, x509)
 
 } // namespace TLS

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -561,23 +561,23 @@ struct MLSCiphertext
 
 namespace tls {
 
-TLS_VARIANT_MAP(PSKType, ExternalPSK, external)
-TLS_VARIANT_MAP(PSKType, ReInitPSK, reinit)
-TLS_VARIANT_MAP(PSKType, BranchPSK, branch)
+TLS_VARIANT_MAP(mls::PSKType, mls::ExternalPSK, external)
+TLS_VARIANT_MAP(mls::PSKType, mls::ReInitPSK, reinit)
+TLS_VARIANT_MAP(mls::PSKType, mls::BranchPSK, branch)
 
-TLS_VARIANT_MAP(ProposalOrRefType, Proposal, value)
-TLS_VARIANT_MAP(ProposalOrRefType, ProposalRef, reference)
+TLS_VARIANT_MAP(mls::ProposalOrRefType, mls::Proposal, value)
+TLS_VARIANT_MAP(mls::ProposalOrRefType, mls::ProposalRef, reference)
 
-TLS_VARIANT_MAP(ProposalType, Add, add)
-TLS_VARIANT_MAP(ProposalType, Update, update)
-TLS_VARIANT_MAP(ProposalType, Remove, remove)
-TLS_VARIANT_MAP(ProposalType, PreSharedKey, psk)
-TLS_VARIANT_MAP(ProposalType, ReInit, reinit)
-TLS_VARIANT_MAP(ProposalType, ExternalInit, external_init)
-TLS_VARIANT_MAP(ProposalType, AppAck, app_ack)
+TLS_VARIANT_MAP(mls::ProposalType, mls::Add, add)
+TLS_VARIANT_MAP(mls::ProposalType, mls::Update, update)
+TLS_VARIANT_MAP(mls::ProposalType, mls::Remove, remove)
+TLS_VARIANT_MAP(mls::ProposalType, mls::PreSharedKey, psk)
+TLS_VARIANT_MAP(mls::ProposalType, mls::ReInit, reinit)
+TLS_VARIANT_MAP(mls::ProposalType, mls::ExternalInit, external_init)
+TLS_VARIANT_MAP(mls::ProposalType, mls::AppAck, app_ack)
 
-TLS_VARIANT_MAP(ContentType, ApplicationData, application)
-TLS_VARIANT_MAP(ContentType, Proposal, proposal)
-TLS_VARIANT_MAP(ContentType, Commit, commit)
+TLS_VARIANT_MAP(mls::ContentType, mls::ApplicationData, application)
+TLS_VARIANT_MAP(mls::ContentType, mls::Proposal, proposal)
+TLS_VARIANT_MAP(mls::ContentType, mls::Commit, commit)
 
 } // namespace tls

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -561,8 +561,6 @@ struct MLSCiphertext
 
 namespace tls {
 
-using namespace mls;
-
 TLS_VARIANT_MAP(PSKType, ExternalPSK, external)
 TLS_VARIANT_MAP(PSKType, ReInitPSK, reinit)
 TLS_VARIANT_MAP(PSKType, BranchPSK, branch)

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -177,9 +177,7 @@ private:
 
 namespace tls {
 
-using namespace mls;
-
-TLS_VARIANT_MAP(NodeType, KeyPackage, leaf)
-TLS_VARIANT_MAP(NodeType, ParentNode, parent)
+TLS_VARIANT_MAP(mls::NodeType, mls::KeyPackage, leaf)
+TLS_VARIANT_MAP(mls::NodeType, mls::ParentNode, parent)
 
 } // namespace tls


### PR DESCRIPTION
Removes ``` using namespace mls``` directive from includes under src. The ones under cmd/ test/ andd mls_vectors/ are untouched.