### PR TITLE
Enable FIPS compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"
   add_compile_options(-Wall -pedantic -Wextra -Werror -Wmissing-declarations)
 elseif(MSVC)
   add_compile_options(/W4 /WX)
+
+  # MSVC helpfully recommends safer equivalents for things like
+  # getenv, but they are not portable.
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS)  
 endif()
 
 if (SANITIZERS AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU"))

--- a/lib/hpke/include/hpke/digest.h
+++ b/lib/hpke/include/hpke/digest.h
@@ -28,6 +28,9 @@ struct Digest
 
 private:
   explicit Digest(ID id);
+
+  bytes hmac_for_hkdf_extract(const bytes& key, const bytes& data) const;
+  friend struct HKDF;
 };
 
 } // namespace hpke

--- a/lib/hpke/src/digest.cpp
+++ b/lib/hpke/src/digest.cpp
@@ -87,4 +87,46 @@ Digest::hmac(const bytes& key, const bytes& data) const
   return md;
 }
 
+bytes
+Digest::hmac_for_hkdf_extract(const bytes& key, const bytes& data) const
+{
+  const auto* type = openssl_digest_type(id);
+  auto ctx = make_typed_unique(HMAC_CTX_new());
+
+  // Some FIPS-enabled libraries are overly conservative in their interpretation
+  // of NIST SP 800-131A, which requires HMAC keys to be at least 112 bits long.
+  // That document does not impose that requirement on HKDF, so we disable FIPS
+  // enforcement for purposes of HKDF.
+  //
+  // https://doi.org/10.6028/NIST.SP.800-131Ar2
+  static const auto fips_min_hmac_key_len = 14;
+  auto key_size = static_cast<int>(key.size());
+  if (key_size < fips_min_hmac_key_len) {
+    HMAC_CTX_set_flags(ctx.get(), EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
+  }
+
+  // Guard against sending nullptr to HMAC_Init_ex
+  auto* key_data = key.data();
+  static const auto dummy_key = bytes{ 0 };
+  if (key_data == nullptr) {
+    key_data = dummy_key.data();
+  }
+
+  if (1 != HMAC_Init_ex(ctx.get(), key_data, key_size, type, nullptr)) {
+    throw openssl_error();
+  }
+
+  if (1 != HMAC_Update(ctx.get(), data.data(), data.size())) {
+    throw openssl_error();
+  }
+
+  auto md = bytes(hash_size);
+  unsigned int size = 0;
+  if (1 != HMAC_Final(ctx.get(), md.data(), &size)) {
+    throw openssl_error();
+  }
+
+  return md;
+}
+
 } // namespace hpke

--- a/lib/hpke/src/digest.cpp
+++ b/lib/hpke/src/digest.cpp
@@ -106,10 +106,10 @@ Digest::hmac_for_hkdf_extract(const bytes& key, const bytes& data) const
   }
 
   // Guard against sending nullptr to HMAC_Init_ex
