### PR TITLE
Reintroduce GroupInfo to Session

### DIFF
--- a/include/mls/session.h
+++ b/include/mls/session.h
@@ -77,6 +77,7 @@ public:
   bytes do_export(const std::string& label,
                   const bytes& context,
                   size_t size) const;
+  GroupInfo group_info() const;
   std::vector<LeafNode> roster() const;
   bytes authentication_secret() const;
 

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -415,6 +415,12 @@ Session::do_export(const std::string& label,
   return inner->history.front().do_export(label, context, size);
 }
 
+GroupInfo
+Session::group_info() const
+{
+  return inner->history.front().group_info();
+}
+
 std::vector<LeafNode>
 Session::roster() const
 {


### PR DESCRIPTION
If I understood correctly, Session will eventually go away. But in the meantime, this PR re-introduces the method to retrieve the GroupInfo that was deleted in #257.