### PR TITLE
Re-enable hex encoding on test vectors

### DIFF
--- a/cmd/interop/src/json_details.cpp
+++ b/cmd/interop/src/json_details.cpp
@@ -4,18 +4,20 @@
 /// Bytes
 ///
 
-namespace bytes_ns {
+namespace mls_vectors {
+
 void
-to_json(json& j, const bytes& v)
+to_json(json& j, const HexBytes& v)
 {
-  j = to_hex(v);
+  j = to_hex(v.data);
 }
 
 void
-from_json(const json& j, bytes& v)
+from_json(const json& j, HexBytes& v)
 {
-  v = from_hex(j.get<std::string>());
+  v.data = from_hex(j.get<std::string>());
 }
-} // namespace bytes_ns
+
+} // namespace mls_vectors
 
 // TODO(RLB) Other concrete, non-templated type serializers could be moved here.

--- a/cmd/interop/src/json_details.h
+++ b/cmd/interop/src/json_details.h
@@ -9,12 +9,12 @@ using nlohmann::json;
 /// Serializers for foreign types
 ///
 
-// bytes
-namespace bytes_ns {
+// HexBytes
+namespace mls_vectors {
 void
-to_json(json& j, const bytes& v);
+to_json(json& j, const HexBytes& v);
 void
-from_json(const json& j, bytes& v);
+from_json(const json& j, HexBytes& v);
 }
 
 namespace nlohmann {
@@ -82,10 +82,13 @@ struct adl_serializer<mls::CipherSuite>
 template<typename T>
 struct tls_serializer
 {
-  static void to_json(json& j, const T& v) { j = tls::marshal(v); }
+  static void to_json(json& j, const T& v)
+  {
+    j = mls_vectors::HexBytes(tls::marshal(v));
+  }
   static void from_json(const json& j, T& v)
   {
-    v = tls::get<T>(j.get<bytes>());
+    v = tls::get<T>(j.get<mls_vectors::HexBytes>());
   }
 };
 

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -52,6 +52,12 @@ operator<<(std::ostream& str, const TreeKEMPublicKey& /* obj */)
   return str << "[TreeKEMPublicKey]";
 }
 
+bool
+operator==(const bytes& b, const HexBytes& hb)
+{
+  return b == hb.data;
+}
+
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define VERIFY(label, test)                                                    \
   if (!(test)) {                                                               \
@@ -70,9 +76,9 @@ operator<<(std::ostream& str, const TreeKEMPublicKey& /* obj */)
     return err;                                                                \
   }
 
-template<typename T>
+template<typename T, typename U>
 static std::optional<std::string>
-verify_equal(const std::string& label, const T& actual, const T& expected)
+verify_equal(const std::string& label, const T& actual, const U& expected)
 {
   if (actual == expected) {
     return std::nullopt;


### PR DESCRIPTION
In commit ffc31c5, I introduced a regression that caused `bytes` values to be serialized as JSON arrays of integers as opposed to hex-encoded strings.  This was due to the compiler on Linux complaining about a template for `std::vector<uint8_t>` being defined twice -- once with the JSON array serializer and once with the hex string serializer.  To avoid that problem and still get hex, this PR wraps `bytes` in a fairly transparent `HexBytes` wrapper.