### PR TITLE
Use varints for TLS vector headers

### DIFF
--- a/include/mls/core_types.h
+++ b/include/mls/core_types.h
@@ -34,7 +34,6 @@ struct Extension
   bytes data;
 
   TLS_SERIALIZABLE(type, data)
-  TLS_TRAITS(tls::pass, tls::vector<4>)
 };
 
 struct ExtensionType
@@ -82,7 +81,6 @@ struct ExtensionList
   bool has(uint16_t type) const;
 
   TLS_SERIALIZABLE(extensions)
-  TLS_TRAITS(tls::vector<4>)
 };
 
 struct CapabilitiesExtension
@@ -98,7 +96,6 @@ struct CapabilitiesExtension
 
   static const Extension::Type type;
   TLS_SERIALIZABLE(versions, cipher_suites, extensions, proposals)
-  TLS_TRAITS(tls::vector<1>, tls::vector<1>, tls::vector<1>, tls::vector<1>)
 };
 
 struct RequiredCapabilitiesExtension
@@ -108,7 +105,6 @@ struct RequiredCapabilitiesExtension
 
   static const Extension::Type type;
   TLS_SERIALIZABLE(extensions, proposals)
-  TLS_TRAITS(tls::vector<1>, tls::vector<1>)
 };
 
 struct LifetimeExtension
@@ -126,7 +122,6 @@ struct KeyIDExtension
 
   static const Extension::Type type;
   TLS_SERIALIZABLE(key_id)
-  TLS_TRAITS(tls::vector<2>)
 };
 
 struct ParentHashExtension
@@ -135,7 +130,6 @@ struct ParentHashExtension
 
   static const Extension::Type type;
   TLS_SERIALIZABLE(parent_hash)
-  TLS_TRAITS(tls::vector<1>)
 };
 
 ///
@@ -151,7 +145,6 @@ struct ParentNode
   bytes hash(CipherSuite suite) const;
 
   TLS_SERIALIZABLE(public_key, parent_hash, unmerged_leaves)
-  TLS_TRAITS(tls::pass, tls::vector<1>, tls::vector<4>)
 };
 
 // struct {
@@ -173,7 +166,6 @@ struct KeyPackageID
 {
   bytes id;
   TLS_SERIALIZABLE(id)
-  TLS_TRAITS(tls::vector<1>)
 };
 
 struct KeyPackage
@@ -231,7 +223,6 @@ struct RatchetNode
   std::vector<HPKECiphertext> node_secrets;
 
   TLS_SERIALIZABLE(public_key, node_secrets)
-  TLS_TRAITS(tls::pass, tls::vector<4>)
 };
 
 // struct {
@@ -243,7 +234,6 @@ struct UpdatePath
   std::vector<RatchetNode> nodes;
 
   TLS_SERIALIZABLE(leaf_key_package, nodes)
-  TLS_TRAITS(tls::pass, tls::vector<4>)
 };
 
 } // namespace mls

--- a/include/mls/credential.h
+++ b/include/mls/credential.h
@@ -26,7 +26,6 @@ struct BasicCredential
   SignaturePublicKey public_key;
 
   TLS_SERIALIZABLE(identity, scheme, public_key)
-  TLS_TRAITS(tls::vector<2>, tls::pass, tls::pass)
 };
 
 struct X509Credential
@@ -36,7 +35,6 @@ struct X509Credential
     bytes data;
 
     TLS_SERIALIZABLE(data)
-    TLS_TRAITS(tls::vector<2>)
   };
 
   X509Credential() = default;

--- a/include/mls/crypto.h
+++ b/include/mls/crypto.h
@@ -97,7 +97,6 @@ struct HPKECiphertext
   bytes ciphertext;
 
   TLS_SERIALIZABLE(kem_output, ciphertext)
-  TLS_TRAITS(tls::vector<2>, tls::vector<2>)
 };
 
 struct HPKEPublicKey
@@ -115,7 +114,6 @@ struct HPKEPublicKey
                                      size_t size) const;
 
   TLS_SERIALIZABLE(data)
-  TLS_TRAITS(tls::vector<2>)
 };
 
 struct HPKEPrivateKey
@@ -141,7 +139,6 @@ struct HPKEPrivateKey
                   size_t size) const;
 
   TLS_SERIALIZABLE(data, public_key)
-  TLS_TRAITS(tls::vector<2>, tls::pass)
 
 private:
   HPKEPrivateKey(bytes priv_data, bytes pub_data);
@@ -157,7 +154,6 @@ struct SignaturePublicKey
               const bytes& signature) const;
 
   TLS_SERIALIZABLE(data)
-  TLS_TRAITS(tls::vector<2>)
 };
 
 struct SignaturePrivateKey
