### PR TITLE
External Tree + External Join

### DIFF
--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -169,7 +169,9 @@ protected:
   GroupContext group_context() const;
 
   // Assemble a preliminary, unjoined group state
-  State(SignaturePrivateKey sig_priv, const PublicGroupState& pgs, const std::optional<TreeKEMPublicKey>& tree);
+  State(SignaturePrivateKey sig_priv,
+        const PublicGroupState& pgs,
+        const std::optional<TreeKEMPublicKey>& tree);
 
   // Import a tree from an externally-provided tree or an extension
   TreeKEMPublicKey import_tree(const bytes& tree_hash,

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -79,7 +79,8 @@ public:
     const bytes& leaf_secret,
     SignaturePrivateKey sig_priv,
     const KeyPackage& kp,
-    const PublicGroupState& pgs);
+    const PublicGroupState& pgs,
+    const std::optional<TreeKEMPublicKey>& tree);
 
   ///
   /// Message factories
@@ -168,7 +169,12 @@ protected:
   GroupContext group_context() const;
 
   // Assemble a preliminary, unjoined group state
-  State(SignaturePrivateKey sig_priv, const PublicGroupState& pgs);
+  State(SignaturePrivateKey sig_priv, const PublicGroupState& pgs, const std::optional<TreeKEMPublicKey>& tree);
+
+  // Import a tree from an externally-provided tree or an extension
+  TreeKEMPublicKey import_tree(const bytes& tree_hash,
+                               const std::optional<TreeKEMPublicKey>& external,
+                               const ExtensionList& extensions);
 
   // Form a commit that can be either internal or external
   std::tuple<MLSPlaintext, Welcome, State> commit(

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -43,10 +43,11 @@ State::import_tree(const bytes& tree_hash,
     tree = opt::get(external);
   } else if (maybe_tree_extn) {
     tree = opt::get(maybe_tree_extn).tree;
-    tree.suite = _suite;
   } else {
     throw InvalidParameterError("No tree available");
   }
+
+  tree.suite = _suite;
 
   tree.set_hash_all();
   if (tree.root_hash() != tree_hash) {

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -109,6 +109,10 @@ State::State(const HPKEPrivateKey& init_priv,
   }
 
   _tree.set_hash_all();
+  if (_tree.root_hash() != group_info.tree_hash) {
+    throw InvalidParameterError("Tree does not match GroupInfo");
+  }
+
   if (!_tree.parent_hash_valid()) {
     throw InvalidParameterError("Invalid tree");
   }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -32,11 +32,39 @@ State::State(bytes group_id,
   _keys = _key_schedule.encryption_keys(_tree.size());
 }
 
-State::State(SignaturePrivateKey sig_priv, const PublicGroupState& pgs)
+TreeKEMPublicKey
+State::import_tree(const bytes& tree_hash,
+                   const std::optional<TreeKEMPublicKey>& external,
+                   const ExtensionList& extensions)
+{
+  auto tree = TreeKEMPublicKey(_suite);
+  auto maybe_tree_extn = extensions.find<RatchetTreeExtension>();
+  if (external) {
+    tree = opt::get(external);
+  } else if (maybe_tree_extn) {
+    tree = opt::get(maybe_tree_extn).tree;
+    tree.suite = _suite;
+  } else {
+    throw InvalidParameterError("No tree available");
+  }
+
+  tree.set_hash_all();
+  if (tree.root_hash() != tree_hash) {
+    throw InvalidParameterError("Tree does not match GroupInfo");
+  }
+
+  if (!tree.parent_hash_valid()) {
+    throw InvalidParameterError("Invalid tree");
+  }
+
+  return tree;
+}
+
+State::State(SignaturePrivateKey sig_priv, const PublicGroupState& pgs, const std::optional<TreeKEMPublicKey>& tree)
   : _suite(pgs.cipher_suite)
   , _group_id(pgs.group_id)
   , _epoch(pgs.epoch)
-  , _tree(pgs.cipher_suite)
+  , _tree(import_tree(pgs.tree_hash, tree, pgs.extensions))
   , _transcript_hash(pgs.cipher_suite)
   , _extensions(pgs.extensions.for_group())
   , _key_schedule(pgs.cipher_suite)
@@ -45,16 +73,6 @@ State::State(SignaturePrivateKey sig_priv, const PublicGroupState& pgs)
 {
   // Import the interim transcript hash
   _transcript_hash.interim = pgs.interim_transcript_hash;
-
-  // Import the tree
-  auto maybe_tree_extn = pgs.extensions.find<RatchetTreeExtension>();
-  if (!maybe_tree_extn) {
-    throw InvalidParameterError("Ratchet tree not provided in GroupInfo");
-  }
-
-  _tree = opt::get(maybe_tree_extn).tree;
-  _tree.suite = _suite;
-  _tree.set_hash_all();
 
   // The following are not set:
   //    _transcript_hash.confirmed
@@ -98,24 +116,7 @@ State::State(const HPKEPrivateKey& init_priv,
   auto group_info = welcome.decrypt(secrets.joiner_secret, {});
 
   // Import the tree from the argument or from the extension
-  auto maybe_tree_extn = group_info.extensions.find<RatchetTreeExtension>();
-  if (tree) {
-    _tree = opt::get(tree);
-  } else if (maybe_tree_extn) {
-    _tree = opt::get(maybe_tree_extn).tree;
-    _tree.suite = _suite;
-  } else {
-    throw InvalidParameterError("No tree available");
-  }
-
-  _tree.set_hash_all();
-  if (_tree.root_hash() != group_info.tree_hash) {
-    throw InvalidParameterError("Tree does not match GroupInfo");
-  }
-
-  if (!_tree.parent_hash_valid()) {
-    throw InvalidParameterError("Invalid tree");
-  }
+  _tree = import_tree(group_info.tree_hash, tree, group_info.extensions);
 
   // Verify the signature on the GroupInfo
   if (!group_info.verify(_tree)) {
@@ -165,9 +166,10 @@ std::tuple<MLSPlaintext, State>
 State::external_join(const bytes& leaf_secret,
                      SignaturePrivateKey sig_priv,
                      const KeyPackage& kp,
-                     const PublicGroupState& pgs)
+                     const PublicGroupState& pgs,
+                     const std::optional<TreeKEMPublicKey>& tree)
 {
-  auto initial_state = State(std::move(sig_priv), pgs);
+  auto initial_state = State(std::move(sig_priv), pgs, tree);
   auto add = initial_state.add_proposal(kp);
   auto opts = CommitOpts{ { add }, false };
   auto [commit_pt, welcome, state] =

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -61,7 +61,9 @@ State::import_tree(const bytes& tree_hash,
   return tree;
 }
 
-State::State(SignaturePrivateKey sig_priv, const PublicGroupState& pgs, const std::optional<TreeKEMPublicKey>& tree)
+State::State(SignaturePrivateKey sig_priv,
+             const PublicGroupState& pgs,
+             const std::optional<TreeKEMPublicKey>& tree)
   : _suite(pgs.cipher_suite)
   , _group_id(pgs.group_id)
   , _epoch(pgs.epoch)

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -119,10 +119,12 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with external tree for welcome")
 
   auto incorrect_tree = TreeKEMPublicKey(suite);
   incorrect_tree.add_leaf(key_packages[1]);
-  CHECK_THROWS_AS(
-      State(
-      init_privs[1], identity_privs[1], key_packages[1], welcome, incorrect_tree),
-      InvalidParameterError);
+  CHECK_THROWS_AS(State(init_privs[1],
+                        identity_privs[1],
+                        key_packages[1],
+                        welcome,
+                        incorrect_tree),
+                  InvalidParameterError);
 
   auto second0 = State{
     init_privs[1], identity_privs[1], key_packages[1], welcome, first1.tree()
@@ -141,8 +143,11 @@ TEST_CASE_FIXTURE(StateTest, "External Join")
   auto public_group_state = first0.public_group_state();
 
   // Initialize the second participant as an external joiner
-  auto [commit, second0] = State::external_join(
-    fresh_secret(), identity_privs[1], key_packages[1], public_group_state, std::nullopt);
+  auto [commit, second0] = State::external_join(fresh_secret(),
+                                                identity_privs[1],
+                                                key_packages[1],
+                                                public_group_state,
+                                                std::nullopt);
 
   // Creator processes the commit
   auto first1 = opt::get(first0.handle(commit));
@@ -160,8 +165,11 @@ TEST_CASE_FIXTURE(StateTest, "External Join with External Tree")
   auto tree = first0.tree();
 
   // Initialize the second participant as an external joiner
-  auto [commit, second0] = State::external_join(
-    fresh_secret(), identity_privs[1], key_packages[1], public_group_state, tree);
+  auto [commit, second0] = State::external_join(fresh_secret(),
+                                                identity_privs[1],
+                                                key_packages[1],
+                                                public_group_state,
+                                                tree);
 
   // Creator processes the commit
   auto first1 = opt::get(first0.handle(commit));

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -117,6 +117,13 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with external tree for welcome")
       init_privs[1], identity_privs[1], key_packages[1], welcome, std::nullopt),
     InvalidParameterError);
 
+  auto incorrect_tree = TreeKEMPublicKey(suite);
+  incorrect_tree.add_leaf(key_packages[1]);
+  CHECK_THROWS_AS(
+      State(
+      init_privs[1], identity_privs[1], key_packages[1], welcome, incorrect_tree),
+      InvalidParameterError);
+
   auto second0 = State{
     init_privs[1], identity_privs[1], key_packages[1], welcome, first1.tree()
   };

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -142,7 +142,26 @@ TEST_CASE_FIXTURE(StateTest, "External Join")
 
   // Initialize the second participant as an external joiner
   auto [commit, second0] = State::external_join(
-    fresh_secret(), identity_privs[1], key_packages[1], public_group_state);
+    fresh_secret(), identity_privs[1], key_packages[1], public_group_state, std::nullopt);
+
+  // Creator processes the commit
+  auto first1 = opt::get(first0.handle(commit));
+
+  auto group = std::vector<State>{ first1, second0 };
+  verify_group_functionality(group);
+}
+
+TEST_CASE_FIXTURE(StateTest, "External Join with External Tree")
+{
+  // Initialize the creator's state
+  auto first0 = State{ group_id,          suite,           init_privs[0],
+                       identity_privs[0], key_packages[0], {} };
+  auto public_group_state = first0.public_group_state();
+  auto tree = first0.tree();
+
+  // Initialize the second participant as an external joiner
+  auto [commit, second0] = State::external_join(
+    fresh_secret(), identity_privs[1], key_packages[1], public_group_state, tree);
 
   // Creator processes the commit
   auto first1 = opt::get(first0.handle(commit));


### PR DESCRIPTION
This PR extends the "external tree" logic of #197 to also cover the external join case.  The "import tree" logic is consolidated and extended to make sure the tree matches the required hash/signature criteria.