### PR TITLE
More OpenMLS interop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ${BUILD_DIR}: CMakeLists.txt test/CMakeLists.txt
 dev:
 	# Only enable testing, not clang-tidy/sanitizers; the latter make the build
 	# too slow, and we can run them in CI
-	cmake -B${BUILD_DIR} -DTESTING=ON .
+	cmake -B${BUILD_DIR} -DTESTING=ON -DCMAKE_BUILD_TYPE=Debug .
 
 test: ${BUILD_DIR} test/*
 	cmake --build ${BUILD_DIR} --target mlspp_test

--- a/cmd/interop/Makefile
+++ b/cmd/interop/Makefile
@@ -6,7 +6,7 @@ APP_NAME=mlspp_client
 all: ${BUILD_DIR}/${APP_NAME}
 
 ${BUILD_DIR}:
-	cmake -B${BUILD_DIR} .
+	cmake -B${BUILD_DIR} -DCMAKE_BUILD_TYPE=Debug .
 
 ${BUILD_DIR}/${APP_NAME}: ${BUILD_DIR} src/*.cpp
 	cmake --build ${BUILD_DIR} --target ${APP_NAME}
@@ -19,5 +19,6 @@ format:
 
 clean: ${BUILD_DIR}
 	cmake --build ${BUILD_DIR} --target clean
+
 cclean:
 	rm -rf ${BUILD_DIR}

--- a/cmd/interop/src/json_details.h
+++ b/cmd/interop/src/json_details.h
@@ -99,6 +99,7 @@ struct tls_serializer
 
 TLS_SERIALIZER(mls::HPKEPublicKey)
 TLS_SERIALIZER(mls::TreeKEMPublicKey)
+TLS_SERIALIZER(mls::Credential)
 TLS_SERIALIZER(mls::MLSPlaintext)
 TLS_SERIALIZER(mls::UpdatePath)
 TLS_SERIALIZER(mls::KeyPackage)
@@ -173,6 +174,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(TranscriptTestVector,
                                    interim_transcript_hash_before,
                                    membership_key,
                                    confirmation_key,
+                                   credential,
                                    commit,
                                    group_context,
                                    confirmed_transcript_hash_after,

--- a/cmd/interop/src/mls_client_impl.cpp
+++ b/cmd/interop/src/mls_client_impl.cpp
@@ -1,8 +1,10 @@
 #include "mls_client_impl.h"
 #include "json_details.h"
+#include <bytes/bytes.h>
 
 using grpc::StatusCode;
 using nlohmann::json;
+using namespace bytes_ns;
 
 static inline std::string
 bytes_to_string(const std::vector<uint8_t>& data)
@@ -265,6 +267,8 @@ uint32_t
 MLSClientImpl::store_state(mls::State&& state, bool encrypt_handshake)
 {
   auto state_id = tls::get<uint32_t>(state.authentication_secret());
+  state_id += state.index().val;
+
   auto entry = CachedState{ std::move(state), encrypt_handshake, {}, {} };
   state_cache.emplace(std::make_pair(state_id, std::move(entry)));
   return state_id;

--- a/include/mls/core_types.h
+++ b/include/mls/core_types.h
@@ -130,13 +130,13 @@ struct ParentHashExtension
 struct ParentNode
 {
   HPKEPublicKey public_key;
-  std::vector<LeafIndex> unmerged_leaves;
   bytes parent_hash;
+  std::vector<LeafIndex> unmerged_leaves;
 
   bytes hash(CipherSuite suite) const;
 
-  TLS_SERIALIZABLE(public_key, unmerged_leaves, parent_hash)
-  TLS_TRAITS(tls::pass, tls::vector<4>, tls::vector<1>)
+  TLS_SERIALIZABLE(public_key, parent_hash, unmerged_leaves)
+  TLS_TRAITS(tls::pass, tls::vector<1>, tls::vector<4>)
 };
 
 // struct {

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -189,7 +189,8 @@ protected:
   // transition
   MLSPlaintext ratchet_and_sign(const Sender& sender,
                                 const Commit& op,
-                                const bytes& update_secret,
+                                const bytes& commit_secret,
+                                const bytes& psk_secret,
                                 const std::optional<bytes>& force_init_secret,
                                 const GroupContext& prev_ctx);
 
@@ -220,6 +221,7 @@ protected:
 
   // Derive and set the secrets for an epoch, given some new entropy
   void update_epoch_secrets(const bytes& commit_secret,
+                            const bytes& psk_secret,
                             const std::optional<bytes>& force_init_secret);
 
   // Signature verification over a handshake message

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -191,7 +191,7 @@ protected:
   MLSPlaintext ratchet_and_sign(const Sender& sender,
                                 const Commit& op,
                                 const bytes& commit_secret,
-                                const bytes& psk_secret,
+                                const std::vector<PSKWithSecret>& psks,
                                 const std::optional<bytes>& force_init_secret,
                                 bool encrypt_handshake,
                                 const GroupContext& prev_ctx);
@@ -223,7 +223,7 @@ protected:
 
   // Derive and set the secrets for an epoch, given some new entropy
   void update_epoch_secrets(const bytes& commit_secret,
-                            const bytes& psk_secret,
+                            const std::vector<PSKWithSecret>& psks,
                             const std::optional<bytes>& force_init_secret);
 
   // Signature verification over a handshake message

--- a/lib/hpke/src/hpke.cpp
+++ b/lib/hpke/src/hpke.cpp
@@ -10,6 +10,8 @@
 #include <stdexcept>
 #include <string>
 
+#include <iostream>
+
 namespace hpke {
 
 using namespace bytes_ns::operators;
@@ -316,6 +318,8 @@ ReceiverContext::ReceiverContext(Context&& c)
 std::optional<bytes>
 ReceiverContext::open(const bytes& aad, const bytes& ct)
 {
+  std::cout << "--- open aad=[" << to_hex(aad) << "] ct=[" << to_hex(ct) << "]" << std::endl;
+
   auto maybe_pt = aead.open(key, current_nonce(), aad, ct);
   increment_seq();
   return maybe_pt;
@@ -408,6 +412,9 @@ HPKE::setup_base_r(const bytes& enc,
                    const KEM::PrivateKey& skR,
                    const bytes& info) const
 {
+  auto pkRm = kem.serialize(*skR.public_key());
+  std::cout << "--- setup_base_r pkr=[" << to_hex(pkRm) << "] info=[" << to_hex(info) << "]" << std::endl;
+
   auto shared_secret = kem.decap(enc, skR);
   auto ctx =
     key_schedule(Mode::base, shared_secret, info, default_psk, default_psk_id);

--- a/lib/hpke/src/hpke.cpp
+++ b/lib/hpke/src/hpke.cpp
@@ -10,8 +10,6 @@
 #include <stdexcept>
 #include <string>
 
-#include <iostream>
-
 namespace hpke {
 
 using namespace bytes_ns::operators;
@@ -318,9 +316,6 @@ ReceiverContext::ReceiverContext(Context&& c)
 std::optional<bytes>
 ReceiverContext::open(const bytes& aad, const bytes& ct)
 {
-  std::cout << "--- open aad=[" << to_hex(aad) << "] ct=[" << to_hex(ct) << "]"
-            << std::endl;
-
   auto maybe_pt = aead.open(key, current_nonce(), aad, ct);
   increment_seq();
   return maybe_pt;
@@ -414,9 +409,6 @@ HPKE::setup_base_r(const bytes& enc,
                    const bytes& info) const
 {
   auto pkRm = kem.serialize(*skR.public_key());
-  std::cout << "--- setup_base_r pkr=[" << to_hex(pkRm) << "] info=["
-            << to_hex(info) << "]" << std::endl;
-
   auto shared_secret = kem.decap(enc, skR);
   auto ctx =
     key_schedule(Mode::base, shared_secret, info, default_psk, default_psk_id);

--- a/lib/hpke/src/hpke.cpp
+++ b/lib/hpke/src/hpke.cpp
@@ -318,7 +318,8 @@ ReceiverContext::ReceiverContext(Context&& c)
 std::optional<bytes>
 ReceiverContext::open(const bytes& aad, const bytes& ct)
 {
-  std::cout << "--- open aad=[" << to_hex(aad) << "] ct=[" << to_hex(ct) << "]" << std::endl;
+  std::cout << "--- open aad=[" << to_hex(aad) << "] ct=[" << to_hex(ct) << "]"
+            << std::endl;
 
   auto maybe_pt = aead.open(key, current_nonce(), aad, ct);
   increment_seq();
@@ -413,7 +414,8 @@ HPKE::setup_base_r(const bytes& enc,
                    const bytes& info) const
 {
   auto pkRm = kem.serialize(*skR.public_key());
-  std::cout << "--- setup_base_r pkr=[" << to_hex(pkRm) << "] info=[" << to_hex(info) << "]" << std::endl;
+  std::cout << "--- setup_base_r pkr=[" << to_hex(pkRm) << "] info=["
+            << to_hex(info) << "]" << std::endl;
 
   auto shared_secret = kem.decap(enc, skR);
   auto ctx =

--- a/lib/mls_vectors/include/mls_vectors/mls_vectors.h
+++ b/lib/mls_vectors/include/mls_vectors/mls_vectors.h
@@ -138,6 +138,7 @@ struct TranscriptTestVector
 
   HexBytes membership_key;
   HexBytes confirmation_key;
+  mls::Credential credential;
   mls::MLSPlaintext commit;
 
   HexBytes group_context;

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -429,7 +429,8 @@ TranscriptTestVector::create(CipherSuite suite)
   auto ks_epoch = KeyScheduleEpoch(suite, init_secret, ctx);
 
   auto sig_priv = SignaturePrivateKey::generate(suite);
-  auto credential = Credential::basic({ 0, 1, 2, 3 }, suite, sig_priv.public_key);
+  auto credential =
+    Credential::basic({ 0, 1, 2, 3 }, suite, sig_priv.public_key);
   auto commit =
     MLSPlaintext{ group_id, epoch, { SenderType::member, 0 }, Commit{} };
   commit.sign(suite, group_context, sig_priv);
@@ -479,7 +480,8 @@ TranscriptTestVector::verify() const
   VERIFY_EQUAL("interim", transcript.interim, interim_transcript_hash_after);
 
   // Verify that the commit signature is valid
-  auto commit_valid = commit.verify(cipher_suite, group_context_obj, credential.public_key());
+  auto commit_valid =
+    commit.verify(cipher_suite, group_context_obj, credential.public_key());
   VERIFY("commit signature valid", commit_valid);
 
   // Verify the Commit tags
@@ -645,7 +647,8 @@ TreeKEMTestVector::verify() const
                                         leaf_priv,
                                         ancestor,
                                         my_path_secret);
-  VERIFY("private key consistent with tree before", priv.consistent(ratchet_tree_before));
+  VERIFY("private key consistent with tree before",
+         priv.consistent(ratchet_tree_before));
   VERIFY_EQUAL(
     "root secret after add", priv.update_secret, root_secret_after_add);
 

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -508,7 +508,8 @@ new_key_package(CipherSuite suite)
 {
   auto scheme = suite;
   auto init_secret = random_bytes(suite.secret_size());
-  auto init_priv = HPKEPrivateKey::derive(suite, init_secret);
+  auto leaf_node_secret = suite.derive_secret(init_secret, "node");
+  auto init_priv = HPKEPrivateKey::derive(suite, leaf_node_secret);
   auto sig_priv = SignaturePrivateKey::generate(suite);
   auto cred = Credential::basic({ 0, 1, 2, 3 }, scheme, sig_priv.public_key);
   auto kp =
@@ -636,13 +637,15 @@ TreeKEMTestVector::verify() const
   auto ancestor = tree_math::ancestor(my_index, add_sender);
 
   // Establish a TreeKEMPrivate Key
-  auto leaf_priv = HPKEPrivateKey::derive(cipher_suite, my_leaf_secret);
+  auto leaf_node_secret = cipher_suite.derive_secret(my_leaf_secret, "node");
+  auto leaf_priv = HPKEPrivateKey::derive(cipher_suite, leaf_node_secret);
   auto priv = TreeKEMPrivateKey::joiner(cipher_suite,
                                         ratchet_tree_before.size(),
                                         my_index,
                                         leaf_priv,
                                         ancestor,
                                         my_path_secret);
+  VERIFY("private key consistent with tree before", priv.consistent(ratchet_tree_before));
   VERIFY_EQUAL(
     "root secret after add", priv.update_secret, root_secret_after_add);
 

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -691,7 +691,7 @@ MessagesTestVector::create()
   auto key_package =
     KeyPackage{ suite, hpke_pub, cred, sig_priv, std::nullopt };
 
-  auto lifetime = LifetimeExtension{ 0xA0A1A2A3A4A5A6A7, 0xB0B1B2B3B4B5B6B7 };
+  auto lifetime = LifetimeExtension{ 0x0000000000000000, 0xffffffffffffffff };
   auto capabilities = CapabilitiesExtension{ { version },
                                              { suite.cipher_suite() },
                                              { ExtensionType::ratchet_tree } };

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -218,8 +218,10 @@ Welcome::group_info_key_nonce(CipherSuite suite,
   // XXX(RLB): These used to be done with ExpandWithLabel.  Should we do that
   // instead, for better domain separation? (In particular, including "mls10")
   // That is what we do for the sender data key/nonce.
-  auto key = suite.hpke().kdf.expand(welcome_secret, key_label, suite.key_size());
-  auto nonce = suite.hpke().kdf.expand(welcome_secret, nonce_label, suite.nonce_size());
+  auto key =
+    suite.hpke().kdf.expand(welcome_secret, key_label, suite.key_size());
+  auto nonce =
+    suite.hpke().kdf.expand(welcome_secret, nonce_label, suite.nonce_size());
   return { std::move(key), std::move(nonce) };
 }
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -109,7 +109,7 @@ GroupInfo::to_be_signed() const
   w << epoch;
   tls::vector<1>::encode(w, tree_hash);
   tls::vector<1>::encode(w, confirmed_transcript_hash);
-  w << confirmation_tag << signer_index;
+  w << extensions << confirmation_tag << signer_index;
   return w.bytes();
 }
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -389,8 +389,12 @@ State::commit(const bytes& leaf_secret,
   const auto psk_secret = _suite.zero();
 
   // Create the Commit message and advance the transcripts / key schedule
-  auto pt = next.ratchet_and_sign(
-    sender, commit, commit_secret, psk_secret, force_init_secret, group_context());
+  auto pt = next.ratchet_and_sign(sender,
+                                  commit,
+                                  commit_secret,
+                                  psk_secret,
+                                  force_init_secret,
+                                  group_context());
 
   // Complete the GroupInfo and form the Welcome
   auto group_info = GroupInfo{

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -1,5 +1,7 @@
 #include <mls/treekem.h>
 
+#include <iostream> // XXX
+
 namespace mls {
 
 // Utility method used for removing leaves from a resolution
@@ -207,6 +209,8 @@ TreeKEMPrivateKey::decap(LeafIndex from,
                          const UpdatePath& path,
                          const std::vector<LeafIndex>& except)
 {
+  std::cout << "decap with context: [" << to_hex(context) << "]" << std::endl;
+
   // Identify which node in the path secret we will be decrypting
   auto ni = NodeIndex(index);
   auto size = pub.size();
@@ -406,7 +410,7 @@ TreeKEMPublicKey::merge(LeafIndex from, const UpdatePath& path)
     }
 
     node_at(n).node = { ParentNode{
-      path.nodes[i].public_key, {}, parent_hash } };
+      path.nodes[i].public_key, parent_hash, {} } };
   }
 
   clear_hash_path(from);
@@ -540,6 +544,8 @@ TreeKEMPublicKey::encap(LeafIndex from,
                         const std::vector<LeafIndex>& except,
                         const std::optional<KeyPackageOpts>& maybe_opts)
 {
+  std::cout << "encap with context: [" << to_hex(context) << "]" << std::endl;
+
   // Grab information about the sender
   auto& maybe_node = node_at(NodeIndex(from)).node;
   if (!maybe_node) {
@@ -708,7 +714,7 @@ TreeKEMPublicKey::parent_hashes(LeafIndex from, const UpdatePath& path) const
     auto n = dp[i];
     auto s = tree_math::sibling(n, size());
 
-    auto parent_node = ParentNode{ path.nodes[i].public_key, {}, last_hash };
+    auto parent_node = ParentNode{ path.nodes[i].public_key, last_hash, {} };
     last_hash = parent_hash(parent_node, s);
     ph[i] = last_hash;
   }

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -365,20 +365,23 @@ TreeKEMPrivateKey::consistent(const TreeKEMPublicKey& other) const
     private_key(node);
   }
 
-  return std::all_of(private_key_cache.begin(), private_key_cache.end(), [other](const auto& entry) {
-    const auto& [node, priv] = entry;
-    const auto& opt_node = other.node_at(node).node;
-    if (!opt_node) {
-      // It's OK for a TreeKEMPrivateKey to have private keys for nodes that are
-      // blank in the TreeKEMPublicKey.  This will happen traniently during
-      // Commit processing, since proposals will be applied in the public tree
-      // and not in the private tree.
-      return true;
-    }
+  return std::all_of(private_key_cache.begin(),
+                     private_key_cache.end(),
+                     [other](const auto& entry) {
+                       const auto& [node, priv] = entry;
+                       const auto& opt_node = other.node_at(node).node;
+                       if (!opt_node) {
+                         // It's OK for a TreeKEMPrivateKey to have private keys
+                         // for nodes that are blank in the TreeKEMPublicKey.
+                         // This will happen traniently during Commit
+                         // processing, since proposals will be applied in the
+                         // public tree and not in the private tree.
+                         return true;
+                       }
 
-    const auto& pub = opt::get(opt_node).public_key();
-    return priv.public_key == pub;
-  });
+                       const auto& pub = opt::get(opt_node).public_key();
+                       return priv.public_key == pub;
+                     });
 }
 
 ///

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -29,9 +29,9 @@ TEST_CASE_FIXTURE(TreeKEMTest, "ParentNode Equality")
   auto initB = HPKEPrivateKey::generate(suite);
 
   auto nodeA =
-    ParentNode{ initA.public_key, { LeafIndex(1), LeafIndex(2) }, { 3, 4 } };
+    ParentNode{ initA.public_key, { 3, 4 }, { LeafIndex(1), LeafIndex(2) } };
   auto nodeB =
-    ParentNode{ initB.public_key, { LeafIndex(5), LeafIndex(6) }, { 7, 8 } };
+    ParentNode{ initB.public_key, { 7, 8 }, { LeafIndex(5), LeafIndex(6) } };
 
   REQUIRE(nodeA == nodeA);
   REQUIRE(nodeB == nodeB);


### PR DESCRIPTION
Draft PR to collect changes found in interop testing with OpenMLS.  So far:

* Added a `credential` field to the transcript test vector and send a valid signed commit
* Fixed encoding of ParentNode 
* Send an infinite lifetime in messages tests to make OpenMLS's validation logic happy

There will be more changes as we debug TreeKEM tests and protocol scripts.

There is some logging / debug code in here that should be removed before mergin.