### PR TITLE
Disable non-FIPS algorithms in tests when in FIPS mode

### DIFF
--- a/lib/hpke/src/digest.cpp
+++ b/lib/hpke/src/digest.cpp
@@ -101,7 +101,7 @@ Digest::hmac_for_hkdf_extract(const bytes& key, const bytes& data) const
   // https://doi.org/10.6028/NIST.SP.800-131Ar2
   static const auto fips_min_hmac_key_len = 14;
   auto key_size = static_cast<int>(key.size());
-  if (key_size < fips_min_hmac_key_len) {
+  if (FIPS_mode() != 0 && key_size < fips_min_hmac_key_len) {
     HMAC_CTX_set_flags(ctx.get(), EVP_MD_CTX_FLAG_NON_FIPS_ALLOW);
   }
 

--- a/lib/hpke/test/common.cpp
+++ b/lib/hpke/test/common.cpp
@@ -1,4 +1,5 @@
 #include "common.h"
+#include <set>
 #include <stdexcept>
 
 #include <doctest/doctest.h>
@@ -13,21 +14,24 @@ ensure_fips_if_required()
   }
 }
 
-static inline bool
-fips() {
+bool
+fips()
+{
   return FIPS_mode() == 0;
 }
 
-static bool
-fips_disable(AEAD::ID id) {
+bool
+fips_disable(AEAD::ID id)
+{
   static const auto approved = std::set<AEAD::ID>{
     AEAD::ID::CHACHA20_POLY1305,
   };
   return approved.count(id) > 0;
 }
 
-static bool
-fips_disable(Signature::ID id) {
+bool
+fips_disable(Signature::ID id)
+{
   static const auto approved = std::set<Signature::ID>{
     Signature::ID::Ed448,
   };

--- a/lib/hpke/test/common.cpp
+++ b/lib/hpke/test/common.cpp
@@ -17,25 +17,25 @@ ensure_fips_if_required()
 bool
 fips()
 {
-  return FIPS_mode() == 0;
+  return FIPS_mode() != 0;
 }
 
 bool
 fips_disable(AEAD::ID id)
 {
-  static const auto approved = std::set<AEAD::ID>{
+  static const auto disabled = std::set<AEAD::ID>{
     AEAD::ID::CHACHA20_POLY1305,
   };
-  return approved.count(id) > 0;
+  return disabled.count(id) > 0;
 }
 
 bool
 fips_disable(Signature::ID id)
 {
-  static const auto approved = std::set<Signature::ID>{
+  static const auto disabled = std::set<Signature::ID>{
     Signature::ID::Ed448,
   };
-  return approved.count(id) > 0;
+  return disabled.count(id) > 0;
 }
 
 const Signature&

--- a/lib/hpke/test/common.cpp
+++ b/lib/hpke/test/common.cpp
@@ -13,6 +13,27 @@ ensure_fips_if_required()
   }
 }
 
+static inline bool
+fips() {
+  return FIPS_mode() == 0;
+}
+
+static bool
+fips_disable(AEAD::ID id) {
+  static const auto approved = std::set<AEAD::ID>{
+    AEAD::ID::CHACHA20_POLY1305,
+  };
+  return approved.count(id) > 0;
+}
+
+static bool
+fips_disable(Signature::ID id) {
+  static const auto approved = std::set<Signature::ID>{
+    Signature::ID::Ed448,
+  };
+  return approved.count(id) > 0;
+}
+
 const Signature&
 select_signature(Signature::ID id)
 {

--- a/lib/hpke/test/common.h
+++ b/lib/hpke/test/common.h
@@ -8,6 +8,10 @@ using namespace bytes_ns;
 void
 ensure_fips_if_required();
 
+bool fips();
+bool fips_disable(AEAD::ID id);
+bool fips_disable(Signature::ID id);
+
 const Signature&
 select_signature(Signature::ID id);
 

--- a/lib/hpke/test/common.h
+++ b/lib/hpke/test/common.h
@@ -8,9 +8,12 @@ using namespace bytes_ns;
 void
 ensure_fips_if_required();
 
-bool fips();
-bool fips_disable(AEAD::ID id);
-bool fips_disable(Signature::ID id);
+bool
+fips();
+bool
+fips_disable(AEAD::ID id);
+bool
+fips_disable(Signature::ID id);
 
 const Signature&
 select_signature(Signature::ID id);

--- a/lib/hpke/test/hpke.cpp
+++ b/lib/hpke/test/hpke.cpp
@@ -6,28 +6,6 @@
 
 namespace hpke {
 
-static inline bool
-fips() {
-  return FIPS_mode() == 0;
-}
-
-static bool
-fips_disable(AEAD::ID id) {
-  static const auto approved = std::set<AEAD::ID>{
-    AEAD::ID::CHACHA20_POLY1305,
-  };
-  return approved.count(id) > 0;
-}
-
-static bool
-fips_disable(Signature::ID id) {
-  static const auto approved = std::set<Signature::ID>{
-    Signature::ID::Ed448,
-  };
-  return approved.count(id) > 0;
-}
-
-
 struct HPKETest
 {
   static bytes key(const Context& ctx) { return ctx.key; }
@@ -214,7 +192,7 @@ TEST_CASE("HPKE Round-Trip")
 
     for (const auto& kdf_id : kdfs) {
       for (const auto& aead_id : aeads) {
-        if (fips() && fips_disable(tv.aead_id)) {
+        if (fips() && fips_disable(aead_id)) {
           continue;
         }
 

--- a/lib/hpke/test/signature.cpp
+++ b/lib/hpke/test/signature.cpp
@@ -65,6 +65,10 @@ TEST_CASE("Signature Known-Answer")
   };
 
   for (const auto& tc : cases) {
+    if (fips() && fips_disable(tc.id)) {
+      continue;
+    }
+
     const auto& sig = select_signature(tc.id);
 
     auto priv = sig.deserialize_private(tc.priv_serialized);
@@ -94,6 +98,10 @@ TEST_CASE("Signature Round-Trip")
   const auto data = from_hex("00010203");
 
   for (const auto& id : ids) {
+    if (fips() && fips_disable(tc.id)) {
+      continue;
+    }
+
     const auto& sig = select_signature(id);
 
     auto priv = std::unique_ptr<Signature::PrivateKey>(nullptr);

--- a/lib/hpke/test/signature.cpp
+++ b/lib/hpke/test/signature.cpp
@@ -98,7 +98,7 @@ TEST_CASE("Signature Round-Trip")
   const auto data = from_hex("00010203");
 
   for (const auto& id : ids) {
-    if (fips() && fips_disable(tc.id)) {
+    if (fips() && fips_disable(id)) {
       continue;
     }
 


### PR DESCRIPTION
This still leaves the algorithms defined, including offering them as supported ciphersuites.  If we want to create a real, hard FIPS mode, we probably need some thing like `#define FIPS`.