### PR TITLE
Separate TreeKEM update/merge and encap/decap and reverse their order

### DIFF
--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -126,6 +126,15 @@ struct TreeKEMPublicKey
   void update_leaf(LeafIndex index, const LeafNode& leaf);
   void blank_path(LeafIndex index);
 
+  TreeKEMPrivateKey update(LeafIndex from,
+                           const bytes& leaf_secret,
+                           const bytes& group_id,
+                           const SignaturePrivateKey& sig_priv,
+                           const LeafNodeOptions& opts);
+  UpdatePath encap(const TreeKEMPrivateKey& priv,
+                   const bytes& context,
+                   const std::vector<LeafIndex>& except) const;
+
   void merge(LeafIndex from, const UpdatePath& path);
   void set_hash_all();
   bytes root_hash() const;
@@ -141,15 +150,6 @@ struct TreeKEMPublicKey
   using FilteredDirectPath =
     std::vector<std::tuple<NodeIndex, std::vector<NodeIndex>>>;
   FilteredDirectPath filtered_direct_path(NodeIndex index) const;
-
-  std::tuple<TreeKEMPrivateKey, UpdatePath> encap(
-    LeafIndex from,
-    const bytes& group_id,
-    const bytes& context,
-    const bytes& leaf_secret,
-    const SignaturePrivateKey& sig_priv,
-    const std::vector<LeafIndex>& except,
-    const LeafNodeOptions& opts);
 
   void truncate();
 

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -1234,7 +1234,8 @@ struct TreeTestCase
 
       auto context = opt::get(maybe_context);
       auto pub_before = pub;
-      auto sender_priv = pub.update(from, leaf_secret, group_id, priv.sig_priv, {});
+      auto sender_priv =
+        pub.update(from, leaf_secret, group_id, priv.sig_priv, {});
       auto path = pub.encap(sender_priv, context, joiner);
 
       // Process the UpdatePath at all the members
