### PR TITLE
Update to latest key schedule test vector

### DIFF
--- a/cmd/interop/src/json_details.h
+++ b/cmd/interop/src/json_details.h
@@ -208,9 +208,15 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(SecretTreeTestVector,
                                    sender_data,
                                    leaves)
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(KeyScheduleTestVector::Export,
+                                   label,
+                                   context,
+                                   length,
+                                   secret)
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(KeyScheduleTestVector::Epoch,
                                    tree_hash,
                                    commit_secret,
+                                   psk_secret,
                                    confirmed_transcript_hash,
                                    group_context,
                                    joiner_secret,
@@ -224,7 +230,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(KeyScheduleTestVector::Epoch,
                                    confirmation_key,
                                    membership_key,
                                    resumption_psk,
-                                   external_pub)
+                                   external_pub,
+                                   exporter)
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(KeyScheduleTestVector,
                                    cipher_suite,
                                    group_id,

--- a/cmd/interop/src/main.cpp
+++ b/cmd/interop/src/main.cpp
@@ -36,8 +36,15 @@ make_test_vector(uint64_t type)
     case TestVectorType::TREE_MATH:
       return TreeMathTestVector{ n };
 
-    case TestVectorType::KEY_SCHEDULE:
-      return KeyScheduleTestVector{ suite, n };
+    case TestVectorType::KEY_SCHEDULE: {
+      auto cases = std::vector<KeyScheduleTestVector>();
+
+      for (const auto& suite : mls::all_supported_suites) {
+        cases.emplace_back(suite, n);
+      }
+
+      return cases;
+    }
 
     case TestVectorType::TRANSCRIPT:
       return TranscriptTestVector{ suite };

--- a/include/mls/key_schedule.h
+++ b/include/mls/key_schedule.h
@@ -97,7 +97,6 @@ private:
 
 public:
   bytes joiner_secret;
-  bytes psk_secret;
   bytes epoch_secret;
 
   bytes sender_data_secret;
@@ -115,10 +114,10 @@ public:
   KeyScheduleEpoch() = default;
 
   // Full initializer, used by invited joiner
-  KeyScheduleEpoch(CipherSuite suite_in,
-                   const bytes& joiner_secret,
-                   const std::vector<PSKWithSecret>& psks,
-                   const bytes& context);
+  static KeyScheduleEpoch joiner(CipherSuite suite_in,
+                                 const bytes& joiner_secret,
+                                 const std::vector<PSKWithSecret>& psks,
+                                 const bytes& context);
 
   // Ciphersuite-only initializer, used by external joiner
   KeyScheduleEpoch(CipherSuite suite_in);
@@ -126,13 +125,6 @@ public:
   // Initial epoch
   KeyScheduleEpoch(CipherSuite suite_in,
                    const bytes& init_secret,
-                   const bytes& context);
-
-  // Subsequent epochs
-  KeyScheduleEpoch(CipherSuite suite_in,
-                   const bytes& init_secret,
-                   const bytes& commit_secret,
-                   const std::vector<PSKWithSecret>& psks,
                    const bytes& context);
 
   static std::tuple<bytes, bytes> external_init(
@@ -162,6 +154,26 @@ public:
   static KeyAndNonce sender_data_keys(CipherSuite suite,
                                       const bytes& sender_data_secret,
                                       const bytes& ciphertext);
+
+  // TODO(RLB) make these methods private, but accessible to test vectors
+  KeyScheduleEpoch(CipherSuite suite_in,
+                   const bytes& init_secret,
+                   const bytes& commit_secret,
+                   const bytes& psk_secret,
+                   const bytes& context);
+  KeyScheduleEpoch next_raw(const bytes& commit_secret,
+                            const bytes& psk_secret,
+                            const std::optional<bytes>& force_init_secret,
+                            const bytes& context) const;
+  static bytes welcome_secret_raw(CipherSuite suite,
+                                  const bytes& joiner_secret,
+                                  const bytes& psk_secret);
+
+private:
+  KeyScheduleEpoch(CipherSuite suite_in,
+                   const bytes& joiner_secret,
+                   const bytes& psk_secret,
+                   const bytes& context);
 };
 
 bool

--- a/lib/mls_vectors/include/mls_vectors/mls_vectors.h
+++ b/lib/mls_vectors/include/mls_vectors/mls_vectors.h
@@ -197,9 +197,10 @@ struct KeyScheduleTestVector : PseudoRandom
 {
   struct Export
   {
-    std::string exporter_label;
-    size_t exporter_length;
-    bytes exported;
+    std::string label;
+    bytes context;
+    size_t length;
+    bytes secret;
   };
 
   struct Epoch
@@ -207,6 +208,7 @@ struct KeyScheduleTestVector : PseudoRandom
     // Chosen by the generator
     bytes tree_hash;
     bytes commit_secret;
+    bytes psk_secret;
     bytes confirmed_transcript_hash;
 
     // Computed values

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -87,8 +87,8 @@ operator<<(std::ostream& str, const T& obj)
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define VERIFY(label, test)                                                    \
-  if (!(test)) {                                                               \
-    return std::string(label);                                                 \
+  if (auto err = verify_bool(label, test)) {                                   \
+    return err;                                                                \
   }
 
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
@@ -108,6 +108,17 @@ operator<<(std::ostream& str, const T& obj)
   if (auto err = verify_round_trip<Type>(label, expected, val)) {              \
     return err;                                                                \
   }
+
+template<typename T>
+static std::optional<std::string>
+verify_bool(const std::string& label, const T& test)
+{
+  if (test) {
+    return std::nullopt;
+  }
+
+  return label;
+}
 
 template<typename T, typename U>
 static std::optional<std::string>
@@ -577,19 +588,24 @@ KeyScheduleTestVector::KeyScheduleTestVector(CipherSuite suite,
       epoch_prg.secret("confirmed_transcript_hash");
     auto ctx = tls::marshal(group_context);
 
-    auto commit_secret = epoch_prg.secret("commit_secret");
     // TODO(RLB) Add Test case for externally-driven epoch change
-    epoch = epoch.next(commit_secret, {}, std::nullopt, ctx);
+    auto commit_secret = epoch_prg.secret("commit_secret");
+    auto psk_secret = epoch_prg.secret("psk_secret");
+    epoch = epoch.next_raw(commit_secret, psk_secret, std::nullopt, ctx);
 
-    auto welcome_secret =
-      KeyScheduleEpoch::welcome_secret(cipher_suite, epoch.joiner_secret, {});
+    auto welcome_secret = KeyScheduleEpoch::welcome_secret_raw(
+      cipher_suite, epoch.joiner_secret, psk_secret);
 
-    auto exporter_label = to_hex(epoch_prg.secret("exporter_label"));
+    auto exporter_prg = epoch_prg.sub("exporter");
+    auto exporter_label = to_hex(exporter_prg.secret("label"));
+    auto exporter_context = exporter_prg.secret("context");
     auto exporter_length = cipher_suite.secret_size();
-    auto exported = epoch.do_export(exporter_label, {}, exporter_length);
+    auto exported =
+      epoch.do_export(exporter_label, exporter_context, exporter_length);
 
     epochs.push_back({ group_context.tree_hash,
                        commit_secret,
+                       psk_secret,
                        group_context.confirmed_transcript_hash,
 
                        ctx,
@@ -611,6 +627,7 @@ KeyScheduleTestVector::KeyScheduleTestVector(CipherSuite suite,
 
                        {
                          exporter_label,
+                         exporter_context,
                          exporter_length,
                          exported,
                        } });
@@ -632,13 +649,14 @@ KeyScheduleTestVector::verify() const
     auto ctx = tls::marshal(group_context);
     VERIFY_EQUAL("group context", ctx, tve.group_context);
 
-    epoch = epoch.next(tve.commit_secret, {}, std::nullopt, ctx);
+    epoch =
+      epoch.next_raw(tve.commit_secret, tve.psk_secret, std::nullopt, ctx);
 
     // Verify the rest of the epoch
     VERIFY_EQUAL("joiner secret", epoch.joiner_secret, tve.joiner_secret);
 
-    auto welcome_secret =
-      KeyScheduleEpoch::welcome_secret(cipher_suite, tve.joiner_secret, {});
+    auto welcome_secret = KeyScheduleEpoch::welcome_secret_raw(
+      cipher_suite, tve.joiner_secret, tve.psk_secret);
     VERIFY_EQUAL("welcome secret", welcome_secret, tve.welcome_secret);
 
     VERIFY_EQUAL(
@@ -660,8 +678,8 @@ KeyScheduleTestVector::verify() const
       "external pub", epoch.external_priv.public_key, tve.external_pub);
 
     auto exported = epoch.do_export(
-      tve.exporter.exporter_label, {}, tve.exporter.exporter_length);
-    VERIFY_EQUAL("exported", exported, tve.exporter.exported);
+      tve.exporter.label, tve.exporter.context, tve.exporter.length);
+    VERIFY_EQUAL("exported", exported, tve.exporter.secret);
 
     group_context.epoch += 1;
   }
@@ -1056,7 +1074,7 @@ WelcomeTestVector::WelcomeTestVector(CipherSuite suite)
     cipher_suite, group_id, epoch, tree_hash, confirmed_transcript_hash, {}
   };
 
-  auto key_schedule = KeyScheduleEpoch(
+  auto key_schedule = KeyScheduleEpoch::joiner(
     cipher_suite, joiner_secret, {}, tls::marshal(group_context));
   auto confirmation_tag =
     key_schedule.confirmation_tag(confirmed_transcript_hash);
@@ -1099,7 +1117,7 @@ WelcomeTestVector::verify() const
 
   // Verify confirmation tag
   const auto& group_context = group_info.group_context;
-  auto key_schedule = KeyScheduleEpoch(
+  auto key_schedule = KeyScheduleEpoch::joiner(
     cipher_suite, group_secrets.joiner_secret, {}, tls::marshal(group_context));
   auto confirmation_tag =
     key_schedule.confirmation_tag(group_context.confirmed_transcript_hash);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -171,7 +171,7 @@ State::State(const HPKEPrivateKey& init_priv,
 
   // Ratchet forward into the current epoch
   auto group_ctx = tls::marshal(group_context());
-  _key_schedule = KeyScheduleEpoch(
+  _key_schedule = KeyScheduleEpoch::joiner(
     _suite, secrets.joiner_secret, { /* no PSKs */ }, group_ctx);
   _keys = _key_schedule.encryption_keys(_tree.size);
 


### PR DESCRIPTION
* Add exporter test
* Add `psk_secret` input
* ... and make API changes to KeyScheduleEpoch to accommodate