@@ -172,7 +168,6 @@ struct SignaturePrivateKey
   bytes sign(const CipherSuite& suite, const bytes& message) const;
 
   TLS_SERIALIZABLE(data, public_key)
-  TLS_TRAITS(tls::vector<2>, tls::pass)
 
 private:
   SignaturePrivateKey(bytes priv_data, bytes pub_data);

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -35,7 +35,6 @@ struct SFrameCapabilities
 
   static const uint16_t type;
   TLS_SERIALIZABLE(cipher_suites)
-  TLS_TRAITS(tls::vector<1>)
 };
 
 struct MAC
@@ -43,7 +42,6 @@ struct MAC
   bytes mac_value;
 
   TLS_SERIALIZABLE(mac_value)
-  TLS_TRAITS(tls::vector<1>)
 };
 
 ///
@@ -61,7 +59,6 @@ struct ExternalPSK
 {
   bytes psk_id;
   TLS_SERIALIZABLE(psk_id)
-  TLS_TRAITS(tls::vector<1>)
 };
 
 struct ReInitPSK
@@ -69,7 +66,6 @@ struct ReInitPSK
   bytes group_id;
   epoch_t psk_epoch;
   TLS_SERIALIZABLE(group_id, psk_epoch)
-  TLS_TRAITS(tls::vector<1>, tls::pass)
 };
 
 struct BranchPSK
@@ -77,7 +73,6 @@ struct BranchPSK
   bytes group_id;
   epoch_t psk_epoch;
   TLS_SERIALIZABLE(group_id, psk_epoch)
-  TLS_TRAITS(tls::vector<1>, tls::pass)
 };
 
 struct PreSharedKeyID
@@ -85,14 +80,13 @@ struct PreSharedKeyID
   var::variant<ExternalPSK, ReInitPSK, BranchPSK> content;
   bytes psk_nonce;
   TLS_SERIALIZABLE(content, psk_nonce)
-  TLS_TRAITS(tls::variant<PSKType>, tls::vector<1>)
+  TLS_TRAITS(tls::variant<PSKType>, tls::pass)
 };
 
 struct PreSharedKeys
 {
   std::vector<PreSharedKeyID> psks;
   TLS_SERIALIZABLE(psks)
-  TLS_TRAITS(tls::vector<2>)
 };
 
 struct PSKWithSecret
@@ -152,16 +146,6 @@ struct PublicGroupState
                    external_pub,
                    signer,
                    signature)
-  TLS_TRAITS(tls::pass,
-             tls::vector<1>,
-             tls::pass,
-             tls::vector<1>,
-             tls::vector<1>,
-             tls::pass,
-             tls::pass,
-             tls::pass,
-             tls::pass,
-             tls::vector<2>)
 };
 
 // struct {
@@ -213,15 +197,6 @@ public:
                    confirmation_tag,
                    signer,
                    signature)
-  TLS_TRAITS(tls::vector<1>,
-             tls::pass,
-             tls::vector<1>,
-             tls::vector<1>,
-             tls::pass,
-             tls::pass,
-             tls::pass,
-             tls::pass,
-             tls::vector<2>)
 };
 
 // struct {
@@ -236,7 +211,6 @@ struct GroupSecrets
     bytes secret;
 
     TLS_SERIALIZABLE(secret)
-    TLS_TRAITS(tls::vector<1>)
   };
 
   bytes joiner_secret;
@@ -244,7 +218,6 @@ struct GroupSecrets
   PreSharedKeys psks;
 
   TLS_SERIALIZABLE(joiner_secret, path_secret, psks)
-  TLS_TRAITS(tls::vector<1>, tls::pass, tls::pass)
 };
 
 // struct {
@@ -284,7 +257,6 @@ struct Welcome
                     const std::vector<PSKWithSecret>& psks) const;
 
   TLS_SERIALIZABLE(version, cipher_suite, secrets, encrypted_group_info)
-  TLS_TRAITS(tls::pass, tls::pass, tls::vector<4>, tls::vector<4>)
 
 private:
   bytes _joiner_secret;
@@ -335,7 +307,6 @@ struct ReInit
   ExtensionList extensions;
 
   TLS_SERIALIZABLE(group_id, version, cipher_suite, extensions)
-  TLS_TRAITS(tls::vector<1>, tls::pass, tls::pass, tls::pass)
 };
 
 // ExternalInit
@@ -343,7 +314,6 @@ struct ExternalInit
 {
   bytes kem_output;
   TLS_SERIALIZABLE(kem_output)
-  TLS_TRAITS(tls::vector<2>)
 };
 
 // AppAck
@@ -359,7 +329,6 @@ struct AppAck
 {
   std::vector<MessageRange> received_ranges;
   TLS_SERIALIZABLE(received_ranges)
-  TLS_TRAITS(tls::vector<4>)
 };
 
 // GroupContextExtensions
