### PR TITLE
Add missing methods about the current state to Session

### DIFF
--- a/include/mls/session.h
+++ b/include/mls/session.h
@@ -4,6 +4,7 @@
 #include <mls/core_types.h>
 #include <mls/credential.h>
 #include <mls/crypto.h>
+#include <mls/state.h>
 
 namespace mls {
 
@@ -60,6 +61,7 @@ public:
   bytes add(const bytes& key_package_data);
   bytes update();
   bytes remove(uint32_t index);
+  bytes remove(const bytes& key_id_data);
   std::tuple<bytes, bytes> commit(const bytes& proposal);
   std::tuple<bytes, bytes> commit(const std::vector<bytes>& proposals);
   std::tuple<bytes, bytes> commit();
@@ -68,11 +70,16 @@ public:
   bool handle(const bytes& handshake_data);
 
   // Information about the current state
-  epoch_t current_epoch() const;
-  uint32_t index() const;
+  epoch_t epoch() const;
+  KeyPackageID id() const;
+  LeafIndex index() const;
+  CipherSuite cipher_suite() const;
+  const ExtensionList& extensions() const;
+  const TreeKEMPublicKey& tree() const;
   bytes do_export(const std::string& label,
                   const bytes& context,
                   size_t size) const;
+  PublicGroupState public_group_state() const;
   std::vector<KeyPackage> roster() const;
   bytes authentication_secret() const;
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -1,7 +1,6 @@
 #include <mls/session.h>
 
 #include <mls/messages.h>
-#include <mls/state.h>
 
 #include <deque>
 
@@ -279,6 +278,14 @@ Session::remove(uint32_t index)
   return inner->export_message(proposal);
 }
 
+bytes
+Session::remove(const bytes& key_id_data)
+{
+  auto key_id = tls::get<KeyPackageID>(key_id_data);
+  auto proposal = inner->history.front().remove(key_id);
+  return inner->export_message(proposal);
+}
+
 std::tuple<bytes, bytes>
 Session::commit(const bytes& proposal)
 {
@@ -350,15 +357,39 @@ Session::handle(const bytes& handshake_data)
 }
 
 epoch_t
-Session::current_epoch() const
+Session::epoch() const
 {
   return inner->history.front().epoch();
 }
 
-uint32_t
+KeyPackageID
+Session::id() const
+{
+  return inner->history.front().id();
+}
+
+LeafIndex
 Session::index() const
 {
-  return inner->history.front().index().val;
+  return inner->history.front().index();
+}
+
+CipherSuite
+Session::cipher_suite() const
+{
+  return inner->history.front().cipher_suite();
+}
+
+const ExtensionList&
+Session::extensions() const
+{
+  return inner->history.front().extensions();
+}
+
+const TreeKEMPublicKey&
+Session::tree() const
+{
+  return inner->history.front().tree();
 }
 
 bytes
@@ -367,6 +398,12 @@ Session::do_export(const std::string& label,
                    size_t size) const
 {
   return inner->history.front().do_export(label, context, size);
+}
+
+PublicGroupState
+Session::public_group_state() const
+{
+  return inner->history.front().public_group_state();
 }
 
 std::vector<KeyPackage>


### PR DESCRIPTION
I'm developing an application that uses MLSPP and I'm using a `Session` object as the interface between my app and MLS. But I ran into two issues:
* Given a `Session` object, there is no way to retrieve the group ID, the cipher suite, or the current key ID. These information are publicly available in the underlying `State` so I've added them to `Session` as well as other methods that `State` exposes.
* The `remove(RosterIndex)` method is currently unusable: we only have access to the `LeafIndex` returned by `index()`. We could in theory retrieve the `RosterIndex` by looking for the client in `roster()` but as said previously, we don't have access to the key ID or the key package that would allow this search. The previous fix solves this issue as well, and I've also added the `remove(KeyPackageID)` function from `State` to `Session`.

Finally, I've renamed `current_epoch()` to `epoch()` and `index()` now returns a `LeafIndex` to be consistent with the methods from `State`.