### PR TITLE
External tree

### DIFF
--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -89,7 +89,8 @@ public:
   MLSPlaintext remove(RosterIndex index) const;
   MLSPlaintext remove(LeafIndex removed) const;
 
-  struct CommitOpts {
+  struct CommitOpts
+  {
     std::vector<Proposal> extra_proposals;
     bool inline_tree;
   };

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -89,9 +89,13 @@ public:
   MLSPlaintext remove(RosterIndex index) const;
   MLSPlaintext remove(LeafIndex removed) const;
 
+  struct CommitOpts {
+    std::vector<Proposal> extra_proposals;
+    bool inline_tree;
+  };
   std::tuple<MLSPlaintext, Welcome, State> commit(
     const bytes& leaf_secret,
-    const std::vector<Proposal>& extra_proposals) const;
+    const std::optional<CommitOpts>& opts) const;
 
   ///
   /// Generic handshake message handler
@@ -167,7 +171,7 @@ protected:
   // Form a commit that can be either internal or external
   std::tuple<MLSPlaintext, Welcome, State> commit(
     const bytes& leaf_secret,
-    const std::vector<Proposal>& extra_proposals,
+    const std::optional<CommitOpts>& opts,
     const std::optional<KeyPackage>& joiner_key_package,
     const std::optional<HPKEPublicKey>& external_pub) const;
 

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -62,7 +62,8 @@ public:
   State(const HPKEPrivateKey& init_priv,
         SignaturePrivateKey sig_priv,
         const KeyPackage& kp,
-        const Welcome& welcome);
+        const Welcome& welcome,
+        const std::optional<TreeKEMPublicKey>& tree);
 
   // Join a group from outside
   // XXX(RLB) For full generality, this should be capable of covering other
@@ -104,6 +105,7 @@ public:
   LeafIndex index() const { return _index; }
   CipherSuite cipher_suite() const { return _suite; }
   const ExtensionList& extensions() const { return _extensions; }
+  const TreeKEMPublicKey& tree() const { return _tree; }
 
   bytes do_export(const std::string& label,
                   const bytes& context,

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -43,6 +43,12 @@ struct RosterIndex : public UInt32
   using UInt32::UInt32;
 };
 
