### PR TITLE
Consistency with structs in the spec

### DIFF
--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -508,6 +508,16 @@ struct MLSPlaintextTBS
              tls::variant<ContentType>)
 };
 
+struct MLSPlaintextTBM
+{
+  const MLSPlaintextTBS& tbs;
+  const bytes& signature;
+  const std::optional<MAC>& confirmation_tag;
+
+  TLS_SERIALIZABLE(tbs, signature, confirmation_tag)
+  TLS_TRAITS(tls::pass, tls::vector<2>, tls::pass)
+};
+
 struct MLSPlaintext
 {
   bytes group_id;

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -461,6 +461,8 @@ struct MLSPlaintext
   epoch_t epoch;
   Sender sender;
   bytes authenticated_data;
+
+  ContentType content_type;
   var::variant<ApplicationData, Proposal, Commit> content;
 
   bytes signature;
@@ -486,7 +488,7 @@ struct MLSPlaintext
   MLSPlaintext(bytes group_id, epoch_t epoch, Sender sender, Proposal proposal);
   MLSPlaintext(bytes group_id, epoch_t epoch, Sender sender, Commit commit);
 
-  ContentType content_type() const;
+  ContentType infer_content_type() const;
 
   bytes to_be_signed(const GroupContext& context) const;
   void sign(const CipherSuite& suite,
@@ -508,6 +510,7 @@ struct MLSPlaintext
                    epoch,
                    sender,
                    authenticated_data,
+                   content_type,
                    content,
                    signature,
                    confirmation_tag,
@@ -516,6 +519,7 @@ struct MLSPlaintext
              tls::pass,
              tls::pass,
              tls::vector<4>,
+             tls::pass,
              tls::variant<ContentType>,
              tls::vector<2>,
              tls::pass,

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -539,8 +539,8 @@ struct MLSPlaintext
   MLSPlaintext(bytes group_id,
                epoch_t epoch,
                Sender sender,
-               ContentType content_type,
                bytes authenticated_data,
+               ContentType content_type,
                const bytes& content);
 
   // Constructors for encrypting
@@ -592,6 +592,47 @@ private:
   // Not part of the struct, an indicator of whether this MLSPlaintext was
   // constructed from an MLSCiphertext
   bool decrypted;
+};
+
+// struct {
+//     select (MLSCiphertext.content_type) {
+//         case application:
+//           opaque application_data<0..2^32-1>;
+//         case proposal:
+//           Proposal proposal;
+//         case commit:
+//           Commit commit;
+//     }
+//     opaque signature<0..2^16-1>;
+//     optional<MAC> confirmation_tag;
+//     opaque padding<0..2^16-1>;
+// } MLSCiphertextContent;
+struct MLSCiphertextContent
+{
+  const var::variant<ApplicationData, Proposal, Commit>& content;
+  const bytes& signature;
+  const std::optional<MAC>& confirmation_tag;
+  const bytes& padding;
+};
+
+tls::ostream&
+operator<<(tls::ostream& str, const MLSCiphertextContent& ct);
+
+// struct {
+//     opaque group_id<0..255>;
+//     uint64 epoch;
+//     ContentType content_type;
+//     opaque authenticated_data<0..2^32-1>;
+// } MLSCiphertextContentAAD;
+struct MLSCiphertextContentAAD
+{
+  const bytes& group_id;
+  const epoch_t epoch;
+  const ContentType content_type;
+  const bytes& authenticated_data;
+
+  TLS_SERIALIZABLE(group_id, epoch, content_type, authenticated_data)
+  TLS_TRAITS(tls::vector<1>, tls::pass, tls::pass, tls::vector<4>)
 };
 
 // struct {

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -594,6 +594,42 @@ private:
   bool decrypted;
 };
 