@@ -419,7 +388,6 @@ struct ProposalRef
 {
   bytes id;
   TLS_SERIALIZABLE(id)
-  TLS_TRAITS(tls::vector<1>)
 };
 
 enum struct ProposalOrRefType : uint8_t
@@ -451,7 +419,6 @@ struct Commit
   std::optional<bytes> valid_external() const;
 
   TLS_SERIALIZABLE(proposals, path)
-  TLS_TRAITS(tls::vector<4>, tls::pass)
 };
 
 // struct {
@@ -475,7 +442,6 @@ struct ApplicationData
 {
   bytes data;
   TLS_SERIALIZABLE(data)
-  TLS_TRAITS(tls::vector<4>)
 };
 
 struct GroupContext;
@@ -507,7 +473,6 @@ struct PreconfiguredKeyID
 {
   bytes id;
   TLS_SERIALIZABLE(id)
-  TLS_TRAITS(tls::vector<1>)
 };
 
 struct NewMemberID
@@ -585,12 +550,12 @@ struct MLSPlaintext
                    confirmation_tag,
                    membership_tag)
   TLS_TRAITS(tls::pass,
-             tls::vector<1>,
              tls::pass,
              tls::pass,
-             tls::vector<4>,
+             tls::pass,
+             tls::pass,
              tls::variant<ContentType>,
-             tls::vector<2>,
+             tls::pass,
              tls::pass,
              tls::pass)
 };
@@ -620,13 +585,6 @@ struct MLSCiphertext
                    authenticated_data,
                    encrypted_sender_data,
                    ciphertext)
-  TLS_TRAITS(tls::pass,
-             tls::vector<1>,
-             tls::pass,
-             tls::pass,
-             tls::vector<4>,
-             tls::vector<1>,
-             tls::vector<4>)
 };
 
 } // namespace mls

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -30,11 +30,6 @@ struct GroupContext
                    tree_hash,
                    confirmed_transcript_hash,
                    extensions)
-  TLS_TRAITS(tls::vector<1>,
-             tls::pass,
-             tls::vector<1>,
-             tls::vector<1>,
-             tls::pass)
 };
 
 // Index into the session roster

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -165,7 +165,6 @@ struct TreeKEMPublicKey
   }
 
   TLS_SERIALIZABLE(nodes)
-  TLS_TRAITS(tls::vector<4>)
 
 private:
   void clear_hash_all();

--- a/lib/hpke/test/hpke.cpp
+++ b/lib/hpke/test/hpke.cpp
@@ -198,9 +198,9 @@ TEST_CASE("HPKE Round-Trip")
 
         auto hpke = HPKE(kem_id, kdf_id, aead_id);
 
-        auto [enc, ctxS] = hpke.setup_base_s(*pkR, info);
+        auto enc_and_ctxS = hpke.setup_base_s(*pkR, info);
         auto ctxR = hpke.setup_base_r(enc, *skR, info);
