### PR TITLE
Add "crypto basics" test vectors

### DIFF
--- a/cmd/interop/src/json_details.h
+++ b/cmd/interop/src/json_details.h
@@ -96,7 +96,9 @@ struct tls_serializer
   };
 
 TLS_SERIALIZER(mls::HPKEPublicKey)
+TLS_SERIALIZER(mls::HPKEPrivateKey)
 TLS_SERIALIZER(mls::SignaturePublicKey)
+TLS_SERIALIZER(mls::SignaturePrivateKey)
 TLS_SERIALIZER(mls::TreeKEMPublicKey)
 TLS_SERIALIZER(mls::Credential)
 TLS_SERIALIZER(mls::MLSAuthenticatedContent)
@@ -120,6 +122,42 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(TreeMathTestVector,
                                    right,
                                    parent,
                                    sibling)
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(CryptoBasicsTestVector::RefHash,
+                                   label,
+                                   value,
+                                   out)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(CryptoBasicsTestVector::ExpandWithLabel,
+                                   secret,
+                                   label,
+                                   context,
+                                   length,
+                                   out)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(CryptoBasicsTestVector::DeriveSecret,
+                                   secret,
+                                   label,
+                                   out)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(CryptoBasicsTestVector::SignWithLabel,
+                                   priv,
+                                   pub,
+                                   content,
+                                   label,
+                                   signature)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(CryptoBasicsTestVector::EncryptWithLabel,
+                                   priv,
+                                   pub,
+                                   label,
+                                   context,
+                                   plaintext,
+                                   kem_output,
+                                   ciphertext)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(CryptoBasicsTestVector,
+                                   cipher_suite,
+                                   ref_hash,
+                                   expand_with_label,
+                                   derive_secret,
+                                   sign_with_label,
+                                   encrypt_with_label)
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(EncryptionTestVector::SenderDataInfo,
                                    ciphertext,

--- a/cmd/interop/src/main.cpp
+++ b/cmd/interop/src/main.cpp
@@ -17,6 +17,8 @@ using nlohmann::json;
 using namespace mls_client;
 using namespace mls_vectors;
 
+static constexpr uint64_t CRYPTO_BASICS = 10;
+
 // XXX(RLB): This function currently produces only one example of each type, as
 // a top-level object, not a top-level array.  We should produce a more
 // comprehensive matrix.
@@ -44,6 +46,16 @@ make_test_vector(uint64_t type)
 
     case TestVectorType::MESSAGES:
       return MessagesTestVector::create();
+
+    case CRYPTO_BASICS: {
+      auto cases = std::vector<CryptoBasicsTestVector>();
+
+      for (const auto& suite : mls::all_supported_suites) {
+        cases.emplace_back(suite);
+      }
+
+      return cases;
+    }
 
     default:
       return nullptr;
@@ -99,6 +111,9 @@ verify_test_vector(uint64_t type)
 
     case TestVectorType::MESSAGES:
       return j.get<MessagesTestVector>().verify();
+
+    case CRYPTO_BASICS:
+      return verify_test_vector<CryptoBasicsTestVector>(j);
 
     default:
       return "Invalid test vector type";

--- a/include/mls/crypto.h
+++ b/include/mls/crypto.h
@@ -189,6 +189,8 @@ struct SignaturePrivateKey
   static SignaturePrivateKey parse(CipherSuite suite, const bytes& data);
   static SignaturePrivateKey derive(CipherSuite suite, const bytes& secret);
 
+  SignaturePrivateKey() = default;
+
   bytes data;
   SignaturePublicKey public_key;
 

--- a/include/mls/crypto.h
+++ b/include/mls/crypto.h
@@ -117,6 +117,11 @@ extern const std::array<CipherSuite::ID, 6> all_supported_suites;
 using hpke::random_bytes;
 
 // HPKE Keys
+namespace encrypt_label {
+extern const bytes update_path_node;
+extern const bytes welcome;
+} // namespace encrypt_label
+
 struct HPKECiphertext
 {
   bytes kem_output;
@@ -130,8 +135,8 @@ struct HPKEPublicKey
   bytes data;
 
   HPKECiphertext encrypt(CipherSuite suite,
-                         const bytes& info,
-                         const bytes& aad,
+                         const bytes& label,
+                         const bytes& context,
                          const bytes& pt) const;
 
   std::tuple<bytes, bytes> do_export(CipherSuite suite,
@@ -154,8 +159,8 @@ struct HPKEPrivateKey
   HPKEPublicKey public_key;
 
   bytes decrypt(CipherSuite suite,
-                const bytes& info,
-                const bytes& aad,
+                const bytes& label,
+                const bytes& context,
                 const HPKECiphertext& ct) const;
 
   bytes do_export(CipherSuite suite,

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -237,6 +237,8 @@ struct Welcome
 
   void encrypt(const KeyPackage& kp, const std::optional<bytes>& path_secret);
   std::optional<int> find(const KeyPackage& kp) const;
+  GroupSecrets decrypt_secrets(int kp_index,
+                               const HPKEPrivateKey& init_priv) const;
   GroupInfo decrypt(const bytes& joiner_secret,
                     const std::vector<PSKWithSecret>& psks) const;
 

--- a/lib/mls_vectors/include/mls_vectors/mls_vectors.h
+++ b/lib/mls_vectors/include/mls_vectors/mls_vectors.h
@@ -32,7 +32,8 @@ struct TreeMathTestVector
 
 struct CryptoBasicsTestVector
 {
-  struct RefHash {
+  struct RefHash
+  {
     std::string label;
     bytes value;
     bytes out;
@@ -42,7 +43,8 @@ struct CryptoBasicsTestVector
     std::optional<std::string> verify(mls::CipherSuite suite) const;
   };
 
-  struct ExpandWithLabel {
+  struct ExpandWithLabel
+  {
     bytes secret;
     std::string label;
     bytes context;
@@ -54,7 +56,8 @@ struct CryptoBasicsTestVector
     std::optional<std::string> verify(mls::CipherSuite suite) const;
   };
 
-  struct DeriveSecret {
+  struct DeriveSecret
+  {
     bytes secret;
     std::string label;
     bytes out;
@@ -64,7 +67,8 @@ struct CryptoBasicsTestVector
     std::optional<std::string> verify(mls::CipherSuite suite) const;
   };
 
-  struct SignWithLabel {
+  struct SignWithLabel
+  {
     mls::SignaturePrivateKey priv;
     mls::SignaturePublicKey pub;
     bytes content;
@@ -76,7 +80,8 @@ struct CryptoBasicsTestVector
     std::optional<std::string> verify(mls::CipherSuite suite) const;
   };
 
-  struct EncryptWithLabel {
+  struct EncryptWithLabel
+  {
     mls::HPKEPrivateKey priv;
     mls::HPKEPublicKey pub;
     std::string label;

--- a/lib/mls_vectors/include/mls_vectors/mls_vectors.h
+++ b/lib/mls_vectors/include/mls_vectors/mls_vectors.h
@@ -30,6 +30,79 @@ struct TreeMathTestVector
   std::optional<std::string> verify() const;
 };
 
+struct CryptoBasicsTestVector
+{
+  struct RefHash {
+    std::string label;
+    bytes value;
+    bytes out;
+
+    RefHash() = default;
+    RefHash(mls::CipherSuite suite);
+    std::optional<std::string> verify(mls::CipherSuite suite) const;
+  };
+
+  struct ExpandWithLabel {
+    bytes secret;
+    std::string label;
+    bytes context;
+    uint16_t length;
+    bytes out;
+
+    ExpandWithLabel() = default;
+    ExpandWithLabel(mls::CipherSuite suite);
+    std::optional<std::string> verify(mls::CipherSuite suite) const;
+  };
+
+  struct DeriveSecret {
+    bytes secret;
+    std::string label;
+    bytes out;
+
+    DeriveSecret() = default;
+    DeriveSecret(mls::CipherSuite suite);
+    std::optional<std::string> verify(mls::CipherSuite suite) const;
+  };
+
+  struct SignWithLabel {
+    mls::SignaturePrivateKey priv;
+    mls::SignaturePublicKey pub;
+    bytes content;
+    std::string label;
+    bytes signature;
+
+    SignWithLabel() = default;
+    SignWithLabel(mls::CipherSuite suite);
+    std::optional<std::string> verify(mls::CipherSuite suite) const;
+  };
+
+  struct EncryptWithLabel {
+    mls::HPKEPrivateKey priv;
+    mls::HPKEPublicKey pub;
+    std::string label;
+    bytes context;
+    bytes plaintext;
+    bytes kem_output;
+    bytes ciphertext;
+
+    EncryptWithLabel() = default;
+    EncryptWithLabel(mls::CipherSuite suite);
+    std::optional<std::string> verify(mls::CipherSuite suite) const;
+  };
+
+  mls::CipherSuite cipher_suite;
+
+  RefHash ref_hash;
+  ExpandWithLabel expand_with_label;
+  DeriveSecret derive_secret;
+  SignWithLabel sign_with_label;
+  EncryptWithLabel encrypt_with_label;
+
+  CryptoBasicsTestVector() = default;
+  CryptoBasicsTestVector(mls::CipherSuite suite);
+  std::optional<std::string> verify() const;
+};
+
 struct EncryptionTestVector
 {
   struct SenderDataInfo

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -199,37 +199,50 @@ TreeMathTestVector::verify() const
 /// TreeMathTestVector
 ///
 
-CryptoBasicsTestVector::RefHash::RefHash(CipherSuite  /* suite */)
+CryptoBasicsTestVector::RefHash::RefHash(CipherSuite suite)
+  : label("RefHash")
+  , value(random_bytes(suite.secret_size()))
+  , out(suite.raw_ref(from_ascii(label), value))
 {
-  // TODO
 }
 
 std::optional<std::string>
-CryptoBasicsTestVector::RefHash::verify(CipherSuite  /* suite */) const
+CryptoBasicsTestVector::RefHash::verify(CipherSuite suite) const
 {
-  return std::nullopt; // TODO
+  VERIFY_EQUAL("ref hash", out, suite.raw_ref(from_ascii(label), value));
+  return std::nullopt;
 }
 
-CryptoBasicsTestVector::ExpandWithLabel::ExpandWithLabel(CipherSuite  /* suite */)
+CryptoBasicsTestVector::ExpandWithLabel::ExpandWithLabel(CipherSuite suite)
+  : secret(random_bytes(suite.secret_size()))
+  , label("ExpandWithLabel")
+  , context(random_bytes(suite.secret_size()))
+  , length(suite.key_size())
+  , out(suite.expand_with_label(secret, label, context, length))
 {
-  // TODO
-}
-
-std::optional<std::string>
-CryptoBasicsTestVector::ExpandWithLabel::verify(CipherSuite  /* suite */) const
-{
-  return std::nullopt; // TODO
-}
-
-CryptoBasicsTestVector::DeriveSecret::DeriveSecret(CipherSuite  /* suite */)
-{
-  // TODO
 }
 
 std::optional<std::string>
-CryptoBasicsTestVector::DeriveSecret::verify(CipherSuite  /* suite */) const
+CryptoBasicsTestVector::ExpandWithLabel::verify(CipherSuite suite) const
 {
-  return std::nullopt; // TODO
+  VERIFY_EQUAL("expand with label",
+               out,
+               suite.expand_with_label(secret, label, context, length));
+  return std::nullopt;
+}
+
+CryptoBasicsTestVector::DeriveSecret::DeriveSecret(CipherSuite suite)
+  : secret(random_bytes(suite.secret_size()))
+  , label("DeriveSecret")
+  , out(suite.derive_secret(secret, label))
+{
+}
+
+std::optional<std::string>
+CryptoBasicsTestVector::DeriveSecret::verify(CipherSuite suite) const
+{
+  VERIFY_EQUAL("derive secret", out, suite.derive_secret(secret, label));
+  return std::nullopt;
 }
 
 CryptoBasicsTestVector::SignWithLabel::SignWithLabel(CipherSuite suite)
@@ -256,7 +269,6 @@ CryptoBasicsTestVector::EncryptWithLabel::verify(CipherSuite /* suite */) const
   return std::nullopt; // TODO
 }
 
-
 CryptoBasicsTestVector::CryptoBasicsTestVector(CipherSuite suite)
   : cipher_suite(suite)
   , ref_hash(suite)
@@ -264,7 +276,8 @@ CryptoBasicsTestVector::CryptoBasicsTestVector(CipherSuite suite)
   , derive_secret(suite)
   , sign_with_label(suite)
   , encrypt_with_label(suite)
-{}
+{
+}
 
 std::optional<std::string>
 CryptoBasicsTestVector::verify() const
@@ -893,8 +906,7 @@ MessagesTestVector::create()
   auto external_init = ExternalInit{ opaque };
 
   // Commit
-  auto proposal_ref = ProposalRef{};
-  proposal_ref.fill(0xa0);
+  auto proposal_ref = ProposalRef{ 32, 0xa0 };
 
   auto commit = Commit{ {
                           { proposal_ref },

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -217,7 +217,7 @@ CryptoBasicsTestVector::ExpandWithLabel::ExpandWithLabel(CipherSuite suite)
   : secret(random_bytes(suite.secret_size()))
   , label("ExpandWithLabel")
   , context(random_bytes(suite.secret_size()))
-  , length(suite.key_size())
+  , length(static_cast<uint16_t>(suite.key_size()))
   , out(suite.expand_with_label(secret, label, context, length))
 {
 }

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -196,6 +196,108 @@ TreeMathTestVector::verify() const
 }
 
 ///
+/// TreeMathTestVector
+///
+
+CryptoBasicsTestVector::RefHash::RefHash(CipherSuite  /* suite */)
+{
+  // TODO
+}
+
+std::optional<std::string>
+CryptoBasicsTestVector::RefHash::verify(CipherSuite  /* suite */) const
+{
+  return std::nullopt; // TODO
+}
+
+CryptoBasicsTestVector::ExpandWithLabel::ExpandWithLabel(CipherSuite  /* suite */)
+{
+  // TODO
+}
+
+std::optional<std::string>
+CryptoBasicsTestVector::ExpandWithLabel::verify(CipherSuite  /* suite */) const
+{
+  return std::nullopt; // TODO
+}
+
+CryptoBasicsTestVector::DeriveSecret::DeriveSecret(CipherSuite  /* suite */)
+{
+  // TODO
+}
+
+std::optional<std::string>
+CryptoBasicsTestVector::DeriveSecret::verify(CipherSuite  /* suite */) const
+{
+  return std::nullopt; // TODO
+}
+
+CryptoBasicsTestVector::SignWithLabel::SignWithLabel(CipherSuite suite)
+  : priv(SignaturePrivateKey::generate(suite))
+{
+  // TODO
+}
+
+std::optional<std::string>
+CryptoBasicsTestVector::SignWithLabel::verify(CipherSuite /* suite */) const
+{
+  return std::nullopt; // TODO
+}
+
+CryptoBasicsTestVector::EncryptWithLabel::EncryptWithLabel(CipherSuite suite)
+  : priv(HPKEPrivateKey::generate(suite))
+{
+  // TODO
+}
+
+std::optional<std::string>
+CryptoBasicsTestVector::EncryptWithLabel::verify(CipherSuite /* suite */) const
+{
+  return std::nullopt; // TODO
+}
+
+
+CryptoBasicsTestVector::CryptoBasicsTestVector(CipherSuite suite)
+  : cipher_suite(suite)
+  , ref_hash(suite)
+  , expand_with_label(suite)
+  , derive_secret(suite)
+  , sign_with_label(suite)
+  , encrypt_with_label(suite)
+{}
+
+std::optional<std::string>
+CryptoBasicsTestVector::verify() const
+{
+  auto result = ref_hash.verify(cipher_suite);
+  if (result) {
+    return result;
+  }
+
+  result = expand_with_label.verify(cipher_suite);
+  if (result) {
+    return result;
+  }
+
+  result = derive_secret.verify(cipher_suite);
+  if (result) {
+    return result;
+  }
+
+  result = sign_with_label.verify(cipher_suite);
+  if (result) {
+    return result;
+  }
+
+  result = encrypt_with_label.verify(cipher_suite);
+  if (result) {
+    return result;
+  }
+
+  return std::nullopt;
+}
+
+///
 /// EncryptionTestVector
 ///
 

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -251,16 +251,19 @@ CryptoBasicsTestVector::SignWithLabel::SignWithLabel(CipherSuite suite)
   , content(random_bytes(suite.secret_size()))
   , label("SignWithLabel")
   , signature(priv.sign(suite, from_ascii(label), content))
-{}
+{
+}
 
 std::optional<std::string>
 CryptoBasicsTestVector::SignWithLabel::verify(CipherSuite suite) const
 {
   auto ascii_label = from_ascii(label);
-  VERIFY("verify with label", pub.verify(suite, ascii_label, content, signature));
+  VERIFY("verify with label",
+         pub.verify(suite, ascii_label, content, signature));
 
   auto new_signature = priv.sign(suite, ascii_label, content);
-  VERIFY("sign with label", pub.verify(suite, ascii_label, content, new_signature));
+  VERIFY("sign with label",
+         pub.verify(suite, ascii_label, content, new_signature));
 
   return std::nullopt;
 }

--- a/lib/mls_vectors/test/mls_vectors.cpp
+++ b/lib/mls_vectors/test/mls_vectors.cpp
@@ -19,6 +19,14 @@ TEST_CASE("Tree Math")
   REQUIRE(tv.verify() == std::nullopt);
 }
 
+TEST_CASE("Crypto Basics")
+{
+  for (auto suite : supported_suites) {
+    const auto tv = CryptoBasicsTestVector{ suite };
+    REQUIRE(tv.verify() == std::nullopt);
+  }
+}
+
 TEST_CASE("Encryption Keys")
 {
   for (auto suite : supported_suites) {

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -213,7 +213,7 @@ CipherSuite::reference_label<MLSAuthenticatedContent>()
 #define MLS_1_0_PLUS(label) from_ascii("MLS 1.0 " label)
 
 namespace encrypt_label {
-const bytes encrypt_label = MLS_1_0_PLUS("UpdatePathNode");
+const bytes update_path_node = MLS_1_0_PLUS("UpdatePathNode");
 const bytes welcome = MLS_1_0_PLUS("Welcome");
 } // namespace encrypt_label
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -141,8 +141,20 @@ Welcome::encrypt(const KeyPackage& kp, const std::optional<bytes>& path_secret)
   }
 
   auto gs_data = tls::marshal(gs);
-  auto enc_gs = kp.init_key.encrypt(kp.cipher_suite, {}, {}, gs_data);
+  auto enc_gs = kp.init_key.encrypt(
+    kp.cipher_suite, encrypt_label::welcome, encrypted_group_info, gs_data);
   secrets.push_back({ kp.ref(), enc_gs });
+}
+
+GroupSecrets
+Welcome::decrypt_secrets(int kp_index, const HPKEPrivateKey& init_priv) const
+{
+  auto secrets_data =
+    init_priv.decrypt(cipher_suite,
+                      encrypt_label::welcome,
+                      encrypted_group_info,
+                      secrets.at(kp_index).encrypted_group_secrets);
+  return tls::get<GroupSecrets>(secrets_data);
 }
 
 GroupInfo

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -122,9 +122,7 @@ State::State(const HPKEPrivateKey& init_priv,
   }
 
   // Decrypt the GroupSecrets
-  auto secrets_ct = welcome.secrets[kpi].encrypted_group_secrets;
-  auto secrets_data = init_priv.decrypt(kp.cipher_suite, {}, {}, secrets_ct);
-  auto secrets = tls::get<GroupSecrets>(secrets_data);
+  auto secrets = welcome.decrypt_secrets(kpi, init_priv);
   if (!secrets.psks.psks.empty()) {
     throw NotImplementedError(/* PSKs are not supported */);
   }

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -290,8 +290,10 @@ TreeKEMPrivateKey::decap(LeafIndex from,
 
   // Decrypt and implant
   auto priv = opt::get(private_key(res[resi]));
-  auto path_secret = priv.decrypt(
-    suite, context, {}, path.nodes[dpi].encrypted_path_secret[resi]);
+  auto path_secret = priv.decrypt(suite,
+                                  encrypt_label::update_path_node,
+                                  context,
+                                  path.nodes[dpi].encrypted_path_secret[resi]);
   implant(pub, overlap_node, path_secret);
 }
 
@@ -632,7 +634,8 @@ TreeKEMPublicKey::encap(LeafIndex from,
 
     auto ct = stdx::transform<HPKECiphertext>(res, [&](auto nr) {
       const auto& node_pub = opt::get(node_at(nr).node).public_key();
-      return node_pub.encrypt(suite, context, {}, path_secret);
+      return node_pub.encrypt(
+        suite, encrypt_label::update_path_node, context, path_secret);
     });
 
     return UpdatePathNode{ node_priv.public_key, std::move(ct) };

--- a/test/crypto.cpp
+++ b/test/crypto.cpp
@@ -1,9 +1,11 @@
 #include <doctest/doctest.h>
 #include <mls/crypto.h>
+#include <mls_vectors/mls_vectors.h>
 
 #include <string>
 
 using namespace mls;
+using namespace mls_vectors;
 
 TEST_CASE("Basic HPKE")
 {
@@ -86,5 +88,13 @@ TEST_CASE("Signature Key Serializion")
 
     auto gX2 = tls::get<SignaturePublicKey>(tls::marshal(gX));
     REQUIRE(gX2 == gX);
+  }
+}
+
+TEST_CASE("Crypto Interop")
+{
+  for (auto suite : all_supported_suites) {
+    auto tv = CryptoBasicsTestVector{ suite };
+    REQUIRE(tv.verify() == std::nullopt);
   }
 }


### PR DESCRIPTION
* Changes HPKE encryption/decryption to use the MLS EncryptWithLabel / DecryptWithLabel functions
* Implements CryptoBasicsTestVector to https://github.com/mlswg/mls-implementations/pull/70

Depends on #297 