### PR TITLE
Remove version field from Welcome

### DIFF
--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -224,7 +224,6 @@ struct EncryptedGroupSecrets
 // } Welcome;
 struct Welcome
 {
-  ProtocolVersion version;
   CipherSuite cipher_suite;
   std::vector<EncryptedGroupSecrets> secrets;
   bytes encrypted_group_info;
@@ -242,7 +241,7 @@ struct Welcome
   GroupInfo decrypt(const bytes& joiner_secret,
                     const std::vector<PSKWithSecret>& psks) const;
 
-  TLS_SERIALIZABLE(version, cipher_suite, secrets, encrypted_group_info)
+  TLS_SERIALIZABLE(cipher_suite, secrets, encrypted_group_info)
 
 private:
   bytes _joiner_secret;

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -101,8 +101,7 @@ GroupInfo::verify(const TreeKEMPublicKey& tree) const
 // Welcome
 
 Welcome::Welcome()
-  : version(ProtocolVersion::mls10)
-  , cipher_suite(CipherSuite::ID::unknown)
+  : cipher_suite(CipherSuite::ID::unknown)
 {
 }
 
@@ -110,8 +109,7 @@ Welcome::Welcome(CipherSuite suite,
                  const bytes& joiner_secret,
                  const std::vector<PSKWithSecret>& psks,
                  const GroupInfo& group_info)
-  : version(ProtocolVersion::mls10)
-  , cipher_suite(suite)
+  : cipher_suite(suite)
   , _joiner_secret(joiner_secret)
 {
   auto [key, nonce] = group_info_key_nonce(suite, joiner_secret, psks);


### PR DESCRIPTION
Pointed out by @mulmarta -- We still have a `version` field on the Welcome struct, which [doesn't exist in the spec any more](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-17.html#section-12.4.3.1).  This PR removes it.