-        REQUIRE(ctxS == ctxR);
+        REQUIRE(std::get<1>(enc_and_ctxS) == ctxR);
 
         auto last_encrypted = bytes{};
         for (int i = 0; i < iterations; i += 1) {

--- a/lib/hpke/test/hpke.cpp
+++ b/lib/hpke/test/hpke.cpp
@@ -198,9 +198,14 @@ TEST_CASE("HPKE Round-Trip")
 
         auto hpke = HPKE(kem_id, kdf_id, aead_id);
 
+        // XXX(RLB) Manual destructuring here because the Ubuntu compiler gets
+        // unhappy if we use a destructuring assignment.
         auto enc_and_ctxS = hpke.setup_base_s(*pkR, info);
+        auto enc = std::get<0>(enc_and_ctxS);
+        auto ctxS = std::get<1>(enc_and_ctxS);
+
         auto ctxR = hpke.setup_base_r(enc, *skR, info);
-        REQUIRE(std::get<1>(enc_and_ctxS) == ctxR);
+        REQUIRE(ctxS == ctxR);
 
         auto last_encrypted = bytes{};
         for (int i = 0; i < iterations; i += 1) {

--- a/lib/hpke/test/hpke.cpp
+++ b/lib/hpke/test/hpke.cpp
@@ -201,7 +201,6 @@ TEST_CASE("HPKE Round-Trip")
         auto [enc, ctxS] = hpke.setup_base_s(*pkR, info);
         auto ctxR = hpke.setup_base_r(enc, *skR, info);
         REQUIRE(ctxS == ctxR);
-        // TODO(RLB): Define operator==, CHECK(ctxS == ctxR)
 
         auto last_encrypted = bytes{};
         for (int i = 0; i < iterations; i += 1) {

--- a/lib/tls_syntax/include/tls/tls_syntax.h
+++ b/lib/tls_syntax/include/tls/tls_syntax.h
@@ -659,24 +659,4 @@ inline
   return str;
 }
 
-///
-/// Abbreviation for opaque<N>
-///
-
-template<size_t N>
-struct opaque
-{
-  std::vector<uint8_t> data;
-
-  TLS_SERIALIZABLE(data)
-  TLS_TRAITS(vector<N>)
-};
-
-template<size_t N>
-bool
-operator==(const opaque<N>& lhs, const opaque<N>& rhs)
-{
-  return lhs.data == rhs.data;
-}
-
 } // namespace tls

--- a/lib/tls_syntax/include/tls/tls_syntax.h
+++ b/lib/tls_syntax/include/tls/tls_syntax.h
@@ -454,12 +454,12 @@ variant<Ts>::decode(istream& str, var::variant<Tp...>& data)
 static constexpr size_t VARINT_1_OFFSET = 6;
 static constexpr size_t VARINT_2_OFFSET = 14;
 static constexpr size_t VARINT_4_OFFSET = 30;
-static constexpr uint8_t VARINT_1_HEADER = 0 << VARINT_1_OFFSET;
-static constexpr uint16_t VARINT_2_HEADER = 1 << VARINT_2_OFFSET;
-static constexpr uint32_t VARINT_4_HEADER = 2 << VARINT_4_OFFSET;
-static constexpr uint64_t VARINT_1_MAX = (1 << VARINT_1_OFFSET) - 1;
-static constexpr uint64_t VARINT_2_MAX = (1 << VARINT_2_OFFSET) - 1;
-static constexpr uint64_t VARINT_4_MAX = (1 << VARINT_4_OFFSET) - 1;
+static constexpr auto VARINT_1_HEADER = uint8_t(0 << VARINT_1_OFFSET);
+static constexpr auto VARINT_2_HEADER = uint16_t(1 << VARINT_2_OFFSET);
+static constexpr auto VARINT_4_HEADER = uint32_t(2 << VARINT_4_OFFSET);
+static constexpr auto VARINT_1_MAX = uint64_t((1 << VARINT_1_OFFSET) - 1);
+static constexpr auto VARINT_2_MAX = uint64_t((1 << VARINT_2_OFFSET) - 1);
+static constexpr auto VARINT_4_MAX = uint64_t((1 << VARINT_4_OFFSET) - 1);
 
 template<typename T, typename>
 ostream&
@@ -483,7 +483,7 @@ istream&
 varint::decode(istream& str, T& val)
 {
   auto log_size = str._buffer.back() >> VARINT_1_OFFSET;
-  if (sizeof(T) < (1 << log_size)) {
+  if (sizeof(T) < size_t(1 << log_size)) {
     throw ReadError("Varint value too large for storage");
   }
 

--- a/lib/tls_syntax/include/tls/tls_syntax.h
+++ b/lib/tls_syntax/include/tls/tls_syntax.h
@@ -56,9 +56,6 @@ private:
 
   template<typename T>
   friend ostream& operator<<(ostream& out, const std::vector<T>& data);
-
-  template<size_t head, size_t min, size_t max>
-  friend struct vector;
 };
 
 class istream
@@ -99,9 +96,6 @@ private:
   template<typename T>
   friend istream& operator>>(istream& in, std::vector<T>& data);
 
-  template<size_t head, size_t min, size_t max>
-  friend struct vector;
-
   friend struct varint;
 };
 
@@ -127,16 +121,6 @@ struct pass
 
   template<typename T>
   static istream& decode(istream& str, T& val);
-};
-
-template<size_t head, size_t min = none, size_t max = none>
-struct vector
-{
-  template<typename T>
-  static ostream& encode(ostream& str, const std::vector<T>& data);
-
-  template<typename T>
-  static istream& decode(istream& str, std::vector<T>& data);
 };
 
 template<typename Ts>
@@ -392,23 +376,6 @@ istream&
 pass::decode(istream& str, T& val)
 {
   return str >> val;
-}
-
-// Vector encoding
-template<size_t head, size_t min, size_t max>
-template<typename T>
-ostream&
-vector<head, min, max>::encode(ostream& str, const std::vector<T>& data)
-{
-  return str << data;
-}
-
-template<size_t head, size_t min, size_t max>
-template<typename T>
-istream&
-vector<head, min, max>::decode(istream& str, std::vector<T>& data)
-{
-  return str >> data;
 }
 
 // Variant encoding

--- a/lib/tls_syntax/include/tls/tls_syntax.h
+++ b/lib/tls_syntax/include/tls/tls_syntax.h
@@ -79,10 +79,10 @@ private:
   uint8_t next();
 
   template<typename T>