@@ -1501,7 +1502,8 @@ TreeKEMTestVector::TreeKEMTestVector(mls::CipherSuite suite,
     const auto& sig_priv = tc.privs.at(sender).sig_priv;
 
     auto pub = tc.pub;
-    auto new_sender_priv = pub.update(sender, leaf_secret, group_id, sig_priv, {});
+    auto new_sender_priv =
+      pub.update(sender, leaf_secret, group_id, sig_priv, {});
     auto path = pub.encap(new_sender_priv, ctx, {});
 
     auto path_secrets = std::vector<std::optional<bytes>>{};
@@ -1610,7 +1612,8 @@ TreeKEMTestVector::verify()
     auto pub = ratchet_tree;
     auto leaf_secret = random_bytes(cipher_suite.secret_size());
     const auto& sig_priv = sig_privs.at(from);
-    auto new_sender_priv = pub.update(from, leaf_secret, group_id, sig_priv, {});
+    auto new_sender_priv =
+      pub.update(from, leaf_secret, group_id, sig_priv, {});
     auto new_path = pub.encap(new_sender_priv, ctx, {});
     VERIFY("new path parent hash valid",
            ratchet_tree.parent_hash_valid(from, path));

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -513,11 +513,8 @@ State::commit(const bytes& leaf_secret,
                                              joiner_locations,
                                              leaf_node_opts);
     */
-    auto new_priv = next._tree.update(next._index,
-                                      leaf_secret,
-                                      next._group_id,
-                                      _identity_priv,
-                                      leaf_node_opts);
+    auto new_priv = next._tree.update(
+      next._index, leaf_secret, next._group_id, _identity_priv, leaf_node_opts);
 
     auto ctx = tls::marshal(GroupContext{
       next._suite,

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -504,15 +504,6 @@ State::commit(const bytes& leaf_secret,
       leaf_node_opts = opt::get(opts).leaf_node_opts;
     }
 
-    /*
-    auto [new_priv, path] = next._tree.encap(next._index,
-                                             next._group_id,
-                                             ctx,
-                                             leaf_secret,
-                                             _identity_priv,
-                                             joiner_locations,
-                                             leaf_node_opts);
-    */
     auto new_priv = next._tree.update(
       next._index, leaf_secret, next._group_id, _identity_priv, leaf_node_opts);
 

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -606,10 +606,10 @@ TreeKEMPublicKey::leaf_node(LeafIndex index) const
 
 TreeKEMPrivateKey
 TreeKEMPublicKey::update(LeafIndex from,
-                        const bytes& leaf_secret,
-                        const bytes& group_id,
-                        const SignaturePrivateKey& sig_priv,
-                        const LeafNodeOptions& opts)
+                         const bytes& leaf_secret,
+                         const bytes& group_id,
+                         const SignaturePrivateKey& sig_priv,
+                         const LeafNodeOptions& opts)
 {
   // Grab information about the sender
   const auto& leaf_node = node_at(from);

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -243,10 +243,6 @@ TreeKEMPrivateKey::decap(LeafIndex from,
                          const UpdatePath& path,
                          const std::vector<LeafIndex>& except)
 {
-  if (!consistent(pub)) {
-    throw ProtocolError("TreeKEMPublicKey inconsistent with TreeKEMPrivateKey");
-  }
-
   // Identify which node in the path secret we will be decrypting
   auto ni = NodeIndex(index);
   auto dp = pub.filtered_direct_path(NodeIndex(from));
@@ -295,6 +291,11 @@ TreeKEMPrivateKey::decap(LeafIndex from,
                                   context,
                                   path.nodes[dpi].encrypted_path_secret[resi]);
   implant(pub, overlap_node, path_secret);
+
+  // Check that the resulting state is consistent with the public key
+  if (!consistent(pub)) {
+    throw ProtocolError("TreeKEMPublicKey inconsistent with TreeKEMPrivateKey");
+  }
 }
 
 void
@@ -603,24 +604,57 @@ TreeKEMPublicKey::leaf_node(LeafIndex index) const
   return node.leaf_node();
 }
 
-std::tuple<TreeKEMPrivateKey, UpdatePath>
-TreeKEMPublicKey::encap(LeafIndex from,
-                        const bytes& group_id,
-                        const bytes& context,
+TreeKEMPrivateKey
+TreeKEMPublicKey::update(LeafIndex from,
                         const bytes& leaf_secret,
+                        const bytes& group_id,
                         const SignaturePrivateKey& sig_priv,
-                        const std::vector<LeafIndex>& except,
                         const LeafNodeOptions& opts)
 {
   // Grab information about the sender
   const auto& leaf_node = node_at(from);
   if (leaf_node.blank()) {
-    throw InvalidParameterError("Cannot encap from blank node");
+    throw InvalidParameterError("Cannot update from blank node");
   }
 
   // Generate path secrets
   auto priv = TreeKEMPrivateKey::create(*this, from, leaf_secret);
   auto dp = filtered_direct_path(NodeIndex(from));
+
+  // Encrypt path secrets to the copath, forming a stub UpdatePath with no
+  // encryptions
+  auto path_nodes = stdx::transform<UpdatePathNode>(dp, [&](const auto& dpn) {
+    auto [n, _res] = dpn;
+
+    auto path_secret = priv.path_secrets.at(n);
+    auto node_priv = opt::get(priv.private_key(n));
+
+    return UpdatePathNode{ node_priv.public_key, {} };
+  });
+
+  // Update and re-sign the leaf_node
+  auto ph = parent_hashes(from, dp, path_nodes);
+  auto ph0 = bytes{};
+  if (!ph.empty()) {
+    ph0 = ph[0];
+  }
+
+  auto leaf_pub = opt::get(priv.private_key(NodeIndex(from))).public_key;
+  auto new_leaf = leaf_node.leaf_node().for_commit(
+    suite, group_id, leaf_pub, ph0, opts, sig_priv);
+
+  // Merge the changes into the tree
+  merge(from, UpdatePath{ std::move(new_leaf), std::move(path_nodes) });
+
+  return priv;
+}
+
+UpdatePath
+TreeKEMPublicKey::encap(const TreeKEMPrivateKey& priv,
+                        const bytes& context,
+                        const std::vector<LeafIndex>& except) const
+{
+  auto dp = filtered_direct_path(NodeIndex(priv.index));
 
   // Encrypt path secrets to the copath
   auto path_nodes = stdx::transform<UpdatePathNode>(dp, [&](const auto& dpn) {
@@ -641,23 +675,11 @@ TreeKEMPublicKey::encap(LeafIndex from,
     return UpdatePathNode{ node_priv.public_key, std::move(ct) };
   });
 
-  // Update and re-sign the leaf_node
-  auto ph = parent_hashes(from, dp, path_nodes);
-  auto ph0 = bytes{};
-  if (!ph.empty()) {
-    ph0 = ph[0];
-  }
-
-  auto leaf_pub = opt::get(priv.private_key(NodeIndex(from))).public_key;
-  auto new_leaf = leaf_node.leaf_node().for_commit(
-    suite, group_id, leaf_pub, ph0, opts, sig_priv);
-
   // Package everything into an UpdatePath
-  auto path = UpdatePath{ std::move(new_leaf), std::move(path_nodes) };
+  auto new_leaf = opt::get(leaf_node(priv.index));
+  auto path = UpdatePath{ new_leaf, std::move(path_nodes) };
 
-  // Update the public key itself
-  merge(from, path);
-  return std::make_tuple(priv, path);
+  return path;
 }
 
 void

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -229,10 +229,8 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM encap/decap")
 
     auto leaf_secret = random_bytes(32);
     pubs[i].set_hash_all();
-    auto [new_adder_priv, path_] = pubs[i].encap(
-      adder, group_id, context, leaf_secret, sig_privs[i], {}, {});
-    auto path = path_;
-    privs[i] = new_adder_priv;
+    privs[i] = pubs[i].update(adder, leaf_secret, group_id, sig_privs[i], {});
+    auto path = pubs[i].encap(privs[i], context, {});
     REQUIRE(pubs[i].parent_hash_valid(adder, path));
 
     auto [overlap, path_secret, ok_] = privs[i].shared_path_secret(joiner);


### PR DESCRIPTION
Currently, the context provided to TreeKEM encap/decap reflects an intermediate ratchet tree, where proposals have been applied, but the sender's direct path has not been updated.  The specification calls for encap/decap to be done [based on the new ratchet tree](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-17.html#section-12.4.1), after both applying proposals and updating the sender's direct path.  This PR splits the `update()` and `encap()` operations, and reverses their order, so that the context provided to encap/decap reflects the new tree.