+struct MLSPlaintextCommitContent
+{
+  const bytes& group_id;
+  const epoch_t& epoch;
+  const Sender& sender;
+  const bytes& authenticated_data;
+
+  const ContentType content_type{ ContentType::commit };
+  const Commit& commit;
+
+  const bytes& signature;
+
+  TLS_SERIALIZABLE(group_id,
+                   epoch,
+                   sender,
+                   authenticated_data,
+                   content_type,
+                   commit,
+                   signature)
+  TLS_TRAITS(tls::vector<1>,
+             tls::pass,
+             tls::pass,
+             tls::vector<4>,
+             tls::pass,
+             tls::pass,
+             tls::vector<2>)
+};
+
+struct MLSPlaintextCommitAuthData
+{
+  const std::optional<MAC>& confirmation_tag;
+
+  TLS_SERIALIZABLE(confirmation_tag)
+  TLS_TRAITS(tls::pass)
+};
+
 // struct {
 //     select (MLSCiphertext.content_type) {
 //         case application:

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -10,33 +10,6 @@
 
 namespace mls {
 
-// struct {
-//     opaque group_id<0..255>;
-//     uint64 epoch;
-//     opaque tree_hash<0..255>;
-//     opaque confirmed_transcript_hash<0..255>;
-//     Extension extensions<0..2^16-1>;
-// } GroupContext;
-struct GroupContext
-{
-  bytes group_id;
-  epoch_t epoch;
-  bytes tree_hash;
-  bytes confirmed_transcript_hash;
-  ExtensionList extensions;
-
-  TLS_SERIALIZABLE(group_id,
-                   epoch,
-                   tree_hash,
-                   confirmed_transcript_hash,
-                   extensions)
-  TLS_TRAITS(tls::vector<1>,
-             tls::pass,
-             tls::vector<1>,
-             tls::vector<1>,
-             tls::pass)
-};
-
 // Index into the session roster
 struct RosterIndex : public UInt32
 {

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -326,9 +326,8 @@ GroupKeySource::encrypt(LeafIndex index,
   // Encrypt the content
   // XXX(rlb@ipv.sx): Apply padding?
   auto content = pt.marshal_content(0);
-  auto content_type_val = pt.content_type();
   auto content_aad = tls::marshal(MLSCiphertextContentAAD{
-    pt.group_id, pt.epoch, content_type_val, pt.authenticated_data });
+    pt.group_id, pt.epoch, pt.content_type, pt.authenticated_data });
 
   auto reuse_guard = new_reuse_guard();
   apply_reuse_guard(reuse_guard, content_keys.nonce);
@@ -343,7 +342,7 @@ GroupKeySource::encrypt(LeafIndex index,
   auto sender_data_keys =
     KeyScheduleEpoch::sender_data_keys(suite, sender_data_secret, content_ct);
   auto sender_data_aad =
-    tls::marshal(MLSSenderDataAAD{ pt.group_id, pt.epoch, content_type_val });
+    tls::marshal(MLSSenderDataAAD{ pt.group_id, pt.epoch, pt.content_type });
 
   auto encrypted_sender_data = suite.hpke().aead.seal(
     sender_data_keys.key, sender_data_keys.nonce, sender_data_aad, sender_data);
@@ -352,7 +351,7 @@ GroupKeySource::encrypt(LeafIndex index,
   MLSCiphertext ct;
   ct.group_id = pt.group_id;
   ct.epoch = pt.epoch;
-  ct.content_type = content_type_val;
+  ct.content_type = pt.content_type;
   ct.encrypted_sender_data = encrypted_sender_data;
   ct.authenticated_data = pt.authenticated_data;
   ct.ciphertext = content_ct;

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -391,10 +391,15 @@ MLSPlaintext::verify(const CipherSuite& suite,
 bytes
 MLSPlaintext::membership_tag_input(const GroupContext& context) const
 {
-  tls::ostream w;
-  tls::vector<2>::encode(w, signature);
-  w << confirmation_tag;
-  return to_be_signed(context) + w.bytes();
+  return tls::marshal(MLSPlaintextTBM{ MLSPlaintextTBS{ context,
+                                                        group_id,
+                                                        epoch,
+                                                        sender,
+                                                        authenticated_data,
+                                                        content_type,
+                                                        content },
+                                       signature,
+                                       confirmation_tag });
 }
 
 bool

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -240,6 +240,7 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
   , epoch(epoch_in)
   , sender(sender_in)
   , authenticated_data(std::move(authenticated_data_in))
+  , content_type(content_type_in)
   , content(ApplicationData())
   , decrypted(true)
 {
@@ -280,6 +281,7 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
   : group_id(std::move(group_id_in))
   , epoch(epoch_in)
   , sender(sender_in)
+  , content_type(ContentType::application)
   , content(std::move(application_data_in))
   , decrypted(false)
 {}
@@ -291,6 +293,7 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
   : group_id(std::move(group_id_in))
   , epoch(epoch_in)
   , sender(sender_in)
+  , content_type(ContentType::proposal)
   , content(std::move(proposal))
   , decrypted(false)
 {}
@@ -302,12 +305,13 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
   : group_id(std::move(group_id_in))
   , epoch(epoch_in)
   , sender(sender_in)
+  , content_type(ContentType::commit)
   , content(std::move(commit))
   , decrypted(false)
 {}
 
 ContentType
-MLSPlaintext::content_type() const
+MLSPlaintext::infer_content_type() const
 {
   static const auto get_content_type = overloaded{
     [](const ApplicationData& /*unused*/) { return ContentType::application; },

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -325,25 +325,19 @@ MLSPlaintext::infer_content_type() const
 bytes
 MLSPlaintext::commit_content() const
 {
-  tls::ostream w;
-  tls::vector<1>::encode(w, group_id);
-  w << epoch << sender;
-  tls::vector<4>::encode(w, authenticated_data);
-  tls::variant<ContentType>::encode(w, content);
-  tls::vector<2>::encode(w, signature);
-  return w.bytes();
+  return tls::marshal(MLSPlaintextCommitContent{ group_id,
+                                                 epoch,
+                                                 sender,
+                                                 authenticated_data,
+                                                 ContentType::commit,
+                                                 var::get<Commit>(content),
+                                                 signature });
 }
 
 bytes
 MLSPlaintext::commit_auth_data() const
 {
-  // XXX(RLB): This construction means that the hashed transcript differs from
-  // the wire transcript by one byte -- the optional indicator on the
-  // confirmation tag is missing.  It's always 0x01, so it shouldn't matter, but
-  // it might be clearer to fix this.
-  //
-  // XXX(RLB): This matches PR#466, not the current spec.
-  return tls::marshal(confirmation_tag);
+  return tls::marshal(MLSPlaintextCommitAuthData{ confirmation_tag });
 }
 
 bytes

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -228,6 +228,7 @@ Proposal::proposal_type() const
 
 MLSPlaintext::MLSPlaintext()
   : epoch(0)
+  , content_type(ContentType::invalid)
   , decrypted(false)
 {}
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -361,13 +361,13 @@ MLSPlaintext::commit_auth_data() const
 bytes
 MLSPlaintext::to_be_signed(const GroupContext& context) const
 {
-  tls::ostream w;
-  w << context;
-  tls::vector<1>::encode(w, group_id);
-  w << epoch << sender;
-  tls::vector<4>::encode(w, authenticated_data);
-  tls::variant<ContentType>::encode(w, content);
-  return w.bytes();
+  return tls::marshal(MLSPlaintextTBS{ context,
+                                       group_id,
+                                       epoch,
+                                       sender,
+                                       authenticated_data,
+                                       content_type,
+                                       content });
 }
 
 void


### PR DESCRIPTION
Mainly cosmetic changes:
* `MLSPlaintext` was missing the `content_type` field
* Explicit structs to match the spec when serialising:
  * `MLSPlaintextTBS`, `MLSPlaintextTBM`
  * `MLSCiphertextContent`
  * `MLSPlaintextCommitContent`, `MLSPlaintextCommitAuthData` 
* Draft PR [#466](https://github.com/mlswg/mls-protocol/pull/466) was resolved in the meantime