### PR TITLE
Separate new member sender types

### DIFF
--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -415,7 +415,8 @@ enum struct SenderType : uint8_t
   invalid = 0,
   member = 1,
   preconfigured = 2,
-  new_member = 3,
+  new_member_proposal = 3,
+  new_member_commit = 4,
 };
 
 struct MemberSender
@@ -430,14 +431,23 @@ struct PreconfiguredKeyID
   TLS_SERIALIZABLE(id)
 };
 
-struct NewMemberSender
+struct NewMemberProposalSender
+{
+  TLS_SERIALIZABLE()
+};
+
+struct NewMemberCommitSender
 {
   TLS_SERIALIZABLE()
 };
 
 struct Sender
 {
-  var::variant<MemberSender, PreconfiguredKeyID, NewMemberSender> sender;
+  var::variant<MemberSender,
+               PreconfiguredKeyID,
+               NewMemberProposalSender,
+               NewMemberCommitSender>
+    sender;
 
   SenderType sender_type() const;
 
@@ -653,7 +663,10 @@ TLS_VARIANT_MAP(mls::ContentType, mls::Commit, commit)
 
 TLS_VARIANT_MAP(mls::SenderType, mls::MemberSender, member)
 TLS_VARIANT_MAP(mls::SenderType, mls::PreconfiguredKeyID, preconfigured)
-TLS_VARIANT_MAP(mls::SenderType, mls::NewMemberSender, new_member)
+TLS_VARIANT_MAP(mls::SenderType,
+                mls::NewMemberProposalSender,
+                new_member_proposal)
+TLS_VARIANT_MAP(mls::SenderType, mls::NewMemberCommitSender, new_member_commit)
 
 TLS_VARIANT_MAP(mls::WireFormat, mls::MLSPlaintext, mls_plaintext)
 TLS_VARIANT_MAP(mls::WireFormat, mls::MLSCiphertext, mls_ciphertext)

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -234,7 +234,10 @@ protected:
 
   // Signature verification over a handshake message
   bool verify_internal(const MLSAuthenticatedContent& content_auth) const;
-  bool verify_new_member(const MLSAuthenticatedContent& content_auth) const;
+  bool verify_new_member_proposal(
+    const MLSAuthenticatedContent& content_auth) const;
+  bool verify_new_member_commit(
+    const MLSAuthenticatedContent& content_auth) const;
   bool verify(const MLSAuthenticatedContent& content_auth) const;
 
   // Convert a Roster entry into LeafIndex

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -65,6 +65,12 @@ public:
     const std::optional<TreeKEMPublicKey>& tree,
     const MessageOpts& msg_opts);
 
+  // Propose that a new member be added a group
+  static MLSMessage new_member_add(const bytes& group_id,
+                                   epoch_t epoch,
+                                   const KeyPackage& new_member,
+                                   const SignaturePrivateKey& sig_priv);
+
   ///
   /// Message factories
   ///

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -472,12 +472,16 @@ operator<<(tls::ostream& str, const MLSContentTBS& obj)
 
   switch (obj.content.sender.sender_type()) {
     case SenderType::member:
-    case SenderType::new_member:
+    case SenderType::new_member_commit:
       str << opt::get(obj.context);
       break;
 
-    default:
+    case SenderType::preconfigured:
+    case SenderType::new_member_proposal:
       break;
+
+    default:
+      throw InvalidParameterError("Invalid sender type");
   }
 
   return str;
@@ -579,8 +583,9 @@ operator<<(tls::ostream& str, const MLSPlaintext& obj)
     case SenderType::member:
       return str << obj.content << obj.auth << opt::get(obj.membership_tag);
 
-    case SenderType::new_member:
     case SenderType::preconfigured:
+    case SenderType::new_member_proposal:
+    case SenderType::new_member_commit:
       return str << obj.content << obj.auth;
 
     default:

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -211,6 +211,25 @@ State::external_join(const bytes& leaf_secret,
   return { commit_msg, state };
 }
 
+MLSMessage
+State::new_member_add(const bytes& group_id,
+                      epoch_t epoch,
+                      const KeyPackage& new_member,
+                      const SignaturePrivateKey& sig_priv)
+{
+  const auto suite = new_member.cipher_suite;
+  auto proposal = Proposal{ Add{ new_member } };
+  auto content = MLSContent{ group_id,
+                             epoch,
+                             { NewMemberProposalSender{} },
+                             { /* no authenticated data */ },
+                             { std::move(proposal) } };
+  auto content_auth = MLSAuthenticatedContent::sign(
+    WireFormat::mls_plaintext, std::move(content), suite, sig_priv, {});
+
+  return MLSPlaintext::protect(std::move(content_auth), suite, {}, {});
+}
+
 ///
 /// Proposal and commit factories
 ///

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -472,7 +472,7 @@ State::commit(const bytes& leaf_secret,
 
     const auto pos = it - joiners.begin();
     next._index = joiner_locations[pos];
-    sender = Sender{ NewMemberSender{} };
+    sender = Sender{ NewMemberCommitSender{} };
   }
 
   // KEM new entropy to the group and the new joiners
