### PR TITLE
Make bytes equality testing always constant-time

### DIFF
--- a/include/mls/crypto.h
+++ b/include/mls/crypto.h
@@ -111,9 +111,6 @@ extern const std::array<CipherSuite::ID, 6> all_supported_suites;
 // Utilities
 using hpke::random_bytes;
 
-bool
-constant_time_eq(const bytes& lhs, const bytes& rhs);
-
 // HPKE Keys
 struct HPKECiphertext
 {

--- a/lib/bytes/src/bytes.cpp
+++ b/lib/bytes/src/bytes.cpp
@@ -10,25 +10,36 @@ namespace bytes_ns {
 bool
 bytes::operator==(const bytes& other) const
 {
-  return _data == other._data;
+  return *this == other._data;
 }
 
 bool
 bytes::operator!=(const bytes& other) const
 {
-  return _data != other._data;
+  return !(*this == other._data);
 }
 
 bool
 bytes::operator==(const std::vector<uint8_t>& other) const
 {
-  return other == _data;
+  size_t size = other.size();
+  if (_data.size() != size) {
+    return false;
+  }
+
+  unsigned char diff = 0;
+  for (size_t i = 0; i < size; ++i) {
+    // Not sure why the linter thinks `diff` is signed
+    // NOLINTNEXTLINE(hicpp-signed-bitwise)
+    diff |= (_data.at(i) ^ other.at(i));
+  }
+  return (diff == 0);
 }
 
 bool
 bytes::operator!=(const std::vector<uint8_t>& other) const
 {
-  return other != _data;
+  return !(*this == other);
 }
 
 bytes&

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -229,26 +229,6 @@ CipherSuite::reference_label<MLSPlaintext>()
 }
 
 ///
-/// Utilities
-///
-bool
-constant_time_eq(const bytes& lhs, const bytes& rhs)
-{
-  size_t size = lhs.size();
-  if (rhs.size() > size) {
-    size = rhs.size();
-  }
-
-  unsigned char diff = 0;
-  for (size_t i = 0; i < size; ++i) {
-    // Not sure why the linter thinks `diff` is signed
-    // NOLINTNEXTLINE(hicpp-signed-bitwise)
-    diff |= (lhs.at(i) ^ rhs.at(i));
-  }
-  return (diff == 0);
-}
-
-///
 /// HPKEPublicKey and HPKEPrivateKey
 ///
 HPKECiphertext

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -462,7 +462,7 @@ MLSPlaintext::verify_membership_tag(const bytes& tag) const
     return false;
   }
 
-  return constant_time_eq(tag, opt::get(membership_tag).mac_value);
+  return tag == opt::get(membership_tag).mac_value;
 }
 
 } // namespace mls

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1039,7 +1039,7 @@ bool
 State::verify_confirmation(const bytes& confirmation) const
 {
   auto confirm = _key_schedule.confirmation_tag(_transcript_hash.confirmed);
-  return constant_time_eq(confirm, confirmation);
+  return confirm == confirmation;
 }
 
 bytes


### PR DESCRIPTION
This is cheap enough, and avoids the need to explicitly call `constant_time_eq` when needed.