-  auto* key_data = key.data();
-  static const auto dummy_key = bytes{ 0 };
+  const auto* key_data = key.data();
+  const auto non_null_zero_length_key = uint8_t(0);
   if (key_data == nullptr) {
-    key_data = dummy_key.data();
+    key_data = &non_null_zero_length_key;
   }
 
   if (1 != HMAC_Init_ex(ctx.get(), key_data, key_size, type, nullptr)) {

--- a/lib/hpke/src/hkdf.cpp
+++ b/lib/hpke/src/hkdf.cpp
@@ -3,7 +3,6 @@
 
 #include <openssl/err.h>
 #include <openssl/evp.h>
-#include <openssl/hmac.h>
 #include <stdexcept>
 
 namespace hpke {
@@ -57,7 +56,7 @@ HKDF::HKDF(const Digest& digest_in)
 bytes
 HKDF::extract(const bytes& salt, const bytes& ikm) const
 {
-  return digest.hmac(salt, ikm);
+  return digest.hmac_for_hkdf_extract(salt, ikm);
 }
 
 bytes

--- a/lib/hpke/src/openssl_common.cpp
+++ b/lib/hpke/src/openssl_common.cpp
@@ -3,6 +3,7 @@
 #include <openssl/ec.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
+#include <openssl/hmac.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
@@ -27,6 +28,13 @@ void
 typed_delete(EVP_MD_CTX* ptr)
 {
   EVP_MD_CTX_free(ptr);
+}
+
+template<>
+void
+typed_delete(HMAC_CTX* ptr)
+{
+  HMAC_CTX_free(ptr);
 }
 
 template<>

--- a/lib/hpke/test/common.cpp
+++ b/lib/hpke/test/common.cpp
@@ -1,6 +1,18 @@
 #include "common.h"
 #include <stdexcept>
 
+#include <doctest/doctest.h>
+#include <openssl/crypto.h>
+
+void
+ensure_fips_if_required()
+{
+  const auto* require = std::getenv("REQUIRE_FIPS");
+  if (require && FIPS_mode() == 0) {
+    REQUIRE(FIPS_mode_set(1) == 1);
+  }
+}
+
 const Signature&
 select_signature(Signature::ID id)
 {

--- a/lib/hpke/test/common.cpp
+++ b/lib/hpke/test/common.cpp
@@ -8,7 +8,7 @@ void
 ensure_fips_if_required()
 {
   const auto* require = std::getenv("REQUIRE_FIPS");
-  if (require && FIPS_mode() == 0) {
+  if (require != nullptr && FIPS_mode() == 0) {
     REQUIRE(FIPS_mode_set(1) == 1);
   }
 }

--- a/lib/hpke/test/common.h
+++ b/lib/hpke/test/common.h
@@ -5,6 +5,9 @@ using namespace hpke;
 #include <bytes/bytes.h>
 using namespace bytes_ns;
 
+void
+ensure_fips_if_required();
+
 const Signature&
 select_signature(Signature::ID id);
 

--- a/lib/hpke/test/hpke.cpp
+++ b/lib/hpke/test/hpke.cpp
@@ -132,6 +132,8 @@ test_auth_psk_vector(const HPKETestVector& tv)
 
 TEST_CASE("HPKE Test Vectors")
 {
+  ensure_fips_if_required();
+
   for (const auto& tv : test_vectors) {
     switch (tv.mode) {
       case HPKE::Mode::base:
@@ -155,6 +157,8 @@ TEST_CASE("HPKE Test Vectors")
 
 TEST_CASE("HPKE Round-Trip")
 {
+  ensure_fips_if_required();
+
   const std::vector<KEM::ID> kems{ KEM::ID::DHKEM_P256_SHA256,
                                    KEM::ID::DHKEM_P384_SHA384,
                                    KEM::ID::DHKEM_P384_SHA384,

--- a/lib/hpke/test/kdf.cpp
+++ b/lib/hpke/test/kdf.cpp
@@ -5,6 +5,8 @@
 
 TEST_CASE("KDF Known-Answer")
 {
+  ensure_fips_if_required();
+
   struct KnownAnswerTest
   {
     KDF::ID id;

--- a/lib/hpke/test/kem.cpp
+++ b/lib/hpke/test/kem.cpp
@@ -7,6 +7,8 @@
 
 TEST_CASE("KEM round-trip")
 {
+  ensure_fips_if_required();
+
   const std::vector<KEM::ID> ids{ KEM::ID::DHKEM_P256_SHA256,
                                   KEM::ID::DHKEM_P384_SHA384,
                                   KEM::ID::DHKEM_P384_SHA384,

--- a/lib/hpke/test/random.cpp
+++ b/lib/hpke/test/random.cpp
@@ -1,8 +1,12 @@
 #include <doctest/doctest.h>
 #include <hpke/random.h>
 
+#include "common.h"
+
 TEST_CASE("Random bytes")
 {
+  ensure_fips_if_required();
+
   auto size = size_t(128);
   auto test_val = hpke::random_bytes(size);
   CHECK(test_val.size() == size);

--- a/lib/hpke/test/signature.cpp
+++ b/lib/hpke/test/signature.cpp
@@ -6,6 +6,8 @@
 #include <vector>
 TEST_CASE("Signature Known-Answer")
 {
+  ensure_fips_if_required();
+
   struct KnownAnswerTest
   {
     Signature::ID id;
@@ -81,6 +83,8 @@ TEST_CASE("Signature Known-Answer")
 
 TEST_CASE("Signature Round-Trip")
 {
+  ensure_fips_if_required();
+
   const std::vector<Signature::ID> ids{
     Signature::ID::P256_SHA256, Signature::ID::P384_SHA384,
     Signature::ID::P521_SHA512, Signature::ID::Ed25519,


### PR DESCRIPTION
When using FIPS-approved algorithms, MLSpp should be compatible with FIPS-enabled crypto libraries.  This PR enables FIPS testing and works around one minor incompatibility.