+struct CommitOpts
+{
+  std::vector<Proposal> extra_proposals;
+  bool inline_tree;
+};
+
 class State
 {
 public:
@@ -89,11 +95,6 @@ public:
   MLSPlaintext remove(RosterIndex index) const;
   MLSPlaintext remove(LeafIndex removed) const;
 
-  struct CommitOpts
-  {
-    std::vector<Proposal> extra_proposals;
-    bool inline_tree;
-  };
   std::tuple<MLSPlaintext, Welcome, State> commit(
     const bytes& leaf_secret,
     const std::optional<CommitOpts>& opts) const;

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -285,10 +285,9 @@ Session::commit(const std::vector<bytes>& proposals)
 std::tuple<bytes, bytes>
 Session::commit()
 {
-  auto opts = State::CommitOpts{ {}, true };
   auto commit_secret = inner->fresh_secret();
   auto [commit, welcome, new_state] =
-    inner->history.front().commit(commit_secret, opts);
+    inner->history.front().commit(commit_secret, CommitOpts{ {}, true });
 
   auto commit_msg = inner->export_message(commit);
   auto welcome_msg = tls::marshal(welcome);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -163,7 +163,7 @@ Session::Inner::join(const HPKEPrivateKey& init_priv,
 {
   auto welcome = tls::get<Welcome>(welcome_data);
 
-  auto state = State(init_priv, sig_priv, key_package, welcome);
+  auto state = State(init_priv, sig_priv, key_package, welcome, std::nullopt);
   auto inner = std::make_unique<Inner>(state);
   return Session(inner.release());
 }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -285,7 +285,7 @@ Session::commit(const std::vector<bytes>& proposals)
 std::tuple<bytes, bytes>
 Session::commit()
 {
-  auto opts = State::CommitOpts{{}, true};
+  auto opts = State::CommitOpts{ {}, true };
   auto commit_secret = inner->fresh_secret();
   auto [commit, welcome, new_state] =
     inner->history.front().commit(commit_secret, opts);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -287,7 +287,7 @@ Session::commit()
 {
   auto commit_secret = inner->fresh_secret();
   auto [commit, welcome, new_state] =
-    inner->history.front().commit(commit_secret, {});
+    inner->history.front().commit(commit_secret, std::nullopt);
 
   auto commit_msg = inner->export_message(commit);
   auto welcome_msg = tls::marshal(welcome);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -285,9 +285,10 @@ Session::commit(const std::vector<bytes>& proposals)
 std::tuple<bytes, bytes>
 Session::commit()
 {
+  auto opts = State::CommitOpts{{}, true};
   auto commit_secret = inner->fresh_secret();
   auto [commit, welcome, new_state] =
-    inner->history.front().commit(commit_secret, std::nullopt);
+    inner->history.front().commit(commit_secret, opts);
 
   auto commit_msg = inner->export_message(commit);
   auto welcome_msg = tls::marshal(welcome);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -165,7 +165,7 @@ State::external_join(const bytes& leaf_secret,
 {
   auto initial_state = State(std::move(sig_priv), pgs);
   auto add = initial_state.add_proposal(kp);
-  auto opts = CommitOpts{ {add}, true };
+  auto opts = CommitOpts{ { add }, true };
   auto [commit_pt, welcome, state] =
     initial_state.commit(leaf_secret, opts, kp, pgs.external_pub);
   silence_unused(welcome);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -165,7 +165,7 @@ State::external_join(const bytes& leaf_secret,
 {
   auto initial_state = State(std::move(sig_priv), pgs);
   auto add = initial_state.add_proposal(kp);
-  auto opts = CommitOpts{ { add }, true };
+  auto opts = CommitOpts{ { add }, false };
   auto [commit_pt, welcome, state] =
     initial_state.commit(leaf_secret, opts, kp, pgs.external_pub);
   silence_unused(welcome);

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -82,7 +82,8 @@ TEST_CASE_FIXTURE(StateTest, "Two Person")
 
   // Handle the Add proposal and create a Commit
   auto add = first0.add_proposal(key_packages[1]);
-  auto [commit, welcome, first1] = first0.commit(fresh_secret(), { add });
+  auto opts = State::CommitOpts { {add}, true};
+  auto [commit, welcome, first1] = first0.commit(fresh_secret(), opts);
   silence_unused(commit);
 
   // Initialize the second participant from the Welcome
@@ -143,7 +144,8 @@ TEST_CASE_FIXTURE(StateTest, "SFrame Parameter Negotiation")
 
   // Add the second member
   auto add = first0.add_proposal(key_packages[1]);
-  auto [commit, welcome, first1] = first0.commit(fresh_secret(), { add });
+  auto opts = State::CommitOpts { {add}, true};
+  auto [commit, welcome, first1] = first0.commit(fresh_secret(), opts);
   silence_unused(commit);
 
   auto second0 =
@@ -179,7 +181,8 @@ TEST_CASE_FIXTURE(StateTest, "Add Multiple Members")
   }
 
   // Create a Commit that adds everybody
-  auto [commit, welcome, new_state] = states[0].commit(fresh_secret(), adds);
+  auto opts = State::CommitOpts { adds, true};
+  auto [commit, welcome, new_state] = states[0].commit(fresh_secret(), opts);
   silence_unused(commit);
   states[0] = new_state;
 
@@ -207,8 +210,9 @@ TEST_CASE_FIXTURE(StateTest, "Full Size Group")
     auto sender = i - 1;
 
     auto add = states[sender].add_proposal(key_packages[i]);
+    auto opts = State::CommitOpts { {add}, true};
     auto [commit, welcome, new_state] =
-      states[sender].commit(fresh_secret(), { add });
+      states[sender].commit(fresh_secret(), opts);
     for (size_t j = 0; j < states.size(); j += 1) {
       if (j == sender) {
         states[j] = new_state;
@@ -248,8 +252,9 @@ protected:
       adds.push_back(states[0].add_proposal(key_packages[i]));
     }
 
+    auto opts = State::CommitOpts { adds, true};
     auto [commit, welcome, new_state] =
-      states[0].commit(fresh_secret(), { adds });
+      states[0].commit(fresh_secret(), opts);
     silence_unused(commit);
     states[0] = new_state;
     for (size_t i = 1; i < group_size; i += 1) {
@@ -294,7 +299,8 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Update Everyone in a Group")
   for (size_t i = 0; i < group_size; i += 1) {
     auto new_leaf = fresh_secret();
     auto update = states[i].update_proposal(new_leaf);
-    auto [commit, welcome, new_state] = states[i].commit(new_leaf, { update });
+    auto opts = State::CommitOpts { {update}, true};
+    auto [commit, welcome, new_state] = states[i].commit(new_leaf, opts);
     silence_unused(welcome);
 
     for (auto& state : states) {
@@ -313,8 +319,9 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Remove Members from a Group")
 {
   for (int i = static_cast<int>(group_size) - 2; i > 0; i -= 1) {
     auto remove = states[i].remove_proposal(LeafIndex{ uint32_t(i + 1) });
+    auto opts = State::CommitOpts { {remove}, true};
     auto [commit, welcome, new_state] =
-      states[i].commit(fresh_secret(), { remove });
+      states[i].commit(fresh_secret(), opts);
     silence_unused(welcome);
 
     states.pop_back();
@@ -342,8 +349,9 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Roster Updates")
 
   // remove member at position 1
   auto remove_1 = states[0].remove_proposal(RosterIndex{ 1 });
+  auto opts = State::CommitOpts { {remove_1}, true};
   auto [commit_1, welcome_1, new_state_1] =
-    states[0].commit(fresh_secret(), { remove_1 });
+    states[0].commit(fresh_secret(), opts);
   silence_unused(welcome_1);
   silence_unused(commit_1);
   // roster should be 0, 2, 3, 4
@@ -357,8 +365,9 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Roster Updates")
 
   // remove member at position 2
   auto remove_2 = new_state_1.remove_proposal(RosterIndex{ 2 });
+  opts = State::CommitOpts { {remove_2}, true};
   auto [commit_2, welcome_2, new_state_2] =
-    new_state_1.commit(fresh_secret(), { remove_2 });
+    new_state_1.commit(fresh_secret(), opts);
   silence_unused(welcome_2);
   // roster should be 0, 2, 4
   expected_creds = std::vector<Credential>{

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -87,7 +87,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person")
 
   // Initialize the second participant from the Welcome
   auto second0 =
-    State{ init_privs[1], identity_privs[1], key_packages[1], welcome };
+    State{ init_privs[1], identity_privs[1], key_packages[1], welcome, std::nullopt };
   REQUIRE(first1 == second0);
 
   auto group = std::vector<State>{ first1, second0 };
@@ -147,7 +147,7 @@ TEST_CASE_FIXTURE(StateTest, "SFrame Parameter Negotiation")
   silence_unused(commit);
 
   auto second0 =
-    State{ init_privs[1], identity_privs[1], key_packages[1], welcome };
+    State{ init_privs[1], identity_privs[1], key_packages[1], welcome, std::nullopt };
   REQUIRE(first1 == second0);
 
   auto group = std::vector<State>{ first1, second0 };
@@ -186,7 +186,7 @@ TEST_CASE_FIXTURE(StateTest, "Add Multiple Members")
   // Initialize the new joiners from the welcome
   for (size_t i = 1; i < group_size; i += 1) {
     states.emplace_back(
-      init_privs[i], identity_privs[i], key_packages[i], welcome);
+      init_privs[i], identity_privs[i], key_packages[i], welcome, std::nullopt);
   }
 
   verify_group_functionality(states);
@@ -218,7 +218,7 @@ TEST_CASE_FIXTURE(StateTest, "Full Size Group")
     }
 
     states.emplace_back(
-      init_privs[i], identity_privs[i], key_packages[i], welcome);
+      init_privs[i], identity_privs[i], key_packages[i], welcome, std::nullopt);
 
     // Check that everyone ended up in the same place
     for (const auto& state : states) {
@@ -254,7 +254,7 @@ protected:
     states[0] = new_state;
     for (size_t i = 1; i < group_size; i += 1) {
       states.emplace_back(
-        init_privs[i], identity_privs[i], key_packages[i], welcome);
+        init_privs[i], identity_privs[i], key_packages[i], welcome, std::nullopt);
     }
 
     check_consistency();


### PR DESCRIPTION
Right now, we require that the Welcome/GroupInfo include a ratchet_tree extension containing the group's ratchet tree.  This PR makes that extension optional, on both the committer and joiner sides.