### PR TITLE
Signal the intended wire format for MLS messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ${BUILD_DIR}: CMakeLists.txt test/CMakeLists.txt
 dev:
 	# Only enable testing, not clang-tidy/sanitizers; the latter make the build
 	# too slow, and we can run them in CI
-	cmake -B${BUILD_DIR} -DTESTING=ON .
+	cmake -B${BUILD_DIR} -DTESTING=ON -DCMAKE_BUILD_TYPE=Debug .
 
 test: ${BUILD_DIR} test/*
 	cmake --build ${BUILD_DIR} --target mlspp_test

--- a/cmd/interop/src/mls_client_impl.cpp
+++ b/cmd/interop/src/mls_client_impl.cpp
@@ -579,7 +579,7 @@ MLSClientImpl::commit(CachedState& entry,
   auto leaf_secret =
     mls::random_bytes(entry.state.cipher_suite().secret_size());
   auto [commit, welcome, next] =
-    entry.state.commit(leaf_secret, mls::CommitOpts{ inline_proposals, true });
+    entry.state.commit(leaf_secret, mls::CommitOpts{ inline_proposals, true, entry.encrypt_handshake });
 
   auto next_id = store_state(std::move(next), entry.encrypt_handshake);
 

--- a/cmd/interop/src/mls_client_impl.cpp
+++ b/cmd/interop/src/mls_client_impl.cpp
@@ -578,8 +578,9 @@ MLSClientImpl::commit(CachedState& entry,
 
   auto leaf_secret =
     mls::random_bytes(entry.state.cipher_suite().secret_size());
-  auto [commit, welcome, next] =
-    entry.state.commit(leaf_secret, mls::CommitOpts{ inline_proposals, true, entry.encrypt_handshake });
+  auto [commit, welcome, next] = entry.state.commit(
+    leaf_secret,
+    mls::CommitOpts{ inline_proposals, true, entry.encrypt_handshake });
 
   auto next_id = store_state(std::move(next), entry.encrypt_handshake);
 

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -530,11 +530,6 @@ struct MLSPlaintext
              tls::vector<2>,
              tls::pass,
              tls::pass)
-
-private:
-  // Not part of the struct, an indicator of whether this MLSPlaintext was
-  // constructed from an MLSCiphertext
-  bool decrypted;
 };
 
 // struct {

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -430,6 +430,13 @@ struct ApplicationData
 
 struct GroupContext;
 
+enum struct WireFormat : uint8_t
+{
+  reserved = 0,
+  mls_plaintext = 1,
+  mls_ciphertext = 2,
+};
+
 enum struct ContentType : uint8_t
 {
   invalid = 0,
@@ -457,6 +464,7 @@ struct Sender
 
 struct MLSPlaintext
 {
+  WireFormat wire_format;
   bytes group_id;
   epoch_t epoch;
   Sender sender;
@@ -504,7 +512,8 @@ struct MLSPlaintext
   bytes commit_content() const;
   bytes commit_auth_data() const;
 
-  TLS_SERIALIZABLE(group_id,
+  TLS_SERIALIZABLE(wire_format,
+                   group_id,
                    epoch,
                    sender,
                    authenticated_data,
@@ -512,7 +521,8 @@ struct MLSPlaintext
                    signature,
                    confirmation_tag,
                    membership_tag)
-  TLS_TRAITS(tls::vector<1>,
+  TLS_TRAITS(tls::pass,
+             tls::vector<1>,
              tls::pass,
              tls::pass,
              tls::vector<4>,
@@ -537,6 +547,7 @@ private:
 // } MLSCiphertext;
 struct MLSCiphertext
 {
+  WireFormat wire_format;
   bytes group_id;
   epoch_t epoch;
   ContentType content_type;
@@ -544,13 +555,15 @@ struct MLSCiphertext
   bytes encrypted_sender_data;
   bytes ciphertext;
 
-  TLS_SERIALIZABLE(group_id,
+  TLS_SERIALIZABLE(wire_format,
+                   group_id,
                    epoch,
                    content_type,
                    authenticated_data,
                    encrypted_sender_data,
                    ciphertext)
-  TLS_TRAITS(tls::vector<1>,
+  TLS_TRAITS(tls::pass,
+             tls::vector<1>,
              tls::pass,
              tls::pass,
              tls::vector<4>,

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -47,6 +47,7 @@ struct CommitOpts
 {
   std::vector<Proposal> extra_proposals;
   bool inline_tree;
+  bool encrypt_handshake;
 };
 
 class State
@@ -191,6 +192,7 @@ protected:
                                 const Commit& op,
                                 const bytes& update_secret,
                                 const std::optional<bytes>& force_init_secret,
+                                bool encrypt_handshake,
                                 const GroupContext& prev_ctx);
 
   // Create an MLSPlaintext with a signature over some content

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -744,7 +744,7 @@ MessagesTestVector::create()
   pt_commit.membership_tag = mac;
 
   auto ct = MLSCiphertext{
-    group_id, epoch, ContentType::application, opaque, opaque, opaque,
+    WireFormat::mls_ciphertext, group_id, epoch, ContentType::application, opaque, opaque, opaque,
   };
 
   return MessagesTestVector{

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -307,6 +307,10 @@ GroupKeySource::encrypt(LeafIndex index,
                         const bytes& sender_data_secret,
                         const MLSPlaintext& pt)
 {
+  if (pt.wire_format != WireFormat::mls_ciphertext) {
+    throw InvalidParameterError("Encrypt on MLSPlaintext without wire_format signal");
+  }
+
   // Pull from the key schedule
   static const auto get_key_type = overloaded{
     [](const ApplicationData& /*unused*/) {

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -308,7 +308,8 @@ GroupKeySource::encrypt(LeafIndex index,
                         const MLSPlaintext& pt)
 {
   if (pt.wire_format != WireFormat::mls_ciphertext) {
-    throw InvalidParameterError("Encrypt on MLSPlaintext without wire_format signal");
+    throw InvalidParameterError(
+      "Encrypt on MLSPlaintext without wire_format signal");
   }
 
   // Pull from the key schedule
@@ -353,14 +354,15 @@ GroupKeySource::encrypt(LeafIndex index,
     sender_data_keys.key, sender_data_keys.nonce, sender_data_aad, sender_data);
 
   // Assemble the MLSCiphertext
-  MLSCiphertext ct;
-  ct.group_id = pt.group_id;
-  ct.epoch = pt.epoch;
-  ct.content_type = content_type_val;
-  ct.encrypted_sender_data = encrypted_sender_data;
-  ct.authenticated_data = pt.authenticated_data;
-  ct.ciphertext = content_ct;
-  return ct;
+  return MLSCiphertext{
+    WireFormat::mls_ciphertext,
+    pt.group_id,
+    pt.epoch,
+    content_type_val,
+    pt.authenticated_data,
+    encrypted_sender_data,
+    content_ct,
+  };
 }
 
 MLSPlaintext

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -236,7 +236,7 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
                            ContentType content_type_in,
                            bytes authenticated_data_in,
                            const bytes& content_in)
