### PR TITLE
Enable compatibility with modern clang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,9 +61,3 @@ jobs:
     - name: Unit tests
       run: |
          cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target "${{ matrix.ctest-target}}"
-
-    - name: Build interop harness
-      run: |
-         cd cmd/interop
-         cmake -B build -DSANITIZERS=ON -DCMAKE_TOOLCHAIN_FILE="${{ matrix.vcpkg-cmake-file}}" .
-         cmake --build build

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Build the library      
       run: |
-        cmake -B build
+        cmake -B build -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}" .
         cmake --build build          
 
     - name: Build interop harness

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
-  MACOSX_DEPLOYMENT_TARGET: 10.11
 
 jobs:
   build:

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -1,0 +1,37 @@
+name: Build the interop harness
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+  MACOSX_DEPLOYMENT_TARGET: 10.11
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    env:
+        CMAKE_BUILD_DIR: ${{ github.workspace }}/build
+        TOOLCHAIN_FILE: $VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Restore cache
+      uses: actions/cache@v2
+      with:
+        path: |
+            ${{ env.CMAKE_BUILD_DIR }}/vcpkg_installed
+        key: ${{ runner.os }}-${{ hashFiles( '**/vcpkg.json' ) }}
+
+    - name: Build interop harness
+      run: |
+         cd cmd/interop
+         cmake -B build -DSANITIZERS=ON -DCMAKE_TOOLCHAIN_FILE="${{ matrix.vcpkg-cmake-file}}" .
+         cmake --build build

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -30,8 +30,13 @@ jobs:
             ${{ env.CMAKE_BUILD_DIR }}/vcpkg_installed
         key: ${{ runner.os }}-${{ hashFiles( '**/vcpkg.json' ) }}
 
+    - name: Build the library      
+      run: |
+        cmake -B build
+        cmake --build build          
+
     - name: Build interop harness
       run: |
          cd cmd/interop
-         cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DSANITIZERS=ON -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}" .
-         cmake --build "${{ env.CMAKE_BUILD_DIR }}"
+         cmake -B build -DSANITIZERS=ON -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}" .
+         cmake --build build

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -33,5 +33,5 @@ jobs:
     - name: Build interop harness
       run: |
          cd cmd/interop
-         cmake -B build -DSANITIZERS=ON -DCMAKE_TOOLCHAIN_FILE="${{ matrix.vcpkg-cmake-file}}" .
-         cmake --build build
+         cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DSANITIZERS=ON -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}" .
+         cmake --build "${{ env.CMAKE_BUILD_DIR }}"

--- a/include/mls/key_schedule.h
+++ b/include/mls/key_schedule.h
@@ -23,6 +23,9 @@ struct HashRatchet
   // These defaults are necessary for use with containers
   HashRatchet() = default;
   HashRatchet(const HashRatchet& other) = default;
+  HashRatchet(HashRatchet&& other) = default;
+  HashRatchet& operator=(const HashRatchet& other) = default;
+  HashRatchet& operator=(HashRatchet&& other) = default;
 
   HashRatchet(CipherSuite suite_in, NodeIndex node_in, bytes base_secret_in);
 

--- a/lib/hpke/test/hpke.cpp
+++ b/lib/hpke/test/hpke.cpp
@@ -198,10 +198,12 @@ TEST_CASE("HPKE Round-Trip")
 
         auto hpke = HPKE(kem_id, kdf_id, aead_id);
 
-        auto [enc, ctxS] = hpke.setup_base_s(*pkR, info);
+        auto [enc_, ctxS_] = hpke.setup_base_s(*pkR, info);
+        auto enc = enc_;
+        auto ctxS = ctxS_;
+
         auto ctxR = hpke.setup_base_r(enc, *skR, info);
         REQUIRE(ctxS == ctxR);
