### PR TITLE
Make TLS parsing more efficient

### DIFF
--- a/include/mls/credential.h
+++ b/include/mls/credential.h
@@ -112,4 +112,7 @@ namespace tls {
 TLS_VARIANT_MAP(mls::CredentialType, mls::BasicCredential, basic)
 TLS_VARIANT_MAP(mls::CredentialType, mls::X509Credential, x509)
 
+template<>
+size_t size_of(const mls::X509Credential& obj);
+
 } // namespace TLS

--- a/lib/bytes/test/CMakeLists.txt
+++ b/lib/bytes/test/CMakeLists.txt
@@ -13,4 +13,4 @@ target_link_libraries(${TEST_APP_NAME} ${CURRENT_LIB_NAME} doctest::doctest)
 # Enable CTest
 include(doctest)
 enable_testing()
-doctest_discover_tests(${TEST_APP_NAME})
+doctest_discover_tests(${TEST_APP_NAME} ADD_LABELS 0)

--- a/lib/hpke/test/CMakeLists.txt
+++ b/lib/hpke/test/CMakeLists.txt
@@ -12,4 +12,4 @@ target_link_libraries(${TEST_APP_NAME} ${CURRENT_LIB_NAME} bytes tls_syntax doct
 
 # Enable CTest
 include(doctest)
-doctest_discover_tests(${TEST_APP_NAME})
+doctest_discover_tests(${TEST_APP_NAME} ADD_LABELS 0)

--- a/lib/mls_vectors/test/CMakeLists.txt
+++ b/lib/mls_vectors/test/CMakeLists.txt
@@ -12,4 +12,4 @@ target_link_libraries(${TEST_APP_NAME} ${CURRENT_LIB_NAME} bytes tls_syntax doct
 
 # Enable CTest
 include(doctest)
-doctest_discover_tests(${TEST_APP_NAME})
+doctest_discover_tests(${TEST_APP_NAME} ADD_LABELS 0)

--- a/lib/tls_syntax/include/tls/tls_syntax.h
+++ b/lib/tls_syntax/include/tls/tls_syntax.h
@@ -380,16 +380,30 @@ struct vector
     // NB: This requires that T be default-constructible
     istream r;
     r._buffer = input_bytes(str._buffer.data(), size);
-    while (r._buffer.size() > 0) {
-      data.emplace_back();
-      r >> data.back();
-    }
+    read_all(r, data);
 
     // Truncate the primary buffer
     str._buffer.remove_prefix(size);
 
     return str;
   }
+
+  private:
+  template<typename T>
+  static void read_all(istream& str, std::vector<T>& data)
+  {
+    while (!str._buffer.empty()) {
+      data.emplace_back();
+      str >> data.back();
+    }
+  }
+
+  template<>
+  static void read_all(istream& str, std::vector<uint8_t>& data)
+  {
+    data.insert(data.end(), str._buffer.begin(), str._buffer.end());
+  }
+
 };
 
 // Variant encoding

--- a/lib/tls_syntax/src/tls_syntax.cpp
+++ b/lib/tls_syntax/src/tls_syntax.cpp
@@ -15,8 +15,12 @@ ostream::write_raw(const std::vector<uint8_t>& bytes)
 ostream&
 ostream::write_uint(uint64_t value, int length)
 {
-  for (int i = length - 1; i >= 0; --i) {
-    _buffer.push_back(static_cast<uint8_t>(value >> unsigned(8 * i)));
+  auto prev_size = _buffer.size();
+  _buffer.resize(prev_size + length);
+
+  for (int i = 0; i < length; i++) {
+    auto shift = 8 * (length - i  - 1);
+    _buffer[prev_size + i] = static_cast<uint8_t>(value >> shift);
   }
   return *this;
 }

--- a/lib/tls_syntax/src/tls_syntax.cpp
+++ b/lib/tls_syntax/src/tls_syntax.cpp
@@ -63,8 +63,8 @@ istream::next()
     throw ReadError("Attempt to read from empty buffer");
   }
 
-  uint8_t value = _buffer.back();
-  _buffer.pop_back();
+  uint8_t value = _buffer.at(0);
+  _buffer.remove_prefix(1);
   return value;
 }
 

