### PR TITLE
Interop fixes for missing values

### DIFF
--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -83,8 +83,9 @@ struct BranchPSK
 struct PreSharedKeyID
 {
   var::variant<ExternalPSK, ReInitPSK, BranchPSK> content;
-  TLS_SERIALIZABLE(content)
-  TLS_TRAITS(tls::variant<PSKType>)
+  bytes psk_nonce;
+  TLS_SERIALIZABLE(content, psk_nonce)
+  TLS_TRAITS(tls::variant<PSKType>, tls::vector<1>)
 };
 
 struct PreSharedKeys

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -109,7 +109,6 @@ struct TreeKEMPrivateKey
 
 private:
   void implant(NodeIndex start, LeafCount size, const bytes& path_secret);
-  bytes path_step(const bytes& path_secret) const;
 };
 
 struct TreeKEMPublicKey

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -670,6 +670,8 @@ MessagesTestVector::create()
   auto hpke_ct = HPKECiphertext{ opaque, opaque };
   auto sig_priv = SignaturePrivateKey::generate(suite);
 
+  auto psk_nonce = random_bytes(suite.secret_size());
+
   // KeyPackage and extensions
   auto cred = Credential::basic(user_id, suite, sig_priv.public_key);
   auto key_package =
@@ -689,8 +691,8 @@ MessagesTestVector::create()
   auto group_secrets = GroupSecrets{ opaque,
                                      { { opaque } },
                                      PreSharedKeys{ {
-                                       { psk_id },
-                                       { psk_id },
+                                       { psk_id, psk_nonce },
+                                       { psk_id, psk_nonce },
                                      } } };
   auto welcome = Welcome{ suite, opaque, opaque, group_info };
   welcome.encrypt(key_package, opaque);
@@ -704,7 +706,7 @@ MessagesTestVector::create()
   auto add = Add{ key_package };
   auto update = Update{ key_package };
   auto remove = Remove{ index };
-  auto pre_shared_key = PreSharedKey{ psk_id };
+  auto pre_shared_key = PreSharedKey{ psk_id, psk_nonce };
   auto reinit = ReInit{ group_id, version, suite, {} };
   auto external_init = ExternalInit{ opaque };
   auto app_ack = AppAck{ { { index.val, 0, 5 }, { index.val, 7, 10 } } };

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -125,12 +125,6 @@ TreeKEMPrivateKey::joiner(CipherSuite suite,
   return priv;
 }
 
-bytes
-TreeKEMPrivateKey::path_step(const bytes& path_secret) const
-{
-  return suite.expand_with_label(path_secret, "path", {}, suite.secret_size());
-}
-
 void
 TreeKEMPrivateKey::implant(NodeIndex start,
                            LeafCount size,
@@ -145,7 +139,7 @@ TreeKEMPrivateKey::implant(NodeIndex start,
     private_key_cache.erase(n);
 
     n = tree_math::parent(n, size);
-    secret = path_step(secret);
+    secret = suite.derive_secret(secret, "path");
   }
 
   path_secrets[r] = secret;
@@ -166,7 +160,8 @@ TreeKEMPrivateKey::private_key(NodeIndex n) const
     return std::nullopt;
   }
 
-  return HPKEPrivateKey::derive(suite, i->second);
+  auto node_secret = suite.derive_secret(i->second, "node");
+  return HPKEPrivateKey::derive(suite, node_secret);
 }
 
 bool


### PR DESCRIPTION
Two minor fixes with respect to the draft:
- The PSK encoding was missing a nonce.
- The HPKE key derivation in UpdatePath was missing the separation step. 