### PR TITLE
Remove the concept of leaf indices

### DIFF
--- a/cmd/interop/src/json_details.h
+++ b/cmd/interop/src/json_details.h
@@ -135,7 +135,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(EncryptionTestVector::LeafInfo,
                                    application)
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(EncryptionTestVector,
                                    cipher_suite,
-                                   n_leaves,
+                                   tree,
                                    encryption_secret,
                                    sender_data_secret,
                                    sender_data_info,

--- a/cmd/interop/src/mls_client_impl.cpp
+++ b/cmd/interop/src/mls_client_impl.cpp
@@ -217,7 +217,7 @@ MLSClientImpl::store_join(mls::HPKEPrivateKey&& init_priv,
                           mls::SignaturePrivateKey&& sig_priv,
                           mls::KeyPackage&& kp)
 {
-  auto join_id = tls::get<uint32_t>(kp.hash());
+  auto join_id = tls::get<uint32_t>(kp.id().id);
   auto entry =
     CachedJoin{ std::move(init_priv), std::move(sig_priv), std::move(kp) };
   join_cache.emplace(std::make_pair(join_id, std::move(entry)));

--- a/include/mls/common.h
+++ b/include/mls/common.h
@@ -34,7 +34,7 @@ template<typename T, typename... Ts>
 bool
 operator==(const var::variant<Ts...>& v, const T& t)
 {
-  return std::visit(
+  return var::visit(
     [&](const auto& arg) {
       using U = std::decay_t<decltype(arg)>;
       if constexpr (std::is_same_v<U, T>) {

--- a/include/mls/common.h
+++ b/include/mls/common.h
@@ -23,6 +23,40 @@ namespace mls {
 // Expose bytes operators for code within this namespace
 using namespace bytes_ns::operators;
 
+// Make variant equality work in the same way as optional equality, with
+// automatic unwrapping.  In other words
+//
+//     v == T(x) <=> hold_alternative<T>(v) && get<T>(v) == x
+//
+// For consistency, we also define symmetric and negated version.  In this
+// house, we obey the symmetric law of equivalence relations!
+template<typename T, typename... Ts>
+bool operator==(const var::variant<Ts...>& v, const T& t) {
+  return std::visit([&](const auto& arg) {
+    using U = std::decay_t<decltype(arg)>;
+    if constexpr (std::is_same_v<U, T>) {
+      return arg == t;
+    } else {
+      return false;
+    }
+  }, v);
+}
+
+template<typename T, typename... Ts>
+bool operator==(const T& t, const var::variant<Ts...>& v) {
+  return v == t;
+}
+
+template<typename T, typename... Ts>
+bool operator!=(const var::variant<Ts...>& v, const T& t) {
+  return !(v == t);
+}
+
+template<typename T, typename... Ts>
+bool operator!=(const T& t, const var::variant<Ts...>& v) {
+  return !(v == t);
+}
+
 using epoch_t = uint64_t;
 
 ///

--- a/include/mls/common.h
+++ b/include/mls/common.h
@@ -31,29 +31,39 @@ using namespace bytes_ns::operators;
 // For consistency, we also define symmetric and negated version.  In this
 // house, we obey the symmetric law of equivalence relations!
 template<typename T, typename... Ts>
-bool operator==(const var::variant<Ts...>& v, const T& t) {
-  return std::visit([&](const auto& arg) {
-    using U = std::decay_t<decltype(arg)>;
-    if constexpr (std::is_same_v<U, T>) {
-      return arg == t;
-    } else {
-      return false;
-    }
-  }, v);
+bool
+operator==(const var::variant<Ts...>& v, const T& t)
+{
+  return std::visit(
+    [&](const auto& arg) {
+      using U = std::decay_t<decltype(arg)>;
+      if constexpr (std::is_same_v<U, T>) {
+        return arg == t;
+      } else {
+        return false;
+      }
+    },
+    v);
 }
 
 template<typename T, typename... Ts>
-bool operator==(const T& t, const var::variant<Ts...>& v) {
+bool
+operator==(const T& t, const var::variant<Ts...>& v)
+{
   return v == t;
 }
 
 template<typename T, typename... Ts>
-bool operator!=(const var::variant<Ts...>& v, const T& t) {
+bool
+operator!=(const var::variant<Ts...>& v, const T& t)
+{
   return !(v == t);
 }
 
 template<typename T, typename... Ts>
-bool operator!=(const T& t, const var::variant<Ts...>& v) {
+bool
+operator!=(const T& t, const var::variant<Ts...>& v)
+{
   return !(v == t);
 }
 

--- a/include/mls/core_types.h
+++ b/include/mls/core_types.h
@@ -168,6 +168,13 @@ struct KeyPackageOpts
   ExtensionList extensions;
 };
 
+struct KeyPackageID
+{
+  bytes id;
+  TLS_SERIALIZABLE(id)
+  TLS_TRAITS(tls::vector<1>)
+};
+
 struct KeyPackage
 {
   ProtocolVersion version;
@@ -184,7 +191,7 @@ struct KeyPackage
              const SignaturePrivateKey& sig_priv_in,
              const std::optional<KeyPackageOpts>& opts_in);
 
-  bytes hash() const;
+  KeyPackageID id() const;
 
   void sign(const SignaturePrivateKey& sig_priv,
             const std::optional<KeyPackageOpts>& opts);

--- a/include/mls/core_types.h
+++ b/include/mls/core_types.h
@@ -158,6 +158,7 @@ struct ParentNode
 //     ProtocolVersion version;
 //     CipherSuite cipher_suite;
 //     HPKEPublicKey hpke_init_key;
+//     opaque endpoint_id<0..255>;
 //     Credential credential;
 //     Extension extensions<8..2^32-1>;
 //     opaque signature<0..2^16-1>;
@@ -180,6 +181,7 @@ struct KeyPackage
   ProtocolVersion version;
   CipherSuite cipher_suite;
   HPKEPublicKey init_key;
+  bytes endpoint_id;
   Credential credential;
   ExtensionList extensions;
   bytes signature;

--- a/include/mls/key_schedule.h
+++ b/include/mls/key_schedule.h
@@ -65,10 +65,12 @@ struct GroupKeySource
   KeyAndNonce get(RatchetType type, LeafIndex sender, uint32_t generation);
   void erase(RatchetType type, LeafIndex sender, uint32_t generation);
 
-  MLSCiphertext encrypt(LeafIndex index,
+  MLSCiphertext encrypt(const TreeKEMPublicKey& tree,
+                        LeafIndex index,
                         const bytes& sender_data_secret,
                         const MLSPlaintext& pt);
-  MLSPlaintext decrypt(const bytes& sender_data_secret,
+  MLSPlaintext decrypt(const TreeKEMPublicKey& tree,
+                       const bytes& sender_data_secret,
                        const MLSCiphertext& ct);
 
 private:

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -501,15 +501,28 @@ enum struct SenderType : uint8_t
   member = 1,
   preconfigured = 2,
   new_member = 3,
-  external_joiner = 4,
+};
+
+struct PreconfiguredKeyID
+{
+  bytes id;
+  TLS_SERIALIZABLE(id)
+  TLS_TRAITS(tls::vector<1>)
+};
+
+struct NewMemberID
+{
+  TLS_SERIALIZABLE()
 };
 
 struct Sender
 {
-  SenderType sender_type{ SenderType::invalid };
-  uint32_t sender{ 0 };
+  var::variant<KeyPackageID, PreconfiguredKeyID, NewMemberID> sender;
 
-  TLS_SERIALIZABLE(sender_type, sender)
+  SenderType sender_type() const;
+
+  TLS_SERIALIZABLE(sender)
+  TLS_TRAITS(tls::variant<SenderType>)
 };
 
 struct MLSPlaintext
@@ -641,5 +654,9 @@ TLS_VARIANT_MAP(mls::ProposalType,
 TLS_VARIANT_MAP(mls::ContentType, mls::ApplicationData, application)
 TLS_VARIANT_MAP(mls::ContentType, mls::Proposal, proposal)
 TLS_VARIANT_MAP(mls::ContentType, mls::Commit, commit)
+
+TLS_VARIANT_MAP(mls::SenderType, mls::KeyPackageID, member)
+TLS_VARIANT_MAP(mls::SenderType, mls::PreconfiguredKeyID, preconfigured)
+TLS_VARIANT_MAP(mls::SenderType, mls::NewMemberID, new_member)
 
 } // namespace tls

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -123,7 +123,7 @@ struct PublicGroupState
   ExtensionList group_context_extensions;
   ExtensionList other_extensions;
   HPKEPublicKey external_pub;
-  LeafIndex signer_index;
+  KeyPackageID signer;
   bytes signature;
 
   PublicGroupState() = default;
@@ -138,7 +138,7 @@ struct PublicGroupState
 
   bytes to_be_signed() const;
   void sign(const TreeKEMPublicKey& tree,
-            LeafIndex index,
+            KeyPackageID signer_id,
             const SignaturePrivateKey& priv);
   bool verify(const TreeKEMPublicKey& tree) const;
 
@@ -150,7 +150,7 @@ struct PublicGroupState
                    group_context_extensions,
                    other_extensions,
                    external_pub,
-                   signer_index,
+                   signer,
                    signature)
   TLS_TRAITS(tls::pass,
              tls::vector<1>,
@@ -186,7 +186,7 @@ public:
   ExtensionList other_extensions;
 
   MAC confirmation_tag;
-  LeafIndex signer_index;
+  KeyPackageID signer;
   bytes signature;
 
   GroupInfo() = default;
@@ -200,7 +200,7 @@ public:
 
   bytes to_be_signed() const;
   void sign(const TreeKEMPublicKey& tree,
-            LeafIndex index,
+            KeyPackageID signer_id,
             const SignaturePrivateKey& priv);
   bool verify(const TreeKEMPublicKey& tree) const;
 
@@ -211,7 +211,7 @@ public:
                    group_context_extensions,
                    other_extensions,
                    confirmation_tag,
-                   signer_index,
+                   signer,
                    signature)
   TLS_TRAITS(tls::vector<1>,
              tls::pass,
@@ -253,11 +253,10 @@ struct GroupSecrets
 // } EncryptedGroupSecrets;
 struct EncryptedGroupSecrets
 {
-  bytes key_package_hash;
+  KeyPackageID new_member;
   HPKECiphertext encrypted_group_secrets;
 
-  TLS_SERIALIZABLE(key_package_hash, encrypted_group_secrets)
-  TLS_TRAITS(tls::vector<1>, tls::pass)
+  TLS_SERIALIZABLE(new_member, encrypted_group_secrets)
 };
 
 // struct {

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -315,7 +315,7 @@ struct Update
 // Remove
 struct Remove
 {
-  LeafIndex removed;
+  KeyPackageID removed;
   TLS_SERIALIZABLE(removed)
 };
 

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -159,6 +159,7 @@ protected:
 
   // Per-participant state
   LeafIndex _index;
+  KeyPackageID _id;
   SignaturePrivateKey _identity_priv;
 
   // Cache of Proposals and update secrets

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -112,6 +112,7 @@ public:
   /// Accessors
   ///
   epoch_t epoch() const { return _epoch; }
+  KeyPackageID id() const { return _id; }
   LeafIndex index() const { return _index; }
   CipherSuite cipher_suite() const { return _suite; }
   const ExtensionList& extensions() const { return _extensions; }
@@ -167,7 +168,7 @@ protected:
   {
     bytes ref;
     Proposal proposal;
-    LeafIndex sender;
+    std::optional<LeafIndex> sender;
   };
   std::list<CachedProposal> _pending_proposals;
   std::map<bytes, bytes> _update_secrets;
@@ -220,10 +221,10 @@ protected:
   // Extract a proposal from the cache
   void cache_proposal(const MLSPlaintext& pt);
   std::optional<CachedProposal> resolve(const ProposalOrRef& id,
-                                        LeafIndex sender_index) const;
+                                        std::optional<LeafIndex> sender_index) const;
   std::vector<CachedProposal> must_resolve(
     const std::vector<ProposalOrRef>& ids,
-    LeafIndex sender_index) const;
+    std::optional<LeafIndex> sender_index) const;
 
   // Compare the **shared** attributes of the states
   friend bool operator==(const State& lhs, const State& rhs);
@@ -236,7 +237,7 @@ protected:
 
   // Signature verification over a handshake message
   bool verify_internal(const MLSPlaintext& pt) const;
-  bool verify_external_commit(const MLSPlaintext& pt) const;
+  bool verify_new_member(const MLSPlaintext& pt) const;
   bool verify(const MLSPlaintext& pt) const;
 
   // Verification of the confirmation MAC

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -90,13 +90,13 @@ public:
   Proposal add_proposal(const KeyPackage& key_package) const;
   Proposal update_proposal(const bytes& leaf_secret);
   Proposal remove_proposal(RosterIndex index) const;
-  Proposal remove_proposal(LeafIndex removed) const;
+  Proposal remove_proposal(KeyPackageID removed) const;
   Proposal group_context_extensions_proposal(ExtensionList exts) const;
 
   MLSPlaintext add(const KeyPackage& key_package) const;
   MLSPlaintext update(const bytes& leaf_secret);
   MLSPlaintext remove(RosterIndex index) const;
-  MLSPlaintext remove(LeafIndex removed) const;
+  MLSPlaintext remove(KeyPackageID removed) const;
   MLSPlaintext group_context_extensions(ExtensionList exts) const;
 
   std::tuple<MLSPlaintext, Welcome, State> commit(
@@ -206,7 +206,7 @@ protected:
   LeafIndex apply(const Add& add);
   void apply(LeafIndex target, const Update& update);
   void apply(LeafIndex target, const Update& update, const bytes& leaf_secret);
-  void apply(const Remove& remove);
+  LeafIndex apply(const Remove& remove);
   void apply(const GroupContextExtensions& gce);
   std::vector<LeafIndex> apply(const std::vector<CachedProposal>& proposals,
                                Proposal::Type required_type);
@@ -243,7 +243,7 @@ protected:
   bool verify_confirmation(const bytes& confirmation) const;
 
   // Convert a Roster entry into LeafIndex
-  LeafIndex leaf_for_roster_entry(RosterIndex index) const;
+  KeyPackageID leaf_for_roster_entry(RosterIndex index) const;
 
   // Create a draft successor state
   State successor() const;

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -204,6 +204,10 @@ protected:
   MLSPlaintext sign(const Proposal& proposal) const;
 
   // Apply the changes requested by various messages
+  void check_add_key_package(const KeyPackage& key_package,
+                             std::optional<LeafIndex> except) const;
+  void check_update_key_package(LeafIndex target,
+                                const KeyPackage& key_package) const;
   LeafIndex apply(const Add& add);
   void apply(LeafIndex target, const Update& update);
   void apply(LeafIndex target, const Update& update, const bytes& leaf_secret);
@@ -220,8 +224,9 @@ protected:
 
   // Extract a proposal from the cache
   void cache_proposal(const MLSPlaintext& pt);
-  std::optional<CachedProposal> resolve(const ProposalOrRef& id,
-                                        std::optional<LeafIndex> sender_index) const;
+  std::optional<CachedProposal> resolve(
+    const ProposalOrRef& id,
+    std::optional<LeafIndex> sender_index) const;
   std::vector<CachedProposal> must_resolve(
     const std::vector<ProposalOrRef>& ids,
     std::optional<LeafIndex> sender_index) const;

--- a/include/mls/tree_math.h
+++ b/include/mls/tree_math.h
@@ -72,8 +72,10 @@ struct LeafIndex : public UInt32
 };
 
 // Leaf indices serialize as node indices, and are validated on deserialize
-tls::ostream& operator<<(tls::ostream& str, const LeafIndex& obj);
-tls::istream& operator>>(tls::istream& str, LeafIndex& obj);
+tls::ostream&
+operator<<(tls::ostream& str, const LeafIndex& obj);
+tls::istream&
+operator>>(tls::istream& str, LeafIndex& obj);
 
 struct NodeIndex : public UInt32
 {

--- a/include/mls/tree_math.h
+++ b/include/mls/tree_math.h
@@ -61,20 +61,24 @@ struct NodeCount : public UInt32
   explicit NodeCount(const LeafCount n);
 };
 
+struct NodeIndex;
+
 struct LeafIndex : public UInt32
 {
   using UInt32::UInt32;
+  explicit LeafIndex(const NodeIndex x);
   bool operator<(const LeafIndex other) const { return val < other.val; }
   bool operator<(const LeafCount other) const { return val < other.val; }
 };
 
+// Leaf indices serialize as node indices, and are validated on deserialize
+tls::ostream& operator<<(tls::ostream& str, const LeafIndex& obj);
+tls::istream& operator>>(tls::istream& str, LeafIndex& obj);
+
 struct NodeIndex : public UInt32
 {
   using UInt32::UInt32;
-  explicit NodeIndex(const LeafIndex x)
-    : UInt32(2 * x.val)
-  {}
-
+  explicit NodeIndex(const LeafIndex x);
   bool operator<(const NodeIndex other) const { return val < other.val; }
 };
 

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -32,6 +32,7 @@ struct OptionalNode
   bytes hash;
 
   bool blank() const { return !node.has_value(); }
+  bool leaf() const { return !blank() && var::holds_alternative<KeyPackage>(opt::get(node).node); }
 
   KeyPackage& key_package()
   {
@@ -137,7 +138,9 @@ struct TreeKEMPublicKey
   bool parent_hash_valid() const;
 
   std::optional<LeafIndex> find(const KeyPackage& kp) const;
+  std::optional<LeafIndex> find(const KeyPackageID& id) const;
   std::optional<KeyPackage> key_package(LeafIndex index) const;
+  std::optional<KeyPackage> key_package(const KeyPackageID& id) const;
   std::vector<NodeIndex> resolve(NodeIndex index) const;
 
   std::tuple<TreeKEMPrivateKey, UpdatePath> encap(

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -32,7 +32,10 @@ struct OptionalNode
   bytes hash;
 
   bool blank() const { return !node.has_value(); }
-  bool leaf() const { return !blank() && var::holds_alternative<KeyPackage>(opt::get(node).node); }
+  bool leaf() const
+  {
+    return !blank() && var::holds_alternative<KeyPackage>(opt::get(node).node);
+  }
 
   KeyPackage& key_package()
   {

--- a/lib/hpke/src/openssl_common.cpp
+++ b/lib/hpke/src/openssl_common.cpp
@@ -73,7 +73,8 @@ typed_delete(X509* ptr)
 }
 
 template<>
-void typed_delete(STACK_OF(GENERAL_NAME) * ptr)
+void
+typed_delete(STACK_OF(GENERAL_NAME) * ptr)
 {
   sk_GENERAL_NAME_pop_free(ptr, GENERAL_NAME_free);
 }

--- a/lib/mls_vectors/include/mls_vectors/mls_vectors.h
+++ b/lib/mls_vectors/include/mls_vectors/mls_vectors.h
@@ -71,8 +71,8 @@ struct EncryptionTestVector
   };
 
   mls::CipherSuite cipher_suite;
-  mls::LeafCount n_leaves;
 
+  HexBytes tree;
   HexBytes encryption_secret;
   HexBytes sender_data_secret;
   SenderDataInfo sender_data_info;

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -787,7 +787,7 @@ MessagesTestVector::create()
   auto public_group_state =
     PublicGroupState{ suite,  group_id, epoch,    opaque,
                       opaque, ext_list, ext_list, hpke_pub };
-  public_group_state.sign(tree, LeafIndex{ 1 }, sig_priv);
+  public_group_state.sign(tree, key_package.id(), sig_priv);
 
   // Proposals
   auto add = Add{ key_package };

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -224,7 +224,8 @@ EncryptionTestVector::create(CipherSuite suite,
     auto init_priv = HPKEPrivateKey::generate(suite);
     auto sig_priv = SignaturePrivateKey::generate(suite);
     auto cred = Credential::basic({}, suite, sig_priv.public_key);
-    auto key_package = KeyPackage{ suite, init_priv.public_key, cred, sig_priv, std::nullopt };
+    auto key_package =
+      KeyPackage{ suite, init_priv.public_key, cred, sig_priv, std::nullopt };
     auto key_package_id = key_package.id();
     tree.add_leaf(key_package);
   }
@@ -246,7 +247,7 @@ EncryptionTestVector::create(CipherSuite suite,
     tv.leaves[i].application.resize(n_generations);
 
     auto N = LeafIndex{ i };
-    auto sender = Sender{ opt::get(tree.key_package(LeafIndex{i})).id() };
+    auto sender = Sender{ opt::get(tree.key_package(LeafIndex{ i })).id() };
     auto hs_pt = MLSPlaintext{ group_id, epoch, sender, proposal };
     hs_pt.wire_format = WireFormat::mls_ciphertext;
 

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -226,7 +226,7 @@ EncryptionTestVector::create(CipherSuite suite,
   auto epoch = epoch_t(0x0001020304050607);
   auto handshake_type = GroupKeySource::RatchetType::handshake;
   auto application_type = GroupKeySource::RatchetType::application;
-  auto proposal = Proposal{ Remove{ LeafIndex{ 0 } } };
+  auto proposal = Proposal{ GroupContextExtensions{} };
   auto app_data = ApplicationData{ random_bytes(suite.secret_size()) };
 
   tv.leaves.resize(n_leaves);
@@ -792,7 +792,7 @@ MessagesTestVector::create()
   // Proposals
   auto add = Add{ key_package };
   auto update = Update{ key_package };
-  auto remove = Remove{ index };
+  auto remove = Remove{ key_package.id() };
   auto pre_shared_key = PreSharedKey{ psk_id, psk_nonce };
   auto reinit = ReInit{ group_id, version, suite, {} };
   auto external_init = ExternalInit{ opaque };

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -219,8 +219,18 @@ EncryptionTestVector::create(CipherSuite suite,
     sender_data_key_nonce.nonce,
   };
 
-  tv.n_leaves = LeafCount{ n_leaves };
-  auto src = GroupKeySource(suite, tv.n_leaves, tv.encryption_secret);
+  auto tree = TreeKEMPublicKey(suite);
+  for (uint32_t i = 0; i < n_leaves; i++) {
+    auto init_priv = HPKEPrivateKey::generate(suite);
+    auto sig_priv = SignaturePrivateKey::generate(suite);
+    auto cred = Credential::basic({}, suite, sig_priv.public_key);
+    auto key_package = KeyPackage{ suite, init_priv.public_key, cred, sig_priv, std::nullopt };
+    auto key_package_id = key_package.id();
+    tree.add_leaf(key_package);
+  }
+  tv.tree = tls::marshal(tree);
+
+  auto src = GroupKeySource(suite, tree.size(), tv.encryption_secret);
 
   auto group_id = bytes{ 0, 1, 2, 3 };
   auto epoch = epoch_t(0x0001020304050607);
@@ -236,7 +246,7 @@ EncryptionTestVector::create(CipherSuite suite,
     tv.leaves[i].application.resize(n_generations);
 
     auto N = LeafIndex{ i };
-    auto sender = Sender{ SenderType::member, i };
+    auto sender = Sender{ opt::get(tree.key_package(LeafIndex{i})).id() };
     auto hs_pt = MLSPlaintext{ group_id, epoch, sender, proposal };
     hs_pt.wire_format = WireFormat::mls_ciphertext;
 
@@ -248,7 +258,7 @@ EncryptionTestVector::create(CipherSuite suite,
 
     for (uint32_t j = 0; j < n_generations; ++j) {
       // Handshake
-      auto hs_ct = src.encrypt(N, tv.sender_data_secret, hs_pt);
+      auto hs_ct = src.encrypt(tree, N, tv.sender_data_secret, hs_pt);
       auto hs_key_nonce = src.get(handshake_type, N, j);
       src.erase(handshake_type, N, j);
 
@@ -260,7 +270,7 @@ EncryptionTestVector::create(CipherSuite suite,
       };
 
       // Application
-      auto app_ct = src.encrypt(N, tv.sender_data_secret, app_pt);
+      auto app_ct = src.encrypt(tree, N, tv.sender_data_secret, app_pt);
       auto app_key_nonce = src.get(application_type, N, j);
       src.erase(application_type, N, j);
 
@@ -286,6 +296,11 @@ EncryptionTestVector::verify() const
   VERIFY_EQUAL(
     "sender data nonce", sender_data_key_nonce.nonce, sender_data_info.nonce);
 
+  auto ratchet_tree = tls::get<TreeKEMPublicKey>(tree);
+  ratchet_tree.suite = cipher_suite;
+  ratchet_tree.set_hash_all();
+  auto n_leaves = ratchet_tree.size();
+
   auto handshake_type = GroupKeySource::RatchetType::handshake;
   auto application_type = GroupKeySource::RatchetType::application;
 
@@ -300,7 +315,7 @@ EncryptionTestVector::verify() const
       VERIFY_EQUAL("hs nonce", hs_key_nonce.nonce, hs_step.nonce);
 
       auto hs_ct = tls::get<MLSCiphertext>(hs_step.ciphertext);
-      auto hs_pt = src.decrypt(sender_data_secret, hs_ct);
+      auto hs_pt = src.decrypt(ratchet_tree, sender_data_secret, hs_ct);
       VERIFY_EQUAL("hs pt", tls::marshal(hs_pt), hs_step.plaintext);
       src.erase(handshake_type, N, j);
 
@@ -311,7 +326,7 @@ EncryptionTestVector::verify() const
       VERIFY_EQUAL("app nonce", app_key_nonce.nonce, app_step.nonce);
 
       auto app_ct = tls::get<MLSCiphertext>(app_step.ciphertext);
-      auto app_pt = src.decrypt(sender_data_secret, app_ct);
+      auto app_pt = src.decrypt(ratchet_tree, sender_data_secret, app_ct);
       VERIFY_EQUAL("app pt", tls::marshal(app_pt), app_step.plaintext);
       src.erase(application_type, N, j);
     }
@@ -492,7 +507,7 @@ TranscriptTestVector::create(CipherSuite suite)
   auto credential =
     Credential::basic({ 0, 1, 2, 3 }, suite, sig_priv.public_key);
   auto commit =
-    MLSPlaintext{ group_id, epoch, { SenderType::member, 0 }, Commit{} };
+    MLSPlaintext{ group_id, epoch, Sender{ KeyPackageID{ {} } }, Commit{} };
   commit.sign(suite, group_context, sig_priv);
 
   transcript.update_confirmed(commit);
@@ -736,7 +751,6 @@ MessagesTestVector::create()
 {
   auto epoch = epoch_t(0xA0A1A2A3A4A5A6A7);
   auto index = LeafIndex{ 0xB0B1B2B3 };
-  auto sender = Sender{ SenderType::member, index.val };
   auto user_id = bytes(16, 0xD1);
   auto group_id = bytes(16, 0xD2);
   auto opaque = bytes(32, 0xD3);
@@ -756,6 +770,7 @@ MessagesTestVector::create()
   auto cred = Credential::basic(user_id, suite, sig_priv.public_key);
   auto key_package =
     KeyPackage{ suite, hpke_pub, cred, sig_priv, std::nullopt };
+  auto sender = Sender{ key_package.id() };
 
   auto lifetime = LifetimeExtension{ 0x0000000000000000, 0xffffffffffffffff };
   auto capabilities = CapabilitiesExtension{ { version },

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -201,15 +201,18 @@ bytes
 KeyPackage::to_be_signed() const
 {
   tls::ostream out;
-  out << version << cipher_suite << init_key << credential << extensions;
+  out << version << cipher_suite << init_key;
+  tls::vector<1>::encode(out, endpoint_id);
+  out << credential << extensions;
   return out.bytes();
 }
 
 tls::ostream&
 operator<<(tls::ostream& str, const KeyPackage& kp)
 {
-  str << kp.version << kp.cipher_suite << kp.init_key << kp.credential
-      << kp.extensions;
+  str << kp.version << kp.cipher_suite << kp.init_key;
+  tls::vector<1>::encode(str, kp.endpoint_id);
+  str << kp.credential << kp.extensions;
   tls::vector<2>::encode(str, kp.signature);
   return str;
 }
@@ -217,11 +220,9 @@ operator<<(tls::ostream& str, const KeyPackage& kp)
 tls::istream&
 operator>>(tls::istream& str, KeyPackage& kp)
 {
-  str >> kp.version;
-  str >> kp.cipher_suite;
-  str >> kp.init_key;
-  str >> kp.credential;
-  str >> kp.extensions;
+  str >> kp.version >> kp.cipher_suite >> kp.init_key;
+  tls::vector<1>::decode(str, kp.endpoint_id);
+  str >> kp.credential >> kp.extensions;
   tls::vector<2>::decode(str, kp.signature);
 
   if (!kp.verify()) {
@@ -233,14 +234,15 @@ operator>>(tls::istream& str, KeyPackage& kp)
 bool
 operator==(const KeyPackage& lhs, const KeyPackage& rhs)
 {
-  auto version = (lhs.version == rhs.version);
-  auto cipher_suite = (lhs.cipher_suite == rhs.cipher_suite);
-  auto init_key = (lhs.init_key == rhs.init_key);
-  auto credential = (lhs.credential == rhs.credential);
-  auto extensions = (lhs.extensions == rhs.extensions);
-  auto signature = (lhs.signature == rhs.signature);
+  const auto version = (lhs.version == rhs.version);
+  const auto cipher_suite = (lhs.cipher_suite == rhs.cipher_suite);
+  const auto init_key = (lhs.init_key == rhs.init_key);
+  const auto endpoint_id = (lhs.endpoint_id == rhs.endpoint_id);
+  const auto credential = (lhs.credential == rhs.credential);
+  const auto extensions = (lhs.extensions == rhs.extensions);
+  const auto signature = (lhs.signature == rhs.signature);
 
-  return version && cipher_suite && init_key && credential && extensions &&
+  return version && cipher_suite && init_key && endpoint_id && credential && extensions &&
          signature;
 }
 

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -116,10 +116,10 @@ KeyPackage::KeyPackage(CipherSuite suite_in,
   sign(sig_priv_in, opts_in);
 }
 
-bytes
-KeyPackage::hash() const
+KeyPackageID
+KeyPackage::id() const
 {
-  return cipher_suite.digest().hash(tls::marshal(*this));
+  return { cipher_suite.digest().hash(tls::marshal(*this)) };
 }
 
 void

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -109,6 +109,7 @@ KeyPackage::KeyPackage(CipherSuite suite_in,
   : version(ProtocolVersion::mls10)
   , cipher_suite(suite_in)
   , init_key(std::move(init_key_in))
+  , endpoint_id(random_bytes(cipher_suite.secret_size()))
   , credential(std::move(credential_in))
 {
   extensions.add(CapabilitiesExtension::create_default());
@@ -242,8 +243,8 @@ operator==(const KeyPackage& lhs, const KeyPackage& rhs)
   const auto extensions = (lhs.extensions == rhs.extensions);
   const auto signature = (lhs.signature == rhs.signature);
 
-  return version && cipher_suite && init_key && endpoint_id && credential && extensions &&
-         signature;
+  return version && cipher_suite && init_key && endpoint_id && credential &&
+         extensions && signature;
 }
 
 } // namespace mls

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -281,8 +281,8 @@ apply_reuse_guard(const ReuseGuard& guard, bytes& nonce)
 struct MLSSenderData
 {
   KeyPackageID sender;
-  uint32_t generation{0};
-  ReuseGuard reuse_guard{0, 0, 0, 0};
+  uint32_t generation{ 0 };
+  ReuseGuard reuse_guard{ 0, 0, 0, 0 };
 
   TLS_SERIALIZABLE(sender, generation, reuse_guard)
 };

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -281,8 +281,8 @@ apply_reuse_guard(const ReuseGuard& guard, bytes& nonce)
 struct MLSSenderData
 {
   KeyPackageID sender;
-  uint32_t generation;
-  ReuseGuard reuse_guard;
+  uint32_t generation{0};
+  ReuseGuard reuse_guard{0, 0, 0, 0};
 
   TLS_SERIALIZABLE(sender, generation, reuse_guard)
 };

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -280,7 +280,7 @@ apply_reuse_guard(const ReuseGuard& guard, bytes& nonce)
 // } MLSSenderData;
 struct MLSSenderData
 {
-  uint32_t sender;
+  KeyPackageID sender;
   uint32_t generation;
   ReuseGuard reuse_guard;
 
@@ -303,7 +303,8 @@ struct MLSSenderDataAAD
 };
 
 MLSCiphertext
-GroupKeySource::encrypt(LeafIndex index,
+GroupKeySource::encrypt(const TreeKEMPublicKey& tree,
+                        LeafIndex index,
                         const bytes& sender_data_secret,
                         const MLSPlaintext& pt)
 {
@@ -342,7 +343,12 @@ GroupKeySource::encrypt(LeafIndex index,
     content_keys.key, content_keys.nonce, content_aad, content);
 
   // Encrypt the sender data
-  auto sender_data_obj = MLSSenderData{ index.val, generation, reuse_guard };
+  auto maybe_sender_kp = tree.key_package(index);
+  if (!maybe_sender_kp) {
+    throw InvalidParameterError("Attempt to send from blank leaf");
+  }
+  auto sender_id = opt::get(maybe_sender_kp).id();
+  auto sender_data_obj = MLSSenderData{ sender_id, generation, reuse_guard };
   auto sender_data = tls::marshal(sender_data_obj);
 
   auto sender_data_keys =
@@ -366,7 +372,8 @@ GroupKeySource::encrypt(LeafIndex index,
 }
 
 MLSPlaintext
-GroupKeySource::decrypt(const bytes& sender_data_secret,
+GroupKeySource::decrypt(const TreeKEMPublicKey& tree,
+                        const bytes& sender_data_secret,
                         const MLSCiphertext& ct)
 {
   // Decrypt and parse the sender data
@@ -383,7 +390,12 @@ GroupKeySource::decrypt(const bytes& sender_data_secret,
   }
 
   auto sender_data = tls::get<MLSSenderData>(opt::get(sender_data_pt));
-  auto sender = LeafIndex(sender_data.sender);
+  auto maybe_sender = tree.find(sender_data.sender);
+  if (!maybe_sender) {
+    throw ProtocolError("Send from unknown group member");
+  }
+
+  auto sender = opt::get(maybe_sender);
 
   // Pull from the key schedule
   auto key_type = GroupKeySource::RatchetType::handshake;
@@ -421,7 +433,7 @@ GroupKeySource::decrypt(const bytes& sender_data_secret,
   // Set up a new plaintext based on the content
   return MLSPlaintext{ ct.group_id,
                        ct.epoch,
-                       { SenderType::member, sender_data.sender },
+                       { sender_data.sender },
                        ct.content_type,
                        ct.authenticated_data,
                        opt::get(content) };

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -294,6 +294,12 @@ Proposal::proposal_type() const
   return tls::variant<ProposalType>::type(content).val;
 }
 
+SenderType
+Sender::sender_type() const
+{
+  return tls::variant<SenderType>::type(sender);
+}
+
 MLSPlaintext::MLSPlaintext()
   : wire_format(WireFormat::mls_plaintext)
   , epoch(0)

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -67,7 +67,7 @@ PublicGroupState::sign(const TreeKEMPublicKey& tree,
     throw InvalidParameterError("Bad key for index");
   }
 
-  signer = signer_id;
+  signer = std::move(signer_id);
   signature = priv.sign(tree.suite, to_be_signed());
 }
 
@@ -133,7 +133,7 @@ GroupInfo::sign(const TreeKEMPublicKey& tree,
     throw InvalidParameterError("Bad key for index");
   }
 
-  signer = signer_id;
+  signer = std::move(signer_id);
   signature = priv.sign(tree.suite, to_be_signed());
 }
 
@@ -315,7 +315,7 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
   : wire_format(WireFormat::mls_ciphertext) // since this is used for decryption
   , group_id(std::move(group_id_in))
   , epoch(epoch_in)
-  , sender(sender_in)
+  , sender(std::move(sender_in))
   , authenticated_data(std::move(authenticated_data_in))
   , content(ApplicationData())
 {
@@ -356,7 +356,7 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
   : wire_format(WireFormat::mls_plaintext)
   , group_id(std::move(group_id_in))
   , epoch(epoch_in)
-  , sender(sender_in)
+  , sender(std::move(sender_in))
   , content(std::move(application_data_in))
 {}
 
@@ -367,7 +367,7 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
   : wire_format(WireFormat::mls_plaintext)
   , group_id(std::move(group_id_in))
   , epoch(epoch_in)
-  , sender(sender_in)
+  , sender(std::move(sender_in))
   , content(std::move(proposal))
 {}
 
@@ -378,7 +378,7 @@ MLSPlaintext::MLSPlaintext(bytes group_id_in,
   : wire_format(WireFormat::mls_plaintext)
   , group_id(std::move(group_id_in))
   , epoch(epoch_in)
-  , sender(sender_in)
+  , sender(std::move(sender_in))
   , content(std::move(commit))
 {}
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -113,7 +113,8 @@ GroupInfo::to_be_signed() const
   w << epoch;
   tls::vector<1>::encode(w, tree_hash);
   tls::vector<1>::encode(w, confirmed_transcript_hash);
-  w << group_context_extensions << other_extensions << confirmation_tag << signer;
+  w << group_context_extensions << other_extensions << confirmation_tag
+    << signer;
   return w.bytes();
 }
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -320,13 +320,13 @@ Session::handle(const bytes& handshake_data)
 {
   auto pt = inner->import_message(handshake_data);
 
-  if (pt.sender.sender_type != SenderType::member) {
+  if (pt.sender.sender_type() != SenderType::member) {
     throw ProtocolError("External senders not supported");
   }
 
   const auto is_commit = var::holds_alternative<Commit>(pt.content);
   if (is_commit &&
-      LeafIndex(pt.sender.sender) == inner->history.front().index()) {
+      pt.sender.sender == inner->history.front().id()) {
     if (!inner->outbound_cache) {
       throw ProtocolError("Received from self without sending");
     }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -325,8 +325,7 @@ Session::handle(const bytes& handshake_data)
   }
 
   const auto is_commit = var::holds_alternative<Commit>(pt.content);
-  if (is_commit &&
-      pt.sender.sender == inner->history.front().id()) {
+  if (is_commit && pt.sender.sender == inner->history.front().id()) {
     if (!inner->outbound_cache) {
       throw ProtocolError("Received from self without sending");
     }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -988,7 +988,7 @@ State::verify_new_member(const MLSPlaintext& pt) const
         const auto& add = var::get<Add>(proposal.content);
         return add.key_package.credential.public_key();
       },
-      [](const auto& /* other */) -> SignaturePublicKey {
+      [](const ApplicationData& /* unused */) -> SignaturePublicKey {
         throw ProtocolError("New member message of unknown type");
       },
     },

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -251,7 +251,7 @@ State::remove_proposal(KeyPackageID removed) const
     throw InvalidParameterError("Remove on blank leaf");
   }
 
-  return { Remove{ removed } };
+  return { Remove{ std::move(removed) } };
 }
 
 Proposal
@@ -285,7 +285,7 @@ State::remove(RosterIndex index) const
 MLSPlaintext
 State::remove(KeyPackageID removed) const
 {
-  return sign(remove_proposal(removed));
+  return sign(remove_proposal(std::move(removed)));
 }
 
 MLSPlaintext

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -969,30 +969,30 @@ State::verify_internal(const MLSPlaintext& pt) const
 bool
 State::verify_new_member(const MLSPlaintext& pt) const
 {
-  const auto get_new_member_key = overloaded{
-    [](const Commit& commit) {
-      if (!commit.path) {
-        throw ProtocolError("External Commit does not have a path");
-      }
+  const auto& pub = var::visit(
+    overloaded{
+      [](const Commit& commit) {
+        if (!commit.path) {
+          throw ProtocolError("External Commit does not have a path");
+        }
 
-      // Verify with public key from update path leaf key package
-      const auto& kp = opt::get(commit.path).leaf_key_package;
-      return kp.credential.public_key();
-    },
-    [](const Proposal& proposal) {
-      if (proposal.proposal_type() != ProposalType::add) {
-        throw ProtocolError("New member proposal is not an Add");
-      }
+        // Verify with public key from update path leaf key package
+        const auto& kp = opt::get(commit.path).leaf_key_package;
+        return kp.credential.public_key();
+      },
+      [](const Proposal& proposal) {
+        if (proposal.proposal_type() != ProposalType::add) {
+          throw ProtocolError("New member proposal is not an Add");
+        }
 
-      const auto& add = var::get<Add>(proposal.content);
-      return add.key_package.credential.public_key();
+        const auto& add = var::get<Add>(proposal.content);
+        return add.key_package.credential.public_key();
+      },
+      [](const ApplicationData& /*unused*/) -> SignaturePublicKey {
+        throw ProtocolError("New member message of unknown type");
+      },
     },
-    [](const ApplicationData& /*unused*/) -> SignaturePublicKey {
-      throw ProtocolError("New member message of unknown type");
-    },
-  };
-
-  const auto& pub = var::visit(get_new_member_key, pt.content);
+    pt.content);
   return pt.verify(_suite, group_context(), pub);
 }
 

--- a/src/tree_math.cpp
+++ b/src/tree_math.cpp
@@ -32,7 +32,7 @@ LeafIndex::LeafIndex(NodeIndex x)
     throw InvalidParameterError("Only even node indices describe leaves");
   }
 
-  val = x.val >> 1;
+  val = x.val >> 1; // NOLINT(hicpp-signed-bitwise)
 }
 
 NodeIndex::NodeIndex(LeafIndex x)

--- a/src/tree_math.cpp
+++ b/src/tree_math.cpp
@@ -25,6 +25,35 @@ NodeCount::NodeCount(const LeafCount n)
   : UInt32(2 * (n.val - 1) + 1)
 {}
 
+LeafIndex::LeafIndex(NodeIndex x)
+  : UInt32(0)
+{
+  if (x.val % 2 == 1) {
+    throw InvalidParameterError("Only even node indices describe leaves");
+  }
+
+  val = x.val >> 1;
+}
+
+NodeIndex::NodeIndex(LeafIndex x)
+  : UInt32(2 * x.val)
+{}
+
+tls::ostream&
+operator<<(tls::ostream& str, const LeafIndex& obj)
+{
+  return str << NodeIndex(obj);
+}
+
+tls::istream&
+operator>>(tls::istream& str, LeafIndex& obj)
+{
+  auto index = NodeIndex(0);
+  str >> index;
+  obj = LeafIndex(index);
+  return str;
+}
+
 namespace tree_math {
 
 static uint32_t

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -569,14 +569,15 @@ TreeKEMPublicKey::resolve(NodeIndex index) const // NOLINT(misc-no-recursion)
 std::optional<LeafIndex>
 TreeKEMPublicKey::find(const KeyPackage& kp) const
 {
-  for (LeafIndex i{ 0 }; i < size(); i.val++) {
-    const auto& node = node_at(NodeIndex(i)).node;
-    if (!node) {
-      continue;
-    }
+  return find(kp.id());
+}
 
-    const auto& node_kp = var::get<KeyPackage>(opt::get(node).node);
-    if (kp == node_kp) {
+std::optional<LeafIndex>
+TreeKEMPublicKey::find(const KeyPackageID& id) const
+{
+  for (LeafIndex i{ 0 }; i < size(); i.val++) {
+    const auto& node = node_at(NodeIndex(i));
+    if (!node.blank() && node.key_package().id() == id) {
       return i;
     }
   }
@@ -593,6 +594,23 @@ TreeKEMPublicKey::key_package(LeafIndex index) const
   }
 
   return var::get<KeyPackage>(opt::get(node).node);
+}
+
+std::optional<KeyPackage>
+TreeKEMPublicKey::key_package(const KeyPackageID& id) const
+{
+  for (const auto& node : nodes) {
+    if (node.blank() || !node.leaf()) {
+      continue;
+    }
+
+    auto kp = node.key_package();
+    if (kp.id() == id) {
+      return kp;
+    }
+  }
+
+  return std::nullopt;
 }
 
 std::tuple<TreeKEMPrivateKey, UpdatePath>

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -490,7 +490,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Update Everyone in a Group")
 
 TEST_CASE_FIXTURE(RunningGroupTest, "Remove Members from a Group")
 {
-  for (uint32_t i = group_size - 2; i > 0; i -= 1) {
+  for (uint32_t i = uint32_t(group_size) - 2; i > 0; i -= 1) {
     auto remove = states[i].remove_proposal(states[i + 1].id());
     auto [commit, welcome, new_state] =
       states[i].commit(fresh_secret(), CommitOpts{ { remove }, true, false });

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -265,7 +265,7 @@ TEST_CASE_FIXTURE(StateTest, "SFrame Parameter Negotiation")
   kp1.sign(id1, KeyPackageOpts{ kp_extensions });
 
   // Create the initial state of the group
-  auto first0 = State{ group_id, suite, init0, id1, kp1, group_extensions };
+  auto first0 = State{ group_id, suite, init0, id0, kp0, group_extensions };
 
   // Add the second member
   auto add = first0.add_proposal(kp1);
@@ -491,7 +491,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Update Everyone in a Group")
 TEST_CASE_FIXTURE(RunningGroupTest, "Remove Members from a Group")
 {
   for (uint32_t i = group_size - 2; i > 0; i -= 1) {
-    auto remove = states[i].remove_proposal(states[i+1].id());
+    auto remove = states[i].remove_proposal(states[i + 1].id());
     auto [commit, welcome, new_state] =
       states[i].commit(fresh_secret(), CommitOpts{ { remove }, true, false });
     silence_unused(welcome);

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -491,9 +491,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Update Everyone in a Group")
 TEST_CASE_FIXTURE(RunningGroupTest, "Remove Members from a Group")
 {
   for (uint32_t i = group_size - 2; i > 0; i -= 1) {
-    auto kp = states[i].tree().key_package(LeafIndex{i+1});
-    auto kp_id = opt::get(kp).id();
-    auto remove = states[i].remove_proposal(kp_id);
+    auto remove = states[i].remove_proposal(states[i+1].id());
     auto [commit, welcome, new_state] =
       states[i].commit(fresh_secret(), CommitOpts{ { remove }, true, false });
     silence_unused(welcome);

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -490,8 +490,10 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Update Everyone in a Group")
 
 TEST_CASE_FIXTURE(RunningGroupTest, "Remove Members from a Group")
 {
-  for (int i = static_cast<int>(group_size) - 2; i > 0; i -= 1) {
-    auto remove = states[i].remove_proposal(LeafIndex{ uint32_t(i + 1) });
+  for (uint32_t i = group_size - 2; i > 0; i -= 1) {
+    auto kp = states[i].tree().key_package(LeafIndex{i+1});
+    auto kp_id = opt::get(kp).id();
+    auto remove = states[i].remove_proposal(kp_id);
     auto [commit, welcome, new_state] =
       states[i].commit(fresh_secret(), CommitOpts{ { remove }, true, false });
     silence_unused(welcome);


### PR DESCRIPTION
This PR implements the LeafIndex, KeyPackageID, and `endpoint_id` changes to the spec.  We still use LeafIndex internally; in the one or two remaining cases where there is an index on the wire (mainly `unmerged_leaves`) we convert between LeafIndex and NodeIndex on encode/decode.