### PR TITLE
Get interop client running again

### DIFF
--- a/cmd/interop/src/mls_client_impl.cpp
+++ b/cmd/interop/src/mls_client_impl.cpp
@@ -441,7 +441,7 @@ MLSClientImpl::join_group(const JoinGroupRequest* request,
   auto welcome = tls::get<mls::Welcome>(welcome_data);
 
   auto state =
-    mls::State(join->init_priv, join->sig_priv, join->key_package, welcome);
+    mls::State(join->init_priv, join->sig_priv, join->key_package, welcome, std::nullopt);
   auto state_id = store_state(std::move(state), request->encrypt_handshake());
 
   response->set_state_id(state_id);
@@ -463,7 +463,7 @@ MLSClientImpl::external_join(const ExternalJoinRequest* request,
 
   auto leaf_secret = mls::random_bytes(pgs.cipher_suite.secret_size());
   auto [commit, state] =
-    mls::State::external_join(leaf_secret, sig_priv, kp, pgs);
+    mls::State::external_join(leaf_secret, sig_priv, kp, pgs, std::nullopt);
   auto commit_data = tls::marshal(commit);
   auto state_id = store_state(std::move(state), request->encrypt_handshake());
 
@@ -579,7 +579,7 @@ MLSClientImpl::commit(CachedState& entry,
   auto leaf_secret =
     mls::random_bytes(entry.state.cipher_suite().secret_size());
   auto [commit, welcome, next] =
-    entry.state.commit(leaf_secret, inline_proposals);
+    entry.state.commit(leaf_secret, mls::CommitOpts{inline_proposals, true});
 
   auto next_id = store_state(std::move(next), entry.encrypt_handshake);
 

--- a/cmd/interop/src/mls_client_impl.cpp
+++ b/cmd/interop/src/mls_client_impl.cpp
@@ -440,8 +440,8 @@ MLSClientImpl::join_group(const JoinGroupRequest* request,
   auto welcome_data = string_to_bytes(request->welcome());
   auto welcome = tls::get<mls::Welcome>(welcome_data);
 
-  auto state =
-    mls::State(join->init_priv, join->sig_priv, join->key_package, welcome, std::nullopt);
+  auto state = mls::State(
+    join->init_priv, join->sig_priv, join->key_package, welcome, std::nullopt);
   auto state_id = store_state(std::move(state), request->encrypt_handshake());
 
   response->set_state_id(state_id);
@@ -579,7 +579,7 @@ MLSClientImpl::commit(CachedState& entry,
   auto leaf_secret =
     mls::random_bytes(entry.state.cipher_suite().secret_size());
   auto [commit, welcome, next] =
-    entry.state.commit(leaf_secret, mls::CommitOpts{inline_proposals, true});
+    entry.state.commit(leaf_secret, mls::CommitOpts{ inline_proposals, true });
 
   auto next_id = store_state(std::move(next), entry.encrypt_handshake);
 


### PR DESCRIPTION
The interop test harness was broken by the API change in #198, and because we don't have CI build the interop test harness, we did not detect the failure.  This PR updates the test harness to build against the new API.  I have filed #218 for CI changes.