### PR TITLE
Pin to OpenSSL 1.1

### DIFF
--- a/cmd/interop/vcpkg.json
+++ b/cmd/interop/vcpkg.json
@@ -3,7 +3,7 @@
   "version-string": "0.1",
   "description": "Interop harness for Cisco MLS C++ library",
   "dependencies": [
-    "openssl",
+    "openssl1",
     "protobuf",
     "grpc",
     "gflags",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,7 @@
   "version-string": "0.1",
   "description": "Cisco MLS C++ library",
   "dependencies": [
-    "openssl",
+    "openssl1",
     "doctest"
   ]
 }


### PR DESCRIPTION
The vcpkg team recently [upgraded the `openssl` package to version 3](https://github.com/microsoft/vcpkg/pull/22878).  That version is incompatible with MLSpp at the moment, so development workflows based on vcpkg (including our CI here) are broken.  To enable people to continue using OpenSSL 1.1, they created an `openssl1` package.  This PR moves to that package.