-        // TODO(RLB): Define operator==, CHECK(ctxS == ctxR)
 
         auto last_encrypted = bytes{};
         for (int i = 0; i < iterations; i += 1) {

--- a/lib/hpke/test/kem.cpp
+++ b/lib/hpke/test/kem.cpp
@@ -33,7 +33,10 @@ TEST_CASE("KEM round-trip")
 
     SUBCASE("Encap/Decap")
     {
-      auto [secretS, enc] = kem.encap(*pkR);
+      auto [secretS_, enc_] = kem.encap(*pkR);
+      auto secretS = secretS_;
+      auto enc = enc_;
+
       REQUIRE(enc.size() == kem.enc_size);
       REQUIRE(secretS.size() == kem.secret_size);
 
@@ -43,7 +46,10 @@ TEST_CASE("KEM round-trip")
 
     SUBCASE("AuthEncap/AuthDecap")
     {
-      auto [secretS, enc] = kem.auth_encap(*pkR, *skS);
+      auto [secretS_, enc_] = kem.auth_encap(*pkR, *skS);
+      auto secretS = secretS_;
+      auto enc = enc_;
+
       REQUIRE(enc.size() == kem.enc_size);
       REQUIRE(secretS.size() == kem.secret_size);
 

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -184,6 +184,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with external tree for welcome")
 
   // Initialize the second participant from the Welcome, pass in the
   // tree externally
+  // NOLINTNEXTLINE(llvm-else-after-return, readability-else-after-return)
   CHECK_THROWS_AS(
     State(
       init_privs[1], identity_privs[1], key_packages[1], welcome, std::nullopt),
@@ -191,6 +192,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with external tree for welcome")
 
   auto incorrect_tree = TreeKEMPublicKey(suite);
   incorrect_tree.add_leaf(key_packages[1]);
+  // NOLINTNEXTLINE(llvm-else-after-return, readability-else-after-return)
   CHECK_THROWS_AS(State(init_privs[1],
                         identity_privs[1],
                         key_packages[1],
@@ -325,6 +327,7 @@ TEST_CASE_FIXTURE(StateTest, "Enforce Required Capabilities")
 
   // Creating a group with a first member that doesn't support the required
   // capabilities should fail.
+  // NOLINTNEXTLINE(llvm-else-after-return, readability-else-after-return)
   REQUIRE_THROWS(
     State{ group_id, suite, init_no, id_no, kp_no, group_extensions });
 
@@ -332,6 +335,7 @@ TEST_CASE_FIXTURE(StateTest, "Enforce Required Capabilities")
   // the required capabilities for the group.
   auto state =
     State{ group_id, suite, init_yes, id_yes, kp_yes, group_extensions };
+  // NOLINTNEXTLINE(llvm-else-after-return, readability-else-after-return)
   REQUIRE_THROWS(state.add_proposal(kp_no));
 
   // When State receives an add proposal for a new member that doesn't

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -112,9 +112,10 @@ TEST_CASE_FIXTURE(StateTest, "Two Person")
 
   // Handle the Add proposal and create a Commit
   auto add = first0.add_proposal(key_packages[1]);
-  auto [commit, welcome, first1] =
+  auto [commit, welcome, first1_] =
     first0.commit(fresh_secret(), CommitOpts{ { add }, true, false });
   silence_unused(commit);
+  auto first1 = first1_;
 
   // Initialize the second participant from the Welcome
   auto second0 = State{
@@ -137,8 +138,9 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with custom extensions")
 
   // Handle the Add proposal and create a Commit
   auto add = first0.add_proposal(key_packages[1]);
-  auto [commit1, welcome1, first1] =
+  auto [commit1, welcome1, first1_] =
     first0.commit(fresh_secret(), CommitOpts{ { add }, true, false });
+  auto first1 = first1_;
   silence_unused(commit1);
 
   // Initialize the second participant from the Welcome
@@ -156,10 +158,11 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with custom extensions")
   second_exts.add(CustomExtension2{ 0xb0 });
 
   auto gce = first1.group_context_extensions_proposal(second_exts);
-  auto [commit2, welcome2, first2] =
+  auto [commit2, welcome2, first2_] =
     first1.commit(fresh_secret(), CommitOpts{ { gce }, false, false });
   auto second2 = second1.handle(commit2);
   silence_unused(welcome2);
+  auto first2 = first2_;
   REQUIRE(first2 == second2);
   REQUIRE(first2.extensions() == second_exts);
 }
@@ -173,8 +176,10 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with external tree for welcome")
   // Handle the Add proposal and create a Commit
   auto add = first0.add_proposal(key_packages[1]);
   // Don't generate RatchetTree extension
-  auto [commit, welcome, first1] =
+  auto [commit, welcome_, first1_] =
     first0.commit(fresh_secret(), CommitOpts{ { add }, false, false });
+  auto welcome = welcome_;
+  auto first1 = first1_;
   silence_unused(commit);
 
   // Initialize the second participant from the Welcome, pass in the
@@ -269,8 +274,9 @@ TEST_CASE_FIXTURE(StateTest, "SFrame Parameter Negotiation")
 
   // Add the second member
   auto add = first0.add_proposal(kp1);
-  auto [commit, welcome, first1] =
+  auto [commit, welcome, first1_] =
     first0.commit(fresh_secret(), CommitOpts{ { add }, true, false });
+  auto first1 = first1_;
   silence_unused(commit);
 
   auto second0 = State{ init1, id1, kp1, welcome, std::nullopt };
@@ -306,7 +312,10 @@ TEST_CASE_FIXTURE(StateTest, "Enforce Required Capabilities")
   kp_extensions.add(capabilities);
 
   // One client that supports the required capabilities, and two that do
-  auto [init_no, id_no, kp_no] = make_client();
+  auto [init_no_, id_no_, kp_no_] = make_client();
+  auto init_no = init_no_;
+  auto id_no = id_no_;
+  auto kp_no = kp_no_;
 
   auto [init_yes, id_yes, kp_yes] = make_client();
   kp_yes.sign(id_yes, KeyPackageOpts{ kp_extensions });
@@ -521,8 +530,9 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Roster Updates")
 
   // remove member at position 1
   auto remove_1 = states[0].remove_proposal(RosterIndex{ 1 });
-  auto [commit_1, welcome_1, new_state_1] =
+  auto [commit_1, welcome_1, new_state_1_] =
     states[0].commit(fresh_secret(), CommitOpts{ { remove_1 }, true, false });
+  auto new_state_1 = new_state_1_;
   silence_unused(welcome_1);
   silence_unused(commit_1);
   // roster should be 0, 2, 3, 4
@@ -536,8 +546,9 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Roster Updates")
 
   // remove member at position 2
   auto remove_2 = new_state_1.remove_proposal(RosterIndex{ 2 });
-  auto [commit_2, welcome_2, new_state_2] =
+  auto [commit_2, welcome_2, new_state_2_] =
     new_state_1.commit(fresh_secret(), CommitOpts{ { remove_2 }, true, false });
+  auto new_state_2 = new_state_2_;
   silence_unused(welcome_2);
   // roster should be 0, 2, 4
   expected_creds = std::vector<Credential>{

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -62,6 +62,7 @@ TEST_CASE_FIXTURE(TreeKEMTest, "Optional node hashes")
 
   auto parent = ParentNode{ init_priv.public_key, {}, {} };
   auto opt_parent = OptionalNode{ Node{ parent }, {} };
+  // NOLINTNEXTLINE(llvm-else-after-return, readability-else-after-return)
   REQUIRE_THROWS_AS(opt_parent.set_tree_hash(suite, node_index),
                     var::bad_variant_access);
 
@@ -69,6 +70,7 @@ TEST_CASE_FIXTURE(TreeKEMTest, "Optional node hashes")
   REQUIRE_FALSE(opt_parent.hash.empty());
 
   auto opt_leaf = OptionalNode{ Node{ kp }, {} };
+  // NOLINTNEXTLINE(llvm-else-after-return, readability-else-after-return)
   REQUIRE_THROWS_AS(
     opt_leaf.set_tree_hash(suite, node_index, child_hash, child_hash),
     var::bad_variant_access);

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -44,7 +44,8 @@ TEST_CASE_FIXTURE(TreeKEMTest, "Node public key")
   auto parent = Node{ ParentNode{ parent_priv.public_key, {}, {} } };
   REQUIRE(parent.public_key() == parent_priv.public_key);
 
-  auto [leaf_priv, sig_priv, kp] = new_key_package();
+  auto [leaf_priv_, sig_priv, kp] = new_key_package();
+  auto leaf_priv = leaf_priv_;
   silence_unused(sig_priv);
 
   auto leaf = Node{ kp };
@@ -119,8 +120,11 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Private Key")
   REQUIRE(priv_joiner.update_secret == last_update_secret);
 
   // shared_path_secret() finds the correct ancestor
-  auto [overlap, overlap_secret, found] =
+  auto [overlap_, overlap_secret_, found_] =
     priv_joiner.shared_path_secret(LeafIndex(0));
+  auto overlap = overlap_;
+  auto overlap_secret = overlap_secret_;
+  auto found = found_;
   REQUIRE(found);
   REQUIRE(overlap == NodeIndex(3));
   REQUIRE(overlap_secret == priv_joiner.path_secrets[overlap]);
@@ -152,7 +156,8 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Public Key")
   auto pub = TreeKEMPublicKey{ suite };
   for (uint32_t i = 0; i < size.val; i++) {
     // Add a leaf
-    auto [init_priv, sig_priv, kp_before] = new_key_package();
+    auto [init_priv, sig_priv, kp_before_] = new_key_package();
+    auto kp_before = kp_before_;
     silence_unused(init_priv);
 
     auto index = LeafIndex(i);
@@ -237,12 +242,14 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM encap/decap")
     REQUIRE(index == joiner);
 
     auto leaf_secret = random_bytes(32);
-    auto [new_adder_priv, path] = pubs[i].encap(
+    auto [new_adder_priv, path_] = pubs[i].encap(
       adder, context, leaf_secret, sig_privs.back(), {}, std::nullopt);
+    auto path = path_;
     privs[i] = new_adder_priv;
     REQUIRE(pubs[i].parent_hash_valid(adder, path));
 
-    auto [overlap, path_secret, ok] = privs[i].shared_path_secret(joiner);
+    auto [overlap, path_secret, ok_] = privs[i].shared_path_secret(joiner);
+    auto ok = ok_;
     REQUIRE(ok);
 
     pubs[i].merge(adder, path);


### PR DESCRIPTION
Modern clang compilers (such as those used on the macOS `latest` GitHub runners) report an error when a variable from a destructuring assignment is captured in a lambda.  This is apparently due to [some ambiguity over what exactly is captured](https://bugs.llvm.org/show_bug.cgi?id=42053), the destructured thing or just the captured part.  This impacts MLSpp because the testing framework we use uses lambdas internally to its assertions.  So we cannot define a variable in a destructuring assignment, then pass it into a test assertion.  For example, the following code is illegal:

```
auto [overlap, path_secret, ok] = privs[i].shared_path_secret(joiner);
REQUIRE(ok);
```

The solution I have implemented here is to make a copy of the captured thing.  The name in the destructuring assignment is suffixed with an underscore, and we then declare a new variable with the name we want to be captured.  For example:

```
auto [overlap, path_secret, ok_] = privs[i].shared_path_secret(joiner);
auto ok = ok_;
REQUIRE(ok);
```

It's clumsy, but it's apparently required until we can use C++20.