### PR TITLE
Fix tests on Linux using vcpkg

### DIFF
--- a/lib/bytes/include/bytes/bytes.h
+++ b/lib/bytes/include/bytes/bytes.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <tls/tls_syntax.h>
 #include <vector>
+#include <memory>
 
 namespace bytes_ns {
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,10 @@
       "name": "openssl",
       "version>=": "1.1.1n"
     },
-    "doctest"
+    {
+        "name": "doctest",
+        "version>=": "2.4.9"
+    }
   ],
   "builtin-baseline": "3b3bd424827a1f7f4813216f6b32b6c61e386b2e",
   "overrides": [


### PR DESCRIPTION
I was using the following command to build on macOs, but I found that using vcpkg on linux did not work.  

*Note: I cloned vcpkg as a sibling directory to mlspp.*

```
rm -rf build && \
cmake -B build \
      -DCMAKE_TOOLCHAIN_FILE=../vcpkg/scripts/buildsystems/vcpkg.cmake \
      -DTESTING=ON && \
cmake --build build --parallel 9 --target all --target test
```

There were two reasons for the issue.  First, it looks like gcc was not picking up the `#include <memory>` in the tests, so it was explicitly added in this PR.

Second, vcpkg was defaulting to run version 2.4.8, which looks to have a bunch of errors that might not be worth digging through.  Ensuring that we use 2.4.9 helped mitigate the issue.  I checked macOs, and the issues with 2.4.8 do not exist with clang environments.

### TODO

- [x] Verify builds using vcpkg work on Linux
- [ ] Verify builds using vcpkg work on Windows
- [x] Verify builds using vcpkg work on macOs