### PR TITLE
Fix a crash issue caused by Visual Studio whole program optimization

### DIFF
--- a/lib/hpke/src/aead_cipher.cpp
+++ b/lib/hpke/src/aead_cipher.cpp
@@ -41,36 +41,27 @@ make_aead(AEAD::ID cipher_in)
 }
 
 template<>
-const AEADCipher AEADCipher::instance<AEAD::ID::AES_128_GCM> =
-  make_aead(AEAD::ID::AES_128_GCM);
-
-template<>
-const AEADCipher AEADCipher::instance<AEAD::ID::AES_256_GCM> =
-  make_aead(AEAD::ID::AES_256_GCM);
-
-template<>
-const AEADCipher AEADCipher::instance<AEAD::ID::CHACHA20_POLY1305> =
-  make_aead(AEAD::ID::CHACHA20_POLY1305);
-
-template<>
 const AEADCipher&
 AEADCipher::get<AEAD::ID::AES_128_GCM>()
 {
-  return AEADCipher::instance<AEAD::ID::AES_128_GCM>;
+  static const auto instance = make_aead(AEAD::ID::AES_128_GCM);
+  return instance;
 }
 
 template<>
 const AEADCipher&
 AEADCipher::get<AEAD::ID::AES_256_GCM>()
 {
-  return AEADCipher::instance<AEAD::ID::AES_256_GCM>;
+  static const auto instance = make_aead(AEAD::ID::AES_256_GCM);
+  return instance;
 }
 
 template<>
 const AEADCipher&
 AEADCipher::get<AEAD::ID::CHACHA20_POLY1305>()
 {
-  return AEADCipher::instance<AEAD::ID::CHACHA20_POLY1305>;
+  static const auto instance = make_aead(AEAD::ID::CHACHA20_POLY1305);
+  return instance;
 }
 
 static size_t

--- a/lib/hpke/src/aead_cipher.h
+++ b/lib/hpke/src/aead_cipher.h
@@ -40,9 +40,6 @@ private:
 
   AEADCipher(AEAD::ID id_in);
   friend AEADCipher make_aead(AEAD::ID cipher_in);
-
-  template<AEAD::ID id>
-  static const AEADCipher instance;
 };
 
 } // namespace hpke


### PR DESCRIPTION
**Problem**
In the 32-bit Webex App, we find a 100% reproducible crash issue https://jira-eng-gpk2.cisco.com/jira/browse/SPARK-396092, but there is no such issue in 64-bit Webex App.
The crash stack is:
```
00 24ceece8 6df448fc spark_windows_desktop_ui!mls_v3::hpke::ReceiverContext::open+0x1b [J:\JenkinsWorkspace\WX_Win@2\spark-client-framework\thirdparty\mlspp\lib\hpke\src\hpke.cpp @ 319] 
01 24ceed84 6df455c1 spark_windows_desktop_ui!mls_v3::HPKEPrivateKey::decrypt+0xad [J:\JenkinsWorkspace\WX_Win@2\spark-client-framework\thirdparty\mlspp\src\crypto.cpp @ 261] 
02 24ceefa0 6df39998 spark_windows_desktop_ui!mls_v3::State::State+0x188 [J:\JenkinsWorkspace\WX_Win@2\spark-client-framework\thirdparty\mlspp\src\state.cpp @ 112] 
03 (Inline) -------- spark_windows_desktop_ui!e2ee_v3::details::WrappedMLSState::create_for_welcome+0x38 [J:\JenkinsWorkspace\WX_Win@2\spark-client-framework\thirdparty\libe2ee\vX\src\details.cpp @ 157] 
04 24cef328 6df3898d spark_windows_desktop_ui!e2ee_v3::details::State::join_group+0xb0 [J:\JenkinsWorkspace\WX_Win@2\spark-client-framework\thirdparty\libe2ee\vX\src\details.cpp @ 1300] 
05 24cef644 6df38786 spark_windows_desktop_ui!e2ee_v3::details::State::process_welcome_message+0x1fd [J:\JenkinsWorkspace\WX_Win@2\spark-client-framework\thirdparty\libe2ee\vX\src\details.cpp @ 754] 
06 24cef6cc 6df340f1 spark_windows_desktop_ui!e2ee_v3::details::State::handle+0xe8 [J:\JenkinsWorkspace\WX_Win@2\spark-client-framework\thirdparty\libe2ee\vX\src\details.cpp @ 708] 
07 (Inline) -------- spark_windows_desktop_ui!e2ee_v3::E2EE::handle_event+0x10 [J:\JenkinsWorkspace\WX_Win@2\spark-client-framework\thirdparty\libe2ee\vX\src\e2ee.cpp @ 415]  
...
```

**Reason**
This crash issue is caused by Visual Studio [Whole program optimization](https://learn.microsoft.com/en-us/cpp/build/reference/gl-whole-program-optimization?view=msvc-170), if the whole program optimization is disabled, then there is no such issue. Seems this is a Visual Studio compiler bug.

**Fix**
Refactoring the implementation to avoid the crash issue.