@@ -632,11 +632,11 @@ State::handle(const MLSMessage& msg, std::optional<State> cached_state)
 
   switch (content.sender.sender_type()) {
     case SenderType::member:
-    case SenderType::new_member:
+    case SenderType::new_member_commit:
       break;
 
     default:
-      throw ProtocolError("Commit must be either member or new_member");
+      throw ProtocolError("Invalid commit sender type");
   }
 
   auto sender = std::optional<LeafIndex>();
@@ -676,7 +676,7 @@ State::handle(const MLSMessage& msg, std::optional<State> cached_state)
     sender_location = opt::get(sender);
   }
 
-  if (content.sender.sender_type() == SenderType::new_member) {
+  if (content.sender.sender_type() == SenderType::new_member_commit) {
     // Extract the forced init secret
     auto kem_output = commit.valid_external();
     if (!kem_output) {
@@ -1097,31 +1097,22 @@ State::verify_internal(const MLSAuthenticatedContent& content_auth) const
 }
 
 bool
-State::verify_new_member(const MLSAuthenticatedContent& content_auth) const
+State::verify_new_member_proposal(
+  const MLSAuthenticatedContent& content_auth) const
 {
-  const auto& pub = var::visit(
-    overloaded{
-      [](const Commit& commit) {
-        if (!commit.path) {
-          throw ProtocolError("External Commit does not have a path");
-        }
+  const auto& proposal = var::get<Proposal>(content_auth.content.content);
+  const auto& add = var::get<Add>(proposal.content);
+  const auto& pub = add.key_package.leaf_node.signature_key;
+  return content_auth.verify(_suite, pub, group_context());
+}
 
-        // Verify with public key from update path leaf key package
-        return opt::get(commit.path).leaf_node.signature_key;
-      },
-      [](const Proposal& proposal) {
-        if (proposal.proposal_type() != ProposalType::add) {
-          throw ProtocolError("New member proposal is not an Add");
-        }
-
-        const auto& add = var::get<Add>(proposal.content);
-        return add.key_package.leaf_node.signature_key;
-      },
-      [](const ApplicationData& /*unused*/) -> SignaturePublicKey {
-        throw ProtocolError("New member message of unknown type");
-      },
-    },
-    content_auth.content.content);
+bool
+State::verify_new_member_commit(
+  const MLSAuthenticatedContent& content_auth) const
+{
+  const auto& commit = var::get<Commit>(content_auth.content.content);
+  const auto& path = opt::get(commit.path);
+  const auto& pub = path.leaf_node.signature_key;
   return content_auth.verify(_suite, pub, group_context());
 }
 
@@ -1132,8 +1123,11 @@ State::verify(const MLSAuthenticatedContent& content_auth) const
     case SenderType::member:
       return verify_internal(content_auth);
 
-    case SenderType::new_member:
-      return verify_new_member(content_auth);
+    case SenderType::new_member_proposal:
+      return verify_new_member_proposal(content_auth);
+
+    case SenderType::new_member_commit:
+      return verify_new_member_commit(content_auth);
 
     default:
       // TODO(RLB) Support other sender types

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -145,6 +145,34 @@ TEST_CASE_FIXTURE(StateTest, "Two Person")
   verify_group_functionality(group);
 }
 
+TEST_CASE_FIXTURE(StateTest, "Two Person with New Member Add")
+{
+  // Initialize the creator's state
+  auto first0 = State{ group_id,
+                       suite,
+                       leaf_privs[0],
+                       identity_privs[0],
+                       key_packages[0].leaf_node,
+                       {} };
+
+  // Have the new member create an Add proposal
+  auto add =
+    State::new_member_add(group_id, 0, key_packages[1], identity_privs[1]);
+  first0.handle(add);
+  auto opts = CommitOpts{ {}, true, false, {} };
+  auto [commit, welcome, first1_] = first0.commit(fresh_secret(), opts, {});
+  silence_unused(commit);
+  auto first1 = first1_;
+
+  // Initialize the second participant from the Welcome
+  auto second0 = State{ init_privs[1],   leaf_privs[1], identity_privs[1],
+                        key_packages[1], welcome,       std::nullopt };
+  REQUIRE(first1 == second0);
+
+  auto group = std::vector<State>{ first1, second0 };
+  verify_group_functionality(group);
+}
+
 TEST_CASE_FIXTURE(StateTest, "Two Person with custom extensions")
 {
   // Initialize the creator's state


### PR DESCRIPTION
Corresponds to https://github.com/mlswg/mls-protocol/pull/716

One notable change here: In the earlier code, we manually checked variant types before accessing them, but this just resulted in us throwing an application error instead of `std::bad_variant_access`.  Here I skip that step and go directly to `var::get` / `opt::get`.  Happy to switch back if reviewers think custom errors are clearer.