--- a/lib/tls_syntax/test/CMakeLists.txt
+++ b/lib/tls_syntax/test/CMakeLists.txt
@@ -12,4 +12,4 @@ target_link_libraries(${TEST_APP_NAME} ${CURRENT_LIB_NAME} bytes doctest::doctes
 
 # Enable CTest
 include(doctest)
-doctest_discover_tests(${TEST_APP_NAME})
+doctest_discover_tests(${TEST_APP_NAME} ADD_LABELS 0)

--- a/lib/tls_syntax/test/tls_syntax.cpp
+++ b/lib/tls_syntax/test/tls_syntax.cpp
@@ -82,9 +82,6 @@ protected:
 
   const IntType val_enum = IntType::uint8;
   const bytes enc_enum = from_hex("aaaa");
-
-  const tls::opaque<2> val_opaque{ from_hex("bbbb") };
-  const bytes enc_opaque = from_hex("0002bbbb");
 };
 
 template<typename T>
@@ -114,7 +111,6 @@ TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS ostream")
   ostream_test(val_optional, enc_optional);
   ostream_test(val_optional_null, enc_optional_null);
   ostream_test(val_enum, enc_enum);
-  ostream_test(val_opaque, enc_opaque);
 }
 
 template<typename T>
@@ -158,9 +154,6 @@ TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS istream")
 
   IntType data_enum;
   istream_test(val_enum, data_enum, enc_enum);
-
-  tls::opaque<2> data_opaque;
-  istream_test(val_opaque, data_opaque, enc_opaque);
 }
 
 TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS abbreviations")

--- a/lib/tls_syntax/test/tls_syntax.cpp
+++ b/lib/tls_syntax/test/tls_syntax.cpp
@@ -86,21 +86,19 @@ protected:
 
 template<typename T>
 void
-ostream_test(T val, const std::vector<uint8_t>& enc)
+ostream_test(const T& val, const std::vector<uint8_t>& enc)
 {
-  tls::ostream w;
-  w << val;
-  REQUIRE(w.bytes() == enc);
-  REQUIRE(w.size() == enc.size());
-  REQUIRE(w.size() == tls::size_of(val));
+  auto sample = tls::marshal(val);
+  REQUIRE(sample == enc);
 }
 
 TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS ostream")
 {
   bytes answer{ 1, 2, 3, 4 };
-  tls::ostream w;
+  bytes sample(answer.size());
+  tls::ostream w(sample);
   w.write_raw(answer);
-  REQUIRE(w.bytes() == answer);
+  REQUIRE(sample == answer);
 
   ostream_test(val_bool, enc_bool);
   ostream_test(val_uint8, enc_uint8);
@@ -116,63 +114,24 @@ TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS ostream")
 
 template<typename T>
 void
-istream_test(T val, T& data, const std::vector<uint8_t>& enc)
+istream_test(const T& val, const std::vector<uint8_t>& enc)
 {
-  tls::istream r(enc);
-  r >> data;
+  auto data = tls::get<T>(enc);
   REQUIRE(data == val);
-  REQUIRE(r.empty());
 }
 
 TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS istream")
 {
-  bool data_bool = false;
-  istream_test(val_bool, data_bool, enc_bool);
-
-  uint8_t data_uint8 = 0;
-  istream_test(val_uint8, data_uint8, enc_uint8);
-
-  uint16_t data_uint16 = 0;
-  istream_test(val_uint16, data_uint16, enc_uint16);
-
-  uint32_t data_uint32 = 0;
-  istream_test(val_uint32, data_uint32, enc_uint32);
-
-  uint64_t data_uint64 = 0;
-  istream_test(val_uint64, data_uint64, enc_uint64);
-
-  std::array<uint16_t, 4> data_array = { 0, 0, 0, 0 };
-  istream_test(val_array, data_array, enc_array);
-
-  ExampleStruct data_struct;
-  istream_test(val_struct, data_struct, enc_struct);
-
-  std::optional<ExampleStruct> data_optional;
-  istream_test(val_optional, data_optional, enc_optional);
-
-  std::optional<ExampleStruct> data_optional_null;
-  istream_test(val_optional_null, data_optional_null, enc_optional_null);
-
-  IntType data_enum;
-  istream_test(val_enum, data_enum, enc_enum);
-}
-
-TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS abbreviations")
-{
-  ExampleStruct val_in = val_struct;
-
-  tls::ostream w;
-  w << val_struct;
-  auto streamed = w.bytes();
-  auto marshaled = tls::marshal(val_struct);
-  REQUIRE(streamed == marshaled);
-
-  ExampleStruct val_out1;
-  tls::unmarshal(marshaled, val_out1);
-  REQUIRE(val_in == val_out1);
-
-  auto val_out2 = tls::get<ExampleStruct>(marshaled);
-  REQUIRE(val_in == val_out2);
+  istream_test(val_bool, enc_bool);
+  istream_test(val_uint8, enc_uint8);
+  istream_test(val_uint16, enc_uint16);
+  istream_test(val_uint32, enc_uint32);
+  istream_test(val_uint64, enc_uint64);
+  istream_test(val_array, enc_array);
+  istream_test(val_struct, enc_struct);
+  istream_test(val_optional, enc_optional);
+  istream_test(val_optional_null, enc_optional_null);
+  istream_test(val_enum, enc_enum);
 }
 
 // TODO(rlb@ipv.sx) Test failure cases

--- a/lib/tls_syntax/test/tls_syntax.cpp
+++ b/lib/tls_syntax/test/tls_syntax.cpp
@@ -20,6 +20,20 @@ TLS_VARIANT_MAP(IntType, uint16_t, uint16)
 } // namespace tls
 
 // A struct to test struct encoding and traits