-  : wire_format(WireFormat::mls_ciphertext)
+  : wire_format(WireFormat::mls_ciphertext) // since this is used for decryption
   , group_id(std::move(group_id_in))
   , epoch(epoch_in)
   , sender(sender_in)

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -228,7 +228,6 @@ Proposal::proposal_type() const
 MLSPlaintext::MLSPlaintext()
   : wire_format(WireFormat::mls_plaintext)
   , epoch(0)
-  , decrypted(false)
 {}
 
 MLSPlaintext::MLSPlaintext(bytes group_id_in,
@@ -243,7 +242,6 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
   , sender(sender_in)
   , authenticated_data(std::move(authenticated_data_in))
   , content(ApplicationData())
-  , decrypted(true)
 {
   tls::istream r(content_in);
   switch (content_type_in) {
@@ -279,36 +277,33 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
                            epoch_t epoch_in,
                            Sender sender_in,
                            ApplicationData application_data_in)
-  : wire_format(WireFormat::mls_ciphertext)
+  : wire_format(WireFormat::mls_plaintext)
   , group_id(std::move(group_id_in))
   , epoch(epoch_in)
   , sender(sender_in)
   , content(std::move(application_data_in))
-  , decrypted(false)
 {}
 
 MLSPlaintext::MLSPlaintext(bytes group_id_in,
                            epoch_t epoch_in,
                            Sender sender_in,
                            Proposal proposal)
-  : wire_format(WireFormat::mls_ciphertext)
+  : wire_format(WireFormat::mls_plaintext)
   , group_id(std::move(group_id_in))
   , epoch(epoch_in)
   , sender(sender_in)
   , content(std::move(proposal))
-  , decrypted(false)
 {}
 
 MLSPlaintext::MLSPlaintext(bytes group_id_in,
                            epoch_t epoch_in,
                            Sender sender_in,
                            Commit commit)
-  : wire_format(WireFormat::mls_ciphertext)
+  : wire_format(WireFormat::mls_plaintext)
   , group_id(std::move(group_id_in))
   , epoch(epoch_in)
   , sender(sender_in)
   , content(std::move(commit))
-  , decrypted(false)
 {}
 
 ContentType
@@ -397,7 +392,7 @@ MLSPlaintext::membership_tag_input(const GroupContext& context) const
 bool
 MLSPlaintext::verify_membership_tag(const bytes& tag) const
 {
-  if (decrypted) {
+  if (wire_format == WireFormat::mls_ciphertext) {
     return true;
   }
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1,5 +1,7 @@
 #include <mls/state.h>
 
+#include <iostream>
+
 namespace mls {
 
 ///
@@ -874,6 +876,11 @@ State::encrypt(const MLSPlaintext& pt)
 MLSPlaintext
 State::decrypt(const MLSCiphertext& ct)
 {
+  if (ct.wire_format != WireFormat::mls_ciphertext) {
+    std::cout << "!!! " << int(ct.wire_format) << std::endl;
+    throw InvalidParameterError("Invalid wire format for MLSCiphertext");
+  }
+
   // Verify the epoch
   if (ct.group_id != _group_id) {
     throw InvalidParameterError("Ciphertext not from this group");

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1,7 +1,5 @@
 #include <mls/state.h>
 
-#include <iostream>
-
 namespace mls {
 
 ///
@@ -176,7 +174,7 @@ State::external_join(const bytes& leaf_secret,
 {
   auto initial_state = State(std::move(sig_priv), pgs, tree);
   auto add = initial_state.add_proposal(kp);
-  auto opts = CommitOpts{ { add }, false };
+  auto opts = CommitOpts{ { add }, false, false };
   auto [commit_pt, welcome, state] =
     initial_state.commit(leaf_secret, opts, kp, pgs.external_pub);
   silence_unused(welcome);
@@ -383,8 +381,13 @@ State::commit(const bytes& leaf_secret,
   }
 
   // Create the Commit message and advance the transcripts / key schedule
-  auto pt = next.ratchet_and_sign(
-    sender, commit, update_secret, force_init_secret, group_context());
+  auto encrypt_handshake = opts && opt::get(opts).encrypt_handshake;
+  auto pt = next.ratchet_and_sign(sender,
+                                  commit,
+                                  update_secret,
+                                  force_init_secret,
+                                  encrypt_handshake,
+                                  group_context());
 
   // Complete the GroupInfo and form the Welcome
   auto group_info = GroupInfo{
@@ -424,11 +427,15 @@ State::ratchet_and_sign(const Sender& sender,
                         const Commit& op,
                         const bytes& update_secret,
                         const std::optional<bytes>& force_init_secret,
+                        bool encrypt_handshake,
                         const GroupContext& prev_ctx)
 {
   auto prev_key_schedule = _key_schedule;
 
   auto pt = MLSPlaintext{ _group_id, _epoch, sender, op };
+  if (encrypt_handshake) {
+    pt.wire_format = WireFormat::mls_ciphertext;
+  }
   pt.sign(_suite, prev_ctx, _identity_priv);
 
   _transcript_hash.update_confirmed(pt);
@@ -688,6 +695,7 @@ State::protect(const bytes& pt)
 {
   auto sender = Sender{ SenderType::member, _index.val };
   MLSPlaintext mpt{ _group_id, _epoch, sender, ApplicationData{ pt } };
+  mpt.wire_format = WireFormat::mls_ciphertext;
   mpt.sign(_suite, group_context(), _identity_priv);
   mpt.membership_tag = { _key_schedule.membership_tag(group_context(), mpt) };
   return encrypt(mpt);
@@ -870,14 +878,32 @@ State::authentication_secret() const
 MLSCiphertext
 State::encrypt(const MLSPlaintext& pt)
 {
-  return _keys.encrypt(_index, _key_schedule.sender_data_secret, pt);
+  if ((pt.sender.sender_type != SenderType::member) ||
+      (pt.sender.sender != _index.val)) {
+    throw InvalidParameterError("Cannot encrypt a plaintext from someone else");
+  }
+
+  if (pt.wire_format == WireFormat::mls_ciphertext) {
+    return _keys.encrypt(_index, _key_schedule.sender_data_secret, pt);
+  }
+
+  // If a plaintext has been created without the prior intent to encrypt it,
+  // then it needs to be re-signed.
+  //
+  // XXX(RLB): This is currently true for all MLSPlaintexts generated with the
+  // X_proposal() methods.  There is a trade-off here between API decoupling
+  // (when do you need to know you're going to encrypt?) and the work of
+  // re-signing.
+  auto pt_copy = pt;
+  pt_copy.wire_format = WireFormat::mls_ciphertext;
+  pt_copy.sign(_suite, group_context(), _identity_priv);
+  return _keys.encrypt(_index, _key_schedule.sender_data_secret, pt_copy);
 }
 
 MLSPlaintext
 State::decrypt(const MLSCiphertext& ct)
 {
   if (ct.wire_format != WireFormat::mls_ciphertext) {
-    std::cout << "!!! " << int(ct.wire_format) << std::endl;
     throw InvalidParameterError("Invalid wire format for MLSCiphertext");
   }
 

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -3,6 +3,8 @@
 #include <mls_vectors/mls_vectors.h>
 #include <tls/tls_syntax.h>
 
+#include <iostream>
+
 using namespace mls;
 using namespace mls_vectors;
 
@@ -46,5 +48,10 @@ TEST_CASE("Extensions")
 TEST_CASE("Messages Interop")
 {
   auto tv = MessagesTestVector::create();
-  REQUIRE(tv.verify() == std::nullopt);
+
+  auto result = tv.verify();
+  if (result) {
+    std::cout << opt::get(result) << std::endl;
+  }
+  REQUIRE(result == std::nullopt);
 }

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -85,7 +85,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person")
   // Handle the Add proposal and create a Commit
   auto add = first0.add_proposal(key_packages[1]);
   auto [commit, welcome, first1] =
-    first0.commit(fresh_secret(), CommitOpts{ { add }, true });
+    first0.commit(fresh_secret(), CommitOpts{ { add }, true, false });
   silence_unused(commit);
 
   // Initialize the second participant from the Welcome
@@ -108,7 +108,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with external tree for welcome")
   auto add = first0.add_proposal(key_packages[1]);
   // Don't generate RatchetTree extension
   auto [commit, welcome, first1] =
-    first0.commit(fresh_secret(), CommitOpts{ { add }, false });
+    first0.commit(fresh_secret(), CommitOpts{ { add }, false, false });
   silence_unused(commit);
 
   // Initialize the second participant from the Welcome, pass in the
@@ -211,7 +211,7 @@ TEST_CASE_FIXTURE(StateTest, "SFrame Parameter Negotiation")
   // Add the second member
   auto add = first0.add_proposal(key_packages[1]);
   auto [commit, welcome, first1] =
-    first0.commit(fresh_secret(), CommitOpts{ { add }, true });
+    first0.commit(fresh_secret(), CommitOpts{ { add }, true, false });
   silence_unused(commit);
 
   auto second0 = State{
@@ -249,7 +249,7 @@ TEST_CASE_FIXTURE(StateTest, "Add Multiple Members")
 
   // Create a Commit that adds everybody
   auto [commit, welcome, new_state] =
-    states[0].commit(fresh_secret(), CommitOpts{ adds, true });
+    states[0].commit(fresh_secret(), CommitOpts{ adds, true, false });
   silence_unused(commit);
   states[0] = new_state;
 
@@ -278,7 +278,7 @@ TEST_CASE_FIXTURE(StateTest, "Full Size Group")
 
     auto add = states[sender].add_proposal(key_packages[i]);
     auto [commit, welcome, new_state] =
-      states[sender].commit(fresh_secret(), CommitOpts{ { add }, true });
+      states[sender].commit(fresh_secret(), CommitOpts{ { add }, true, false });
     for (size_t j = 0; j < states.size(); j += 1) {
       if (j == sender) {
         states[j] = new_state;
@@ -319,7 +319,7 @@ protected:
     }
 
     auto [commit, welcome, new_state] =
-      states[0].commit(fresh_secret(), CommitOpts{ adds, true });
+      states[0].commit(fresh_secret(), CommitOpts{ adds, true, false });
     silence_unused(commit);
     states[0] = new_state;
     for (size_t i = 1; i < group_size; i += 1) {
@@ -368,7 +368,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Update Everyone in a Group")
     auto new_leaf = fresh_secret();
     auto update = states[i].update_proposal(new_leaf);
     auto [commit, welcome, new_state] =
-      states[i].commit(new_leaf, CommitOpts{ { update }, true });
+      states[i].commit(new_leaf, CommitOpts{ { update }, true, false });
     silence_unused(welcome);
 
     for (auto& state : states) {
@@ -388,7 +388,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Remove Members from a Group")
   for (int i = static_cast<int>(group_size) - 2; i > 0; i -= 1) {
     auto remove = states[i].remove_proposal(LeafIndex{ uint32_t(i + 1) });
     auto [commit, welcome, new_state] =
-      states[i].commit(fresh_secret(), CommitOpts{ { remove }, true });
+      states[i].commit(fresh_secret(), CommitOpts{ { remove }, true, false });
     silence_unused(welcome);
 
     states.pop_back();
@@ -417,7 +417,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Roster Updates")
   // remove member at position 1
   auto remove_1 = states[0].remove_proposal(RosterIndex{ 1 });
   auto [commit_1, welcome_1, new_state_1] =
-    states[0].commit(fresh_secret(), CommitOpts{ { remove_1 }, true });
+    states[0].commit(fresh_secret(), CommitOpts{ { remove_1 }, true, false });
   silence_unused(welcome_1);
   silence_unused(commit_1);
   // roster should be 0, 2, 3, 4
@@ -432,7 +432,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Roster Updates")
   // remove member at position 2
   auto remove_2 = new_state_1.remove_proposal(RosterIndex{ 2 });
   auto [commit_2, welcome_2, new_state_2] =
-    new_state_1.commit(fresh_secret(), CommitOpts{ { remove_2 }, true });
+    new_state_1.commit(fresh_secret(), CommitOpts{ { remove_2 }, true, false });
   silence_unused(welcome_2);
   // roster should be 0, 2, 4
   expected_creds = std::vector<Credential>{


### PR DESCRIPTION
Corresponds to https://github.com/mlswg/mls-protocol/pull/477

This ended up being a little more invasive than I expected.  The challenge is that you now need to know whether a message is going to be encrypted before you sign it, and in the case of Commits, before you generate the confirmation tag.  So either (1) every API that generates an MLSPlaintext object needs to be extended to indicate the caller's intent to encrypt, or (2) `State::encrypt` needs to re-sign objects.  (The latter doesn't work for Commit because the confirmation tag would need to be recomputed as well.)  In this PR, I have split the difference:

* On the one hand:
    * The CommitOpts struct used in `State::commit()` now has a flag for whether the commit will be encrypted
    * Application data protected with `State::protect()` is always encrypted, so `protect()` always sets the flag.
* On the other hand:
    * The `State::X_proposal()` methods generate MLSPlaintext objects with `wire_format = mls_plaintext`, then `State::encrypt()` re-signs them.

This seems like it avoids a ton of API clutter in the `State::X_proposal()` methods, while avoiding most re-signing.  There may be more elegant solutions.  But this seemed close enough on the API front to facilitate interop testing.