### PR TITLE
Run CI weekly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '30 2 * * 1'
 
 env:
   CTEST_OUTPUT_ON_FAILURE: 1


### PR DESCRIPTION
This should help catch failures due to CI runner changes more quickly, avoiding the need for big PRs like #293 