+struct InnerStruct
+{
+  uint8_t a;
+
+  TLS_SERIALIZABLE(a)
+  TLS_TRAITS(tls::pass)
+};
+
+static bool
+operator==(const InnerStruct& lhs, const InnerStruct& rhs)
+{
+  return (lhs.a == rhs.a);
+}
+
 struct ExampleStruct
 {
   uint16_t a{ 0 };
@@ -27,19 +41,21 @@ struct ExampleStruct
   std::optional<uint8_t> c;
   std::vector<uint8_t> d;
   tls::var::variant<uint8_t, uint16_t> e;
+  InnerStruct f;
 
-  TLS_SERIALIZABLE(a, b, c, d, e)
+  TLS_SERIALIZABLE(a, b, c, d, e, f)
   TLS_TRAITS(tls::pass,
              tls::pass,
              tls::pass,
              tls::vector<2>,
-             tls::variant<IntType>)
+             tls::variant<IntType>,
+             tls::pass)
 };
 
 static bool
 operator==(const ExampleStruct& lhs, const ExampleStruct& rhs)
 {
-  return (lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c);
+  return (lhs.a == rhs.a) && (lhs.b == rhs.b) && (lhs.c == rhs.c) && (lhs.d == rhs.d) && (lhs.e == rhs.e) && (lhs.f == rhs.f);
 }
 
 // Known-answer tests
@@ -70,9 +86,10 @@ protected:
     { uint8_t(0x66) },
     { 0x77, 0x88 },
     { uint16_t(0x9999) },
+    { 0xaa },
   };
   const bytes enc_struct =
-    from_hex("111122222222333333334444444455555555016600027788BBBB9999");
+    from_hex("111122222222333333334444444455555555016600027788BBBB9999aa");
 
   const std::optional<ExampleStruct> val_optional{ val_struct };
   const bytes enc_optional = from_hex("01") + enc_struct;

--- a/lib/tls_syntax/test/tls_syntax.cpp
+++ b/lib/tls_syntax/test/tls_syntax.cpp
@@ -92,6 +92,7 @@ ostream_test(T val, const std::vector<uint8_t>& enc)
   w << val;
   REQUIRE(w.bytes() == enc);
   REQUIRE(w.size() == enc.size());
+  REQUIRE(w.size() == tls::size_of(val));
 }
 
 TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS ostream")

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -71,7 +71,7 @@ ExtensionList::for_group() const
 bytes
 ParentNode::hash(CipherSuite suite) const
 {
-  return suite.digest().hash(tls::marshal(this));
+  return suite.digest().hash(tls::marshal(*this));
 }
 
 KeyPackage::KeyPackage()
@@ -165,9 +165,7 @@ KeyPackage::verify() const
 bytes
 KeyPackage::to_be_signed() const
 {
-  tls::ostream out;
-  out << version << cipher_suite << init_key << credential;
-  return out.bytes();
+  return tls::marshal(version, cipher_suite, init_key, credential);
 }
 
 bool

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -152,3 +152,14 @@ Credential::x509(const std::vector<bytes>& der_chain)
 }
 
 } // namespace mls
+
+namespace tls {
+
+template<>
+size_t
+size_of(const mls::X509Credential& obj)
+{
+  return vector<4>::size_of(obj.der_chain);
+}
+
+} // namespace tls

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,4 +14,4 @@ target_link_libraries(${TEST_APP_NAME} ${LIB_NAME}
 
 # Enable CTest
 include(doctest)
-doctest_discover_tests(${TEST_APP_NAME})
+doctest_discover_tests(${TEST_APP_NAME} ADD_LABELS 0)


### PR DESCRIPTION
This PR attempts to remove unnecessary copies / allocations in the TLS serialization logic.  The intent is to make parsing faster, but it's not immediately clear whether we actually achieve that objective.  The time of `make test-all` is pretty much the same on my machine, maybe even a little higher.  And since this adds some complexity for consumers, it might not be worth doing.