-  istream& read_uint(T& data, int length)
+  istream& read_uint(T& data, size_t length)
   {
     uint64_t value = 0;
-    for (int i = 0; i < length; i += 1) {
+    for (size_t i = 0; i < length; i += 1) {
       value = (value << unsigned(8)) + next();
     }
     data = static_cast<T>(value);

--- a/lib/tls_syntax/include/tls/tls_syntax.h
+++ b/lib/tls_syntax/include/tls/tls_syntax.h
@@ -297,7 +297,8 @@ operator>>(istream& str, std::vector<T>& vec)
   // NB: Remember that we store the vector in reverse order
   // NB: This requires that T be default-constructible
   istream r;
-  r._buffer = std::vector<uint8_t>{str._buffer.end() - size, str._buffer.end()};
+  r._buffer =
+    std::vector<uint8_t>{ str._buffer.end() - size, str._buffer.end() };
 
   vec.clear();
   while (r._buffer.size() > 0) {
@@ -494,7 +495,9 @@ static constexpr uint64_t VARINT_2_MAX = (1 << VARINT_2_OFFSET) - 1;
 static constexpr uint64_t VARINT_4_MAX = (1 << VARINT_4_OFFSET) - 1;
 
 template<typename T, typename>
-ostream& varint::encode(ostream& str, const T& val) {
+ostream&
+varint::encode(ostream& str, const T& val)
+{
   if (val <= VARINT_1_MAX) {
     return str << uint8_t(VARINT_1_HEADER | static_cast<uint8_t>(val));
   } else if (val <= VARINT_2_MAX) {
@@ -509,7 +512,9 @@ ostream& varint::encode(ostream& str, const T& val) {
 }
 
 template<typename T, typename>
-istream& varint::decode(istream& str, T& val) {
+istream&
+varint::decode(istream& str, T& val)
+{
   auto log_size = str._buffer.back() >> VARINT_1_OFFSET;
   if (sizeof(T) < (1 << log_size)) {
     throw ReadError("Varint value too large for storage");
@@ -611,9 +616,9 @@ read_tuple(istream&, const std::tuple<Tp...>&)
 {}
 
 template<size_t I = 0, typename... Tp>
-  inline typename std::enable_if <
-  I<sizeof...(Tp), void>::type
-  read_tuple(istream& str, const std::tuple<Tp...>& t)
+  inline
+  typename std::enable_if < I<sizeof...(Tp), void>::type
+                            read_tuple(istream& str, const std::tuple<Tp...>& t)
 {
   str >> std::get<I>(t);
   read_tuple<I + 1, Tp...>(str, t);

--- a/lib/tls_syntax/include/tls/tls_syntax.h
+++ b/lib/tls_syntax/include/tls/tls_syntax.h
@@ -454,12 +454,12 @@ variant<Ts>::decode(istream& str, var::variant<Tp...>& data)
 static constexpr size_t VARINT_1_OFFSET = 6;
 static constexpr size_t VARINT_2_OFFSET = 14;
 static constexpr size_t VARINT_4_OFFSET = 30;
-static constexpr auto VARINT_1_HEADER = uint8_t(0 << VARINT_1_OFFSET);
-static constexpr auto VARINT_2_HEADER = uint16_t(1 << VARINT_2_OFFSET);
-static constexpr auto VARINT_4_HEADER = uint32_t(2 << VARINT_4_OFFSET);
-static constexpr auto VARINT_1_MAX = uint64_t((1 << VARINT_1_OFFSET) - 1);
-static constexpr auto VARINT_2_MAX = uint64_t((1 << VARINT_2_OFFSET) - 1);
-static constexpr auto VARINT_4_MAX = uint64_t((1 << VARINT_4_OFFSET) - 1);
+static constexpr uint64_t VARINT_1_HEADER = 0x00;       // 0 << V1_OFFSET
+static constexpr uint64_t VARINT_2_HEADER = 0x4000;     // 1 << V2_OFFSET
+static constexpr uint64_t VARINT_4_HEADER = 0x80000000; // 2 << V4_OFFSET
+static constexpr uint64_t VARINT_1_MAX = 0x3f;          // (1 << V1_OFFSET) - 1
+static constexpr uint64_t VARINT_2_MAX = 0x3fff;        // (1 << V2_OFFSET) - 1
+static constexpr uint64_t VARINT_4_MAX = 0x3fffffff;    // (1 << V4_OFFSET) - 1
 
 template<typename T, typename>
 ostream&

--- a/lib/tls_syntax/src/tls_syntax.cpp
+++ b/lib/tls_syntax/src/tls_syntax.cpp
@@ -145,7 +145,7 @@ varint::decode(istream& str, uint64_t& val)
   }
 
   auto read = uint64_t(0);
-  auto read_bytes = int(1 << log_size);
+  auto read_bytes = size_t(1) << log_size;
   str.read_uint(read, read_bytes);
 
   switch (log_size) {

--- a/lib/tls_syntax/src/tls_syntax.cpp
+++ b/lib/tls_syntax/src/tls_syntax.cpp
@@ -123,13 +123,17 @@ varint::encode(ostream& str, const uint64_t& val)
 {
   if (val <= VARINT_1_MAX) {
     return str.write_uint(VARINT_1_HEADER | val, 1);
-  } else if (val <= VARINT_2_MAX) {
-    return str.write_uint(VARINT_2_HEADER | val, 2);
-  } else if (val <= VARINT_4_MAX) {
-    return str.write_uint(VARINT_4_HEADER | val, 4);
-  } else {
-    throw WriteError("Varint value exceeds maximum size");
   }
+
+  if (val <= VARINT_2_MAX) {
+    return str.write_uint(VARINT_2_HEADER | val, 2);
+  }
+
+  if (val <= VARINT_4_MAX) {
+    return str.write_uint(VARINT_4_HEADER | val, 4);
+  }
+
+  throw WriteError("Varint value exceeds maximum size");
 }
 
 istream&
@@ -146,7 +150,7 @@ varint::decode(istream& str, uint64_t& val)
 
   switch (log_size) {
     case 0:
-      val = (read ^ VARINT_1_HEADER);
+      read ^= VARINT_1_HEADER;
       break;
 
     case 1:
@@ -167,6 +171,7 @@ varint::decode(istream& str, uint64_t& val)
       throw ReadError("Malformed varint header");
   }
 
+  val = read;
   return str;
 }
 

--- a/lib/tls_syntax/src/tls_syntax.cpp
+++ b/lib/tls_syntax/src/tls_syntax.cpp
@@ -139,13 +139,13 @@ varint::encode(ostream& str, const uint64_t& val)
 istream&
 varint::decode(istream& str, uint64_t& val)
 {
-  auto log_size = str._buffer.back() >> VARINT_HEADER_OFFSET;
+  auto log_size = size_t(str._buffer.back() >> VARINT_HEADER_OFFSET);
   if (log_size > 2) {
     throw ReadError("Malformed varint header");
   }
 
   auto read = uint64_t(0);
-  auto read_bytes = size_t(1) << log_size;
+  auto read_bytes = size_t(size_t(1) << log_size);
   str.read_uint(read, read_bytes);
 
   switch (log_size) {

--- a/lib/tls_syntax/test/tls_syntax.cpp
+++ b/lib/tls_syntax/test/tls_syntax.cpp
@@ -27,9 +27,9 @@ struct ExampleStruct
   std::optional<uint8_t> c;
   std::vector<uint8_t> d;
   tls::var::variant<uint8_t, uint16_t> e;
-  uint8_t f;
-  uint16_t g;
-  uint32_t h;
+  uint64_t f;
+  uint64_t g;
+  uint64_t h;
 
   TLS_SERIALIZABLE(a, b, c, d, e, f, g, h)
   TLS_TRAITS(tls::pass,
@@ -207,12 +207,6 @@ TEST_CASE("TLS varint failure cases")
     auto r = tls::istream(enc);
     REQUIRE_THROWS(tls::varint::decode(r, val));
   }
-
-  // Don't overflow storage
-  auto val = uint8_t(0);
-  auto enc = from_hex("7fff");
-  auto r = tls::istream(enc);
-  REQUIRE_THROWS(tls::varint::decode(r, val));
 }
 
 // TODO(rlb@ipv.sx) Test failure cases

--- a/lib/tls_syntax/test/tls_syntax.cpp
+++ b/lib/tls_syntax/test/tls_syntax.cpp
@@ -80,8 +80,8 @@ protected:
     0x2222,
     0x33333333,
   };
-  const bytes enc_struct =
-    from_hex("1111222222223333333344444444555555550166027788BBBB9999116222b3333333");
+  const bytes enc_struct = from_hex(
+    "1111222222223333333344444444555555550166027788BBBB9999116222b3333333");
 
   const std::optional<ExampleStruct> val_optional{ val_struct };
   const bytes enc_optional = from_hex("01") + enc_struct;
@@ -187,7 +187,8 @@ TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS abbreviations")
   REQUIRE(val_in == val_out2);
 }
 
-TEST_CASE("TLS varint failure cases") {
+TEST_CASE("TLS varint failure cases")
+{
   // Encoding a value that is to large
   tls::ostream w;
   REQUIRE_THROWS(tls::varint::encode(w, uint64_t(0xffffffff)));

--- a/lib/tls_syntax/test/tls_syntax.cpp
+++ b/lib/tls_syntax/test/tls_syntax.cpp
@@ -35,7 +35,7 @@ struct ExampleStruct
   TLS_TRAITS(tls::pass,
              tls::pass,
              tls::pass,
-             tls::vector<2>,
+             tls::pass,
              tls::variant<IntType>,
              tls::varint,
              tls::varint,
@@ -70,6 +70,9 @@ protected:
   const std::array<uint16_t, 4> val_array{ 1, 2, 3, 4 };
   const bytes enc_array = from_hex("0001000200030004");
 
+  const std::vector<uint32_t> val_vector{ 5, 6, 7, 8 };
+  const bytes enc_vector = from_hex("1000000005000000060000000700000008");
+
   const ExampleStruct val_struct{
     0x1111,
     { 0x22222222, 0x33333333, 0x44444444, 0x55555555 },
@@ -91,9 +94,6 @@ protected:
 
   const IntType val_enum = IntType::uint8;
   const bytes enc_enum = from_hex("aaaa");
-
-  const tls::opaque<2> val_opaque{ from_hex("bbbb") };
-  const bytes enc_opaque = from_hex("02bbbb");
 };
 
 template<typename T>
@@ -119,11 +119,11 @@ TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS ostream")
   ostream_test(val_uint32, enc_uint32);
   ostream_test(val_uint64, enc_uint64);
   ostream_test(val_array, enc_array);
+  ostream_test(val_vector, enc_vector);
   ostream_test(val_struct, enc_struct);
   ostream_test(val_optional, enc_optional);
   ostream_test(val_optional_null, enc_optional_null);
   ostream_test(val_enum, enc_enum);
-  ostream_test(val_opaque, enc_opaque);
 }
 
 template<typename T>
@@ -155,6 +155,9 @@ TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS istream")
 
   std::array<uint16_t, 4> data_array = { 0, 0, 0, 0 };
   istream_test(val_array, data_array, enc_array);
+
+  std::vector<uint32_t> data_vector = {};
+  istream_test(val_vector, data_vector, enc_vector);
 
   ExampleStruct data_struct;
   istream_test(val_struct, data_struct, enc_struct);

--- a/lib/tls_syntax/test/tls_syntax.cpp
+++ b/lib/tls_syntax/test/tls_syntax.cpp
@@ -85,6 +85,15 @@ protected:
 
   const tls::opaque<2> val_opaque{ from_hex("bbbb") };
   const bytes enc_opaque = from_hex("0002bbbb");
+
+  const uint8_t val_varint8{ 0x11 };
+  const bytes enc_varint8 = from_hex("11");
+
+  const uint16_t val_varint16{ 0x2222 };
+  const bytes enc_varint16 = from_hex("6222");
+
+  const uint32_t val_varint32{ 0x33333333 };
+  const bytes enc_varint32 = from_hex("b3333333");
 };
 
 template<typename T>
@@ -115,6 +124,9 @@ TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS ostream")
   ostream_test(val_optional_null, enc_optional_null);
   ostream_test(val_enum, enc_enum);
   ostream_test(val_opaque, enc_opaque);
+  ostream_test(val_varint8, enc_varint8);
+  ostream_test(val_varint16, enc_varint16);
+  ostream_test(val_varint32, enc_varint32);
 }
 
 template<typename T>
@@ -159,8 +171,14 @@ TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS istream")
   IntType data_enum = IntType::uint16;
   istream_test(val_enum, data_enum, enc_enum);
 
-  tls::opaque<2> data_opaque;
-  istream_test(val_opaque, data_opaque, enc_opaque);
+  varint8_t data_varint8 = 0;
+  istream_test(val_varint8, data_varint8, enc_varint8);
+
+  varint16_t data_varint16 = 0;
+  istream_test(val_varint16, data_varint16, enc_varint16);
+
+  varint32_t data_varint32 = 0;
+  istream_test(val_varint32, data_varint32, enc_varint32);
 }
 
 TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS abbreviations")

--- a/lib/tls_syntax/test/tls_syntax.cpp
+++ b/lib/tls_syntax/test/tls_syntax.cpp
@@ -27,9 +27,9 @@ struct ExampleStruct
   std::optional<uint8_t> c;
   std::vector<uint8_t> d;
   tls::var::variant<uint8_t, uint16_t> e;
-  uint64_t f;
-  uint64_t g;
-  uint64_t h;
+  uint64_t f{ 0 };
+  uint64_t g{ 0 };
+  uint64_t h{ 0 };
 
   TLS_SERIALIZABLE(a, b, c, d, e, f, g, h)
   TLS_TRAITS(tls::pass,
@@ -194,6 +194,7 @@ TEST_CASE("TLS varint failure cases")
 {
   // Encoding a value that is to large
   tls::ostream w;
+  // NOLINTNEXTLINE(llvm-else-after-return, readability-else-after-return)
   REQUIRE_THROWS(tls::varint::encode(w, uint64_t(0xffffffff)));
 
   // Too large and non-minimal values
@@ -205,6 +206,7 @@ TEST_CASE("TLS varint failure cases")
   for (const auto& enc : decode_failure_cases) {
     auto val = uint64_t(0);
     auto r = tls::istream(enc);
+    // NOLINTNEXTLINE(llvm-else-after-return, readability-else-after-return)
     REQUIRE_THROWS(tls::varint::decode(r, val));
   }
 }

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -202,29 +202,24 @@ bytes
 KeyPackage::to_be_signed() const
 {
   tls::ostream out;
-  out << version << cipher_suite << init_key;
-  tls::vector<1>::encode(out, endpoint_id);
-  out << credential << extensions;
+  out << version << cipher_suite << init_key << endpoint_id << credential
+      << extensions;
   return out.bytes();
 }
 
 tls::ostream&
 operator<<(tls::ostream& str, const KeyPackage& kp)
 {
-  str << kp.version << kp.cipher_suite << kp.init_key;
-  tls::vector<1>::encode(str, kp.endpoint_id);
-  str << kp.credential << kp.extensions;
-  tls::vector<2>::encode(str, kp.signature);
+  str << kp.version << kp.cipher_suite << kp.init_key << kp.endpoint_id
+      << kp.credential << kp.extensions << kp.signature;
   return str;
 }
 
 tls::istream&
 operator>>(tls::istream& str, KeyPackage& kp)
 {
-  str >> kp.version >> kp.cipher_suite >> kp.init_key;
-  tls::vector<1>::decode(str, kp.endpoint_id);
-  str >> kp.credential >> kp.extensions;
-  tls::vector<2>::decode(str, kp.signature);
+  str >> kp.version >> kp.cipher_suite >> kp.init_key >> kp.endpoint_id >>
+    kp.credential >> kp.extensions >> kp.signature;
 
   if (!kp.verify()) {
     throw InvalidParameterError("Invalid signature on key package");

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -82,15 +82,15 @@ X509Credential::public_key() const
 tls::ostream&
 operator<<(tls::ostream& str, const X509Credential& obj)
 {
-  tls::vector<4>::encode(str, obj.der_chain);
-  return str;
+  return str << obj.der_chain;
 }
 
 tls::istream&
 operator>>(tls::istream& str, X509Credential& obj)
 {
   auto der_chain = std::vector<X509Credential::CertData>{};
-  tls::vector<4>::decode(str, der_chain);
+  str >> der_chain;
+
   std::vector<bytes> der_in;
   der_in.resize(der_chain.size());
 

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -153,7 +153,6 @@ struct HKDFLabel
   bytes context;
 
   TLS_SERIALIZABLE(length, label, context)
-  TLS_TRAITS(tls::pass, tls::vector<1>, tls::vector<4>)
 };
 
 bytes

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -251,7 +251,6 @@ struct MLSCiphertextContentAAD
   const bytes& authenticated_data;
 
   TLS_SERIALIZABLE(group_id, epoch, content_type, authenticated_data)
-  TLS_TRAITS(tls::vector<1>, tls::pass, tls::pass, tls::vector<4>)
 };
 
 using ReuseGuard = std::array<uint8_t, 4>;
@@ -299,7 +298,6 @@ struct MLSSenderDataAAD
   const ContentType content_type;
 
   TLS_SERIALIZABLE(group_id, epoch, content_type)
-  TLS_TRAITS(tls::vector<1>, tls::pass, tls::pass)
 };
 
 MLSCiphertext

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -78,9 +78,7 @@ OptionalNode::set_tree_hash(CipherSuite suite,
   }
 
   tls::ostream w;
-  w << index << parent;
-  tls::vector<1>::encode(w, left);
-  tls::vector<1>::encode(w, right);
+  w << index << parent << left << right;
   hash = suite.digest().hash(w.bytes());
 }
 
@@ -738,7 +736,6 @@ struct ParentHashInput
   std::vector<HPKEPublicKey> original_child_resolution;
 
   TLS_SERIALIZABLE(public_key, parent_hash, original_child_resolution)
-  TLS_TRAITS(tls::pass, tls::vector<1>, tls::vector<4>)
 };
 
 bytes

--- a/test/crypto.cpp
+++ b/test/crypto.cpp
@@ -45,7 +45,8 @@ TEST_CASE("HPKE Key Serialization")
     HPKEPublicKey parsed{ gX.data };
     REQUIRE(parsed == gX);
 
-    auto gX2 = tls::get<HPKEPublicKey>(tls::marshal(gX));
+    auto marshaled = tls::marshal(gX);
+    auto gX2 = tls::get<HPKEPublicKey>(marshaled);
     REQUIRE(gX2 == gX);
   }
 }


### PR DESCRIPTION
Corresponds to https://github.com/mlswg/mls-protocol/pull/594

This is a big PR just because there was a lot of `tls::vector` boilerplate around.  I also did some cleanup in `tls_syntax.h` while the patient was on the table: Moving declarations to the top, removing unnecessary `tls::`, and removing the unused `opaque` type.