### PR TITLE
Add openssl dependency to interop client

### DIFF
--- a/cmd/interop/CMakeLists.txt
+++ b/cmd/interop/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 ###
 ### Dependencies
 ###
+find_package(OpenSSL 1.1 REQUIRED)
 
 # gRPC dependencies
 find_package(Protobuf REQUIRED)


### PR DESCRIPTION
I'm running into this every time I make a completely fresh build.
I didn't check whether this is the right thing here. But it fixes the issue of not finding the openssl dependency in the interop client.