### PR TITLE
Fix ProtocolVersion enum

### DIFF
--- a/include/mls/core_types.h
+++ b/include/mls/core_types.h
@@ -10,9 +10,14 @@ namespace mls {
 /// Extensions
 ///
 
+// enum {
+//   reserved(0),
+//   mls10(1),
+//   (255)
+// } ProtocolVersion;
 enum class ProtocolVersion : uint8_t
 {
-  mls10 = 0xFF,
+  mls10 = 0x01,
 };
 
 extern const std::array<ProtocolVersion, 1> all_supported_versions;


### PR DESCRIPTION
I couldn't get mlspp to compile, so I'm not sure if this is breaking anything. But I believe this is what causes messages interop to fail 😄 (or at least the first thing that does)