### PR TITLE
Use cascaded KDF instead of concatenation to consolidate PSKs

### DIFF
--- a/cmd/interop/src/json_details.h
+++ b/cmd/interop/src/json_details.h
@@ -140,11 +140,17 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(EncryptionTestVector,
                                    sender_data_info,
                                    leaves)
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(KeyScheduleTestVector::ExternalPSKInfo,
+                                   id,
+                                   nonce,
+                                   secret)
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(KeyScheduleTestVector::Epoch,
                                    tree_hash,
                                    commit_secret,
-                                   psk_secret,
                                    confirmed_transcript_hash,
+                                   external_psks,
+                                   branch_psk_nonce,
+                                   psk_secret,
                                    group_context,
                                    joiner_secret,
                                    welcome_secret,

--- a/cmd/interop/src/main.cpp
+++ b/cmd/interop/src/main.cpp
@@ -29,7 +29,7 @@ make_sample(uint64_t type)
       return mls_vectors::EncryptionTestVector::create(suite, n, n);
 
     case TestVectorType::KEY_SCHEDULE:
-      return mls_vectors::KeyScheduleTestVector::create(suite, n);
+      return mls_vectors::KeyScheduleTestVector::create(suite, n, n);
 
     case TestVectorType::TRANSCRIPT:
       return mls_vectors::TranscriptTestVector::create(suite);

--- a/cmd/interop/src/mls_client_impl.cpp
+++ b/cmd/interop/src/mls_client_impl.cpp
@@ -358,8 +358,8 @@ MLSClientImpl::generate_test_vector(const GenerateTestVectorRequest* request,
 
     case TestVectorType::KEY_SCHEDULE: {
       auto suite = static_cast<mls::CipherSuite::ID>(request->cipher_suite());
-      j =
-        mls_vectors::KeyScheduleTestVector::create(suite, request->n_epochs(), n_psks);
+      j = mls_vectors::KeyScheduleTestVector::create(
+        suite, request->n_epochs(), n_psks);
       break;
     }
 

--- a/cmd/interop/src/mls_client_impl.cpp
+++ b/cmd/interop/src/mls_client_impl.cpp
@@ -339,6 +339,9 @@ Status
 MLSClientImpl::generate_test_vector(const GenerateTestVectorRequest* request,
                                     GenerateTestVectorResponse* reply)
 {
+  // XXX(RLB): Should this value be set by the test runner?
+  static const uint32_t n_psks = 3;
+
   json j;
   switch (request->test_vector_type()) {
     case TestVectorType::TREE_MATH: {
@@ -356,7 +359,7 @@ MLSClientImpl::generate_test_vector(const GenerateTestVectorRequest* request,
     case TestVectorType::KEY_SCHEDULE: {
       auto suite = static_cast<mls::CipherSuite::ID>(request->cipher_suite());
       j =
-        mls_vectors::KeyScheduleTestVector::create(suite, request->n_epochs());
+        mls_vectors::KeyScheduleTestVector::create(suite, request->n_epochs(), n_psks);
       break;
     }
 

--- a/include/mls/key_schedule.h
+++ b/include/mls/key_schedule.h
@@ -90,6 +90,7 @@ private:
 
 public:
   bytes joiner_secret;
+  bytes psk_secret;
   bytes epoch_secret;
 
   bytes sender_data_secret;
@@ -145,8 +146,6 @@ public:
                   const bytes& context,
                   size_t size) const;
 
-  static bytes psk_secret(CipherSuite suite,
-                          const std::vector<PSKWithSecret> psks);
   static bytes welcome_secret(CipherSuite suite,
                               const bytes& joiner_secret,
                               const std::vector<PSKWithSecret>& psks);

--- a/include/mls/key_schedule.h
+++ b/include/mls/key_schedule.h
@@ -145,6 +145,8 @@ public:
   bytes do_export(const std::string& label,
                   const bytes& context,
                   size_t size) const;
+  PSKWithSecret branch_psk(const bytes& group_id, epoch_t epoch);
+  PSKWithSecret reinit_psk(const bytes& group_id, epoch_t epoch);
 
   static bytes welcome_secret(CipherSuite suite,
                               const bytes& joiner_secret,

--- a/include/mls/key_schedule.h
+++ b/include/mls/key_schedule.h
@@ -109,7 +109,7 @@ public:
   // Full initializer, used by invited joiner
   KeyScheduleEpoch(CipherSuite suite_in,
                    const bytes& joiner_secret,
-                   const bytes& psk_secret,
+                   const std::vector<PSKWithSecret>& psks,
                    const bytes& context);
 
   // Ciphersuite-only initializer, used by external joiner
@@ -124,7 +124,7 @@ public:
   KeyScheduleEpoch(CipherSuite suite_in,
                    const bytes& init_secret,
                    const bytes& commit_secret,
-                   const bytes& psk_secret,
+                   const std::vector<PSKWithSecret>& psks,
                    const bytes& context);
 
   static std::tuple<bytes, bytes> external_init(
@@ -133,7 +133,7 @@ public:
   bytes receive_external_init(const bytes& kem_output) const;
 
   KeyScheduleEpoch next(const bytes& commit_secret,
-                        const bytes& psk_secret,
+                        const std::vector<PSKWithSecret>& psks,
                         const std::optional<bytes>& force_init_secret,
                         const bytes& context) const;
 
@@ -145,9 +145,11 @@ public:
                   const bytes& context,
                   size_t size) const;
 
+  static bytes psk_secret(CipherSuite suite,
+                          const std::vector<PSKWithSecret> psks);
   static bytes welcome_secret(CipherSuite suite,
                               const bytes& joiner_secret,
-                              const bytes& psk_secret);
+                              const std::vector<PSKWithSecret>& psks);
   static KeyAndNonce sender_data_keys(CipherSuite suite,
                                       const bytes& sender_data_secret,
                                       const bytes& ciphertext);

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -95,6 +95,11 @@ struct PreSharedKeys
   TLS_TRAITS(tls::vector<2>)
 };
 
+struct PSKWithSecret {
+  PreSharedKeyID id;
+  bytes secret;
+};
+
 // struct {
 //     CipherSuite cipher_suite;
 //     opaque group_id<0..255>;
@@ -261,12 +266,12 @@ struct Welcome
   Welcome();
   Welcome(CipherSuite suite,
           const bytes& joiner_secret,
-          const bytes& psk_secret,
+          const std::vector<PSKWithSecret>& psks,
           const GroupInfo& group_info);
 
   void encrypt(const KeyPackage& kp, const std::optional<bytes>& path_secret);
   std::optional<int> find(const KeyPackage& kp) const;
-  GroupInfo decrypt(const bytes& joiner_secret, const bytes& psk_secret) const;
+  GroupInfo decrypt(const bytes& joiner_secret, const std::vector<PSKWithSecret>& psks) const;
 
   TLS_SERIALIZABLE(version, cipher_suite, secrets, encrypted_group_info)
   TLS_TRAITS(tls::pass, tls::pass, tls::vector<4>, tls::vector<4>)
@@ -275,7 +280,7 @@ private:
   bytes _joiner_secret;
   static KeyAndNonce group_info_key_nonce(CipherSuite suite,
                                           const bytes& joiner_secret,
-                                          const bytes& psk_secret);
+                                          const std::vector<PSKWithSecret>& psks);
 };
 
 ///

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -95,7 +95,8 @@ struct PreSharedKeys
   TLS_TRAITS(tls::vector<2>)
 };
 
-struct PSKWithSecret {
+struct PSKWithSecret
+{
   PreSharedKeyID id;
   bytes secret;
 };
@@ -271,16 +272,18 @@ struct Welcome
 
   void encrypt(const KeyPackage& kp, const std::optional<bytes>& path_secret);
   std::optional<int> find(const KeyPackage& kp) const;
-  GroupInfo decrypt(const bytes& joiner_secret, const std::vector<PSKWithSecret>& psks) const;
+  GroupInfo decrypt(const bytes& joiner_secret,
+                    const std::vector<PSKWithSecret>& psks) const;
 
   TLS_SERIALIZABLE(version, cipher_suite, secrets, encrypted_group_info)
   TLS_TRAITS(tls::pass, tls::pass, tls::vector<4>, tls::vector<4>)
 
 private:
   bytes _joiner_secret;
-  static KeyAndNonce group_info_key_nonce(CipherSuite suite,
-                                          const bytes& joiner_secret,
-                                          const std::vector<PSKWithSecret>& psks);
+  static KeyAndNonce group_info_key_nonce(
+    CipherSuite suite,
+    const bytes& joiner_secret,
+    const std::vector<PSKWithSecret>& psks);
 };
 
 ///

--- a/lib/mls_vectors/include/mls_vectors/mls_vectors.h
+++ b/lib/mls_vectors/include/mls_vectors/mls_vectors.h
@@ -87,7 +87,8 @@ struct EncryptionTestVector
 
 struct KeyScheduleTestVector
 {
-  struct ExternalPSKInfo {
+  struct ExternalPSKInfo
+  {
     HexBytes id;
     HexBytes nonce;
     HexBytes secret;

--- a/lib/mls_vectors/include/mls_vectors/mls_vectors.h
+++ b/lib/mls_vectors/include/mls_vectors/mls_vectors.h
@@ -87,17 +87,24 @@ struct EncryptionTestVector
 
 struct KeyScheduleTestVector
 {
+  struct ExternalPSKInfo {
+    HexBytes id;
+    HexBytes nonce;
+    HexBytes secret;
+  };
+
   struct Epoch
   {
     // Chosen by the generator
     HexBytes tree_hash;
     HexBytes commit_secret;
-    HexBytes psk_secret;
     HexBytes confirmed_transcript_hash;
+    std::vector<ExternalPSKInfo> external_psks;
 
     // Computed values
     HexBytes group_context;
 
+    HexBytes psk_secret;
     HexBytes joiner_secret;
     HexBytes welcome_secret;
     HexBytes init_secret;
@@ -122,7 +129,8 @@ struct KeyScheduleTestVector
   std::vector<Epoch> epochs;
 
   static KeyScheduleTestVector create(mls::CipherSuite suite,
-                                      uint32_t n_epochs);
+                                      uint32_t n_epochs,
+                                      uint32_t n_psks);
   std::optional<std::string> verify() const;
 };
 

--- a/lib/mls_vectors/include/mls_vectors/mls_vectors.h
+++ b/lib/mls_vectors/include/mls_vectors/mls_vectors.h
@@ -100,6 +100,7 @@ struct KeyScheduleTestVector
     HexBytes commit_secret;
     HexBytes confirmed_transcript_hash;
     std::vector<ExternalPSKInfo> external_psks;
+    HexBytes branch_psk_nonce;
 
     // Computed values
     HexBytes group_context;

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -300,7 +300,9 @@ EncryptionTestVector::verify() const
 ///
 
 KeyScheduleTestVector
-KeyScheduleTestVector::create(CipherSuite suite, uint32_t n_epochs, uint32_t n_psks)
+KeyScheduleTestVector::create(CipherSuite suite,
+                              uint32_t n_epochs,
+                              uint32_t n_psks)
 {
   auto tv = KeyScheduleTestVector{};
   tv.cipher_suite = suite;
@@ -324,12 +326,12 @@ KeyScheduleTestVector::create(CipherSuite suite, uint32_t n_epochs, uint32_t n_p
       auto secret = random_bytes(suite.secret_size());
 
       psks.push_back({ PreSharedKeyID{ ExternalPSK{ id }, nonce }, secret });
-      external_psks.push_back({id, nonce, secret});
+      external_psks.push_back({ id, nonce, secret });
     }
 
     auto branch_psk_nonce = bytes{};
     if (i > 0) {
-      auto psk = epoch.branch_psk(tv.group_id, epoch_t(i-1));
+      auto psk = epoch.branch_psk(tv.group_id, epoch_t(i - 1));
       branch_psk_nonce = psk.id.psk_nonce;
       psks.push_back(psk);
     }
@@ -392,7 +394,8 @@ KeyScheduleTestVector::verify() const
 
     auto psks = std::vector<PSKWithSecret>{};
     for (const auto& psk : tve.external_psks) {
-      psks.push_back({ PreSharedKeyID{ ExternalPSK{ psk.id }, psk.nonce }, psk.secret });
+      psks.push_back(
+        { PreSharedKeyID{ ExternalPSK{ psk.id }, psk.nonce }, psk.secret });
     }
 
     if (epoch_n > 0) {
@@ -407,8 +410,8 @@ KeyScheduleTestVector::verify() const
     // Verify the rest of the epoch
     VERIFY_EQUAL("joiner secret", epoch.joiner_secret, tve.joiner_secret);
 
-    auto welcome_secret = KeyScheduleEpoch::welcome_secret(
-      cipher_suite, tve.joiner_secret, psks);
+    auto welcome_secret =
+      KeyScheduleEpoch::welcome_secret(cipher_suite, tve.joiner_secret, psks);
     VERIFY_EQUAL("welcome secret", welcome_secret, tve.welcome_secret);
 
     VERIFY_EQUAL(

--- a/lib/mls_vectors/test/mls_vectors.cpp
+++ b/lib/mls_vectors/test/mls_vectors.cpp
@@ -30,7 +30,7 @@ TEST_CASE("Encryption Keys")
 TEST_CASE("Key Schedule")
 {
   for (auto suite : supported_suites) {
-    const auto tv = KeyScheduleTestVector::create(suite, 15);
+    const auto tv = KeyScheduleTestVector::create(suite, 15, 3);
     REQUIRE(tv.verify() == std::nullopt);
   }
 }

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -425,7 +425,8 @@ GroupKeySource::decrypt(const bytes& sender_data_secret,
 /// KeyScheduleEpoch
 ///
 
-struct PSKLabel {
+struct PSKLabel
+{
   const PreSharedKeyID& id;
   uint16_t index;
   uint16_t count;
@@ -434,14 +435,16 @@ struct PSKLabel {
 };
 
 bytes
-make_psk_secret(CipherSuite suite, const std::vector<PSKWithSecret> psks) {
+make_psk_secret(CipherSuite suite, const std::vector<PSKWithSecret> psks)
+{
   auto psk_secret = suite.zero();
   auto count = uint16_t(psks.size());
   auto index = uint16_t(0);
   for (const auto& psk : psks) {
     auto psk_extracted = suite.hpke().kdf.extract(suite.zero(), psk.secret);
     auto psk_label = tls::marshal(PSKLabel{ psk.id, index, count });
-    auto psk_input = suite.expand_with_label(psk_extracted, "derived psk", psk_label, suite.secret_size());
+    auto psk_input = suite.expand_with_label(
+      psk_extracted, "derived psk", psk_label, suite.secret_size());
     psk_secret = suite.hpke().kdf.extract(psk_input, psk_secret);
     index += 1;
   }

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -434,7 +434,7 @@ struct PSKLabel
   TLS_SERIALIZABLE(id, index, count);
 };
 
-bytes
+static bytes
 make_psk_secret(CipherSuite suite, const std::vector<PSKWithSecret>& psks)
 {
   auto psk_secret = suite.zero();

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -435,7 +435,7 @@ struct PSKLabel
 };
 
 bytes
-make_psk_secret(CipherSuite suite, const std::vector<PSKWithSecret> psks)
+make_psk_secret(CipherSuite suite, const std::vector<PSKWithSecret>& psks)
 {
   auto psk_secret = suite.zero();
   auto count = uint16_t(psks.size());

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -462,10 +462,9 @@ make_joiner_secret(CipherSuite suite,
 static bytes
 make_epoch_secret(CipherSuite suite,
                   const bytes& joiner_secret,
-                  const std::vector<PSKWithSecret> psks,
+                  const bytes& psk_secret,
                   const bytes& context)
 {
-  auto psk_secret = make_psk_secret(suite, psks);
   auto member_secret = suite.hpke().kdf.extract(joiner_secret, psk_secret);
   return suite.expand_with_label(
     member_secret, "epoch", context, suite.secret_size());
@@ -477,8 +476,9 @@ KeyScheduleEpoch::KeyScheduleEpoch(CipherSuite suite_in,
                                    const bytes& context)
   : suite(suite_in)
   , joiner_secret(joiner_secret)
+  , psk_secret(make_psk_secret(suite_in, psks))
   , epoch_secret(
-      make_epoch_secret(suite_in, joiner_secret, psks, context))
+      make_epoch_secret(suite_in, joiner_secret, joiner_secret, context))
   , sender_data_secret(suite.derive_secret(epoch_secret, "sender data"))
   , encryption_secret(suite.derive_secret(epoch_secret, "encryption"))
   , exporter_secret(suite.derive_secret(epoch_secret, "exporter"))

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -578,6 +578,20 @@ KeyScheduleEpoch::do_export(const std::string& label,
   return suite.expand_with_label(secret, "exporter", context_hash, size);
 }
 
+PSKWithSecret
+KeyScheduleEpoch::branch_psk(const bytes& group_id, epoch_t epoch)
+{
+  auto nonce = random_bytes(suite.secret_size());
+  return { { BranchPSK{ group_id, epoch }, nonce }, resumption_secret };
+}
+
+PSKWithSecret
+KeyScheduleEpoch::reinit_psk(const bytes& group_id, epoch_t epoch)
+{
+  auto nonce = random_bytes(suite.secret_size());
+  return { { ReInitPSK{ group_id, epoch }, nonce }, resumption_secret };
+}
+
 bytes
 KeyScheduleEpoch::welcome_secret(CipherSuite suite,
                                  const bytes& joiner_secret,

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -191,10 +191,10 @@ Welcome::encrypt(const KeyPackage& kp, const std::optional<bytes>& path_secret)
 }
 
 GroupInfo
-Welcome::decrypt(const bytes& joiner_secret, const std::vector<PSKWithSecret>& psks) const
+Welcome::decrypt(const bytes& joiner_secret,
+                 const std::vector<PSKWithSecret>& psks) const
 {
-  auto [key, nonce] =
-    group_info_key_nonce(cipher_suite, joiner_secret, psks);
+  auto [key, nonce] = group_info_key_nonce(cipher_suite, joiner_secret, psks);
   auto group_info_data =
     cipher_suite.hpke().aead.open(key, nonce, {}, encrypted_group_info);
   if (!group_info_data) {

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -154,8 +154,8 @@ State::State(const HPKEPrivateKey& init_priv,
 
   // Ratchet forward into the current epoch
   auto group_ctx = tls::marshal(group_context());
-  _key_schedule =
-    KeyScheduleEpoch(_suite, secrets.joiner_secret, { /* no PSKs */ }, group_ctx);
+  _key_schedule = KeyScheduleEpoch(
+    _suite, secrets.joiner_secret, { /* no PSKs */ }, group_ctx);
   _keys = _key_schedule.encryption_keys(_tree.size());
 
   // Verify the confirmation
@@ -742,8 +742,8 @@ State::update_epoch_secrets(const bytes& commit_secret,
     _transcript_hash.confirmed,
     _extensions,
   });
-  _key_schedule =
-    _key_schedule.next(commit_secret, { /* no PSKs */ }, force_init_secret, ctx);
+  _key_schedule = _key_schedule.next(
+    commit_secret, { /* no PSKs */ }, force_init_secret, ctx);
   _keys = _key_schedule.encryption_keys(_tree.size());
 }
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -155,7 +155,7 @@ State::State(const HPKEPrivateKey& init_priv,
   // Ratchet forward into the current epoch
   auto group_ctx = tls::marshal(group_context());
   _key_schedule =
-    KeyScheduleEpoch(_suite, secrets.joiner_secret, _suite.zero(), group_ctx);
+    KeyScheduleEpoch(_suite, secrets.joiner_secret, { /* no PSKs */ }, group_ctx);
   _keys = _key_schedule.encryption_keys(_tree.size());
 
   // Verify the confirmation
@@ -743,7 +743,7 @@ State::update_epoch_secrets(const bytes& commit_secret,
     _extensions,
   });
   _key_schedule =
-    _key_schedule.next(commit_secret, _suite.zero(), force_init_secret, ctx);
+    _key_schedule.next(commit_secret, { /* no PSKs */ }, force_init_secret, ctx);
   _keys = _key_schedule.encryption_keys(_tree.size());
 }
 

--- a/test/key_schedule.cpp
+++ b/test/key_schedule.cpp
@@ -16,7 +16,7 @@ TEST_CASE("Encryption Keys Interop")
 TEST_CASE("Key Schedule Interop")
 {
   for (auto suite : all_supported_suites) {
-    auto tv = KeyScheduleTestVector::create(suite, 15);
+    auto tv = KeyScheduleTestVector::create(suite, 15, 3);
     REQUIRE(tv.verify() == std::nullopt);
   }
 }


### PR DESCRIPTION
This PR implement spec PR https://github.com/mlswg/mls-protocol/pull/490.  Note that it is only implemented at the level of the key schedule -- there is still no way for applications to actually inject PSKs.  That is a larger piece of work, reserved for later.  This is enough to get interop testing going at the key schedule level.