### PR TITLE
Proposal validation

### DIFF
--- a/include/mls/common.h
+++ b/include/mls/common.h
@@ -225,6 +225,13 @@ all_of(const Container& c, const UnaryPredicate& pred)
   return std::all_of(c.begin(), c.end(), pred);
 }
 
+template<typename Container, typename UnaryPredicate>
+auto
+count_if(const Container& c, const UnaryPredicate& pred)
+{
+  return std::count_if(c.begin(), c.end(), pred);
+}
+
 template<typename Container, typename Value>
 bool
 contains(const Container& c, const Value& val)

--- a/include/mls/common.h
+++ b/include/mls/common.h
@@ -239,6 +239,13 @@ contains(const Container& c, const Value& val)
   return std::find(c.begin(), c.end(), val) != c.end();
 }
 
+template<typename Container, typename UnaryPredicate>
+auto
+find_if(const Container& c, const UnaryPredicate& pred)
+{
+  return std::find_if(c.begin(), c.end(), pred);
+}
+
 template<typename Container, typename Value>
 auto
 upper_bound(const Container& c, const Value& val)

--- a/include/mls/common.h
+++ b/include/mls/common.h
@@ -241,6 +241,13 @@ contains(const Container& c, const Value& val)
 
 template<typename Container, typename UnaryPredicate>
 auto
+find_if(Container& c, const UnaryPredicate& pred)
+{
+  return std::find_if(c.begin(), c.end(), pred);
+}
+
+template<typename Container, typename UnaryPredicate>
+auto
 find_if(const Container& c, const UnaryPredicate& pred)
 {
   return std::find_if(c.begin(), c.end(), pred);

--- a/include/mls/core_types.h
+++ b/include/mls/core_types.h
@@ -216,7 +216,7 @@ struct LeafNode
 
   struct MemberBinding
   {
-    const bytes& group_id;
+    bytes group_id;
     LeafIndex leaf_index;
     TLS_SERIALIZABLE(group_id, leaf_index);
   };

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -382,7 +382,7 @@ struct Commit
   std::vector<ProposalOrRef> proposals;
   std::optional<UpdatePath> path;
 
-  // Validate that the commit is accepable as an external commit, and if so,
+  // Validate that the commit is acceptable as an external commit, and if so,
   // produce the public key from the ExternalInit proposal
   std::optional<bytes> valid_external() const;
 

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -60,7 +60,7 @@ public:
   static std::tuple<MLSMessage, State> external_join(
     const bytes& leaf_secret,
     SignaturePrivateKey sig_priv,
-    const KeyPackage& kp,
+    const KeyPackage& key_package,
     const GroupInfo& group_info,
     const std::optional<TreeKEMPublicKey>& tree,
     const MessageOpts& msg_opts);
@@ -232,16 +232,16 @@ protected:
   bool valid(const Add& add) const;
   bool valid(LeafIndex sender, const Update& update) const;
   bool valid(const Remove& remove) const;
-  bool valid(const PreSharedKey& psk) const;
-  bool valid(const ReInit& reinit) const;
+  static bool valid(const PreSharedKey& psk);
+  static bool valid(const ReInit& reinit);
   bool valid(const ExternalInit& external_init) const;
   bool valid(const GroupContextExtensions& gce) const;
   bool valid(std::optional<LeafIndex> sender, const Proposal& proposal) const;
   bool valid(const std::vector<CachedProposal>& proposals,
              LeafIndex commit_sender) const;
-  bool valid_reinit(const std::vector<CachedProposal>& proposals) const;
-  bool valid_external(const std::vector<CachedProposal>& proposals) const;
-  bool path_required(const std::vector<CachedProposal>& proposals) const;
+  static bool valid_reinit(const std::vector<CachedProposal>& proposals);
+  static bool valid_external(const std::vector<CachedProposal>& proposals);
+  static bool path_required(const std::vector<CachedProposal>& proposals);
 
   // Compare the **shared** attributes of the states
   friend bool operator==(const State& lhs, const State& rhs);

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -203,12 +203,6 @@ protected:
   AuthenticatedContent unprotect_to_content_auth(const MLSMessage& msg);
 
   // Apply the changes requested by various messages
-  void check_add_leaf_node(const LeafNode& leaf,
-                           std::optional<LeafIndex> except) const;
-  void check_update_leaf_node(LeafIndex target,
-                              const LeafNode& leaf,
-                              LeafNodeSource required_source,
-                              bool external_commit) const;
   LeafIndex apply(const Add& add);
   void apply(LeafIndex target, const Update& update);
   void apply(LeafIndex target,

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -50,7 +50,7 @@ public:
   State(const HPKEPrivateKey& init_priv,
         HPKEPrivateKey leaf_priv,
         SignaturePrivateKey sig_priv,
-        const KeyPackage& kp,
+        const KeyPackage& key_package,
         const Welcome& welcome,
         const std::optional<TreeKEMPublicKey>& tree);
 
@@ -212,8 +212,7 @@ protected:
   void apply(const GroupContextExtensions& gce);
   std::vector<LeafIndex> apply(const std::vector<CachedProposal>& proposals,
                                Proposal::Type required_type);
-  std::tuple<bool, bool, std::vector<LeafIndex>> apply(
-    const std::vector<CachedProposal>& proposals);
+  std::vector<LeafIndex> apply(const std::vector<CachedProposal>& proposals);
 
   // Verify that a specific key package or all members support a given set of
   // extensions
@@ -227,6 +226,22 @@ protected:
   std::vector<CachedProposal> must_resolve(
     const std::vector<ProposalOrRef>& ids,
     std::optional<LeafIndex> sender_index) const;
+
+  // Check properties of proposals
+  bool valid(const LeafNode& leaf_node, LeafNodeSource required_source, std::optional<LeafIndex> index) const;
+  bool valid(const KeyPackage& key_package) const;
+  bool valid(const Add& add) const;
+  bool valid(LeafIndex sender, const Update& update) const;
+  bool valid(const Remove& remove) const;
+  bool valid(const PreSharedKey& psk) const;
+  bool valid(const ReInit& reinit) const;
+  bool valid(const ExternalInit& external_init) const;
+  bool valid(const GroupContextExtensions& gce) const;
+  bool valid(std::optional<LeafIndex> sender, const Proposal& proposal) const;
+  bool valid(const std::vector<CachedProposal>& proposals, LeafIndex commit_sender) const;
+  bool valid_reinit(const std::vector<CachedProposal>& proposals) const;
+  bool valid_external(const std::vector<CachedProposal>& proposals) const;
+  bool path_required(const std::vector<CachedProposal>& proposals) const;
 
   // Compare the **shared** attributes of the states
   friend bool operator==(const State& lhs, const State& rhs);

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -59,7 +59,6 @@ public:
   // whether to include PSKs or evict our prior appearance.
   static std::tuple<MLSMessage, State> external_join(
     const bytes& leaf_secret,
-    HPKEPrivateKey enc_priv,
     SignaturePrivateKey sig_priv,
     const KeyPackage& kp,
     const GroupInfo& group_info,
@@ -170,9 +169,7 @@ protected:
   std::optional<CachedUpdate> _cached_update;
 
   // Assemble a preliminary, unjoined group state
-  State(HPKEPrivateKey enc_priv,
-        SignaturePrivateKey sig_priv,
-        const KeyPackage& key_package,
+  State(SignaturePrivateKey sig_priv,
         const GroupInfo& group_info,
         const std::optional<TreeKEMPublicKey>& tree);
 

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -80,7 +80,7 @@ struct TreeKEMPrivateKey
                                   NodeIndex intersect,
                                   const std::optional<bytes>& path_secret);
 
-  void set_leaf_secret(const bytes& secret);
+  void set_leaf_priv(HPKEPrivateKey priv);
   std::tuple<NodeIndex, bytes, bool> shared_path_secret(LeafIndex to) const;
 
   bool have_private_key(NodeIndex n) const;

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -101,10 +101,8 @@ Lifetime::create_default()
 void
 ExtensionList::add(uint16_t type, bytes data)
 {
-  auto curr = std::find_if(
-    extensions.begin(), extensions.end(), [&](const Extension& ext) -> bool {
-      return ext.type == type;
-    });
+  auto curr = stdx::find_if(
+    extensions, [&](const Extension& ext) -> bool { return ext.type == type; });
   if (curr != extensions.end()) {
     curr->data = std::move(data);
     return;

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -263,8 +263,10 @@ bytes
 Session::update()
 {
   auto leaf_secret = inner->fresh_secret();
+
+  auto leaf_priv = HPKEPrivateKey::generate(cipher_suite());
   auto proposal = inner->history.front().update(
-    leaf_secret, {}, { inner->encrypt_handshake, {}, 0 });
+    std::move(leaf_priv), {}, { inner->encrypt_handshake, {}, 0 });
   return tls::marshal(proposal);
 }
 

--- a/src/tree_math.cpp
+++ b/src/tree_math.cpp
@@ -166,6 +166,10 @@ NodeIndex::sibling(NodeIndex ancestor) const
 std::vector<NodeIndex>
 NodeIndex::dirpath(LeafCount n)
 {
+  if (val >= NodeCount(n).val) {
+    throw InvalidParameterError("Request for dirpath outside of tree");
+  }
+
   auto d = std::vector<NodeIndex>{};
 
   auto r = root(n);

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -151,9 +151,11 @@ TreeKEMPrivateKey::private_key(NodeIndex n)
 }
 
 void
-TreeKEMPrivateKey::set_leaf_secret(const bytes& secret)
+TreeKEMPrivateKey::set_leaf_priv(HPKEPrivateKey priv)
 {
-  path_secrets[NodeIndex(index)] = secret;
+  auto n = NodeIndex(index);
+  path_secrets.erase(n);
+  private_key_cache.insert_or_assign(n, std::move(priv));
 }
 
 std::tuple<NodeIndex, bytes, bool>
@@ -185,14 +187,10 @@ TreeKEMPrivateKey::dump() const
 
   std::cout << "  Secrets: " << std::endl;
   for (const auto& [n, secret] : path_secrets) {
+    auto sk = opt::get(private_key(n));
     auto ssm = to_hex(secret).substr(0, 8);
-    std::cout << "    " << n.val << " => " << ssm << std::endl;
-  }
-
-  std::cout << "  Public Keys: " << std::endl;
-  for (const auto& [n, sk] : private_key_cache) {
     auto pkm = to_hex(sk.public_key.data).substr(0, 8);
-    std::cout << "    " << n.val << " => " << pkm << std::endl;
+    std::cout << "    " << n.val << " => " << ssm << " = " << pkm << std::endl;
   }
 }
 

--- a/test/session.cpp
+++ b/test/session.cpp
@@ -153,9 +153,6 @@ TEST_CASE_FIXTURE(RunningSessionTest, "Update within Session")
   for (int i = 0; i < group_size; i += 1) {
     auto initial_epoch = sessions[0].epoch();
 
-    auto update = sessions[i].update();
-    broadcast(update);
-
     auto welcome_commit = sessions[i].commit();
     broadcast(std::get<1>(welcome_commit));
 
@@ -207,8 +204,6 @@ TEST_CASE_FIXTURE(RunningSessionTest, "Full Session Life-Cycle")
   // 2. Have everyone update
   for (int i = 0; i < group_size - 1; i += 1) {
     auto initial_epoch = sessions[0].epoch();
-    auto update = sessions[i].update();
-    broadcast(update);
     auto welcome_commit = sessions[i].commit();
     broadcast(std::get<1>(welcome_commit));
     check(initial_epoch);

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -318,7 +318,6 @@ TEST_CASE_FIXTURE(StateTest, "External Join")
 
   // Initialize the second participant as an external joiner
   auto [commit, second0] = State::external_join(fresh_secret(),
-                                                init_privs[1],
                                                 identity_privs[1],
                                                 key_packages[1],
                                                 group_info,
@@ -346,7 +345,6 @@ TEST_CASE_FIXTURE(StateTest, "External Join with External Tree")
 
   // Initialize the second participant as an external joiner
   auto [commit, second0] = State::external_join(fresh_secret(),
-                                                init_privs[1],
                                                 identity_privs[1],
                                                 key_packages[1],
                                                 group_info,

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -344,12 +344,8 @@ TEST_CASE_FIXTURE(StateTest, "External Join with External Tree")
   auto tree = first0.tree();
 
   // Initialize the second participant as an external joiner
-  auto [commit, second0] = State::external_join(fresh_secret(),
-                                                identity_privs[1],
-                                                key_packages[1],
-                                                group_info,
-                                                tree,
-                                                {});
+  auto [commit, second0] = State::external_join(
+    fresh_secret(), identity_privs[1], key_packages[1], group_info, tree, {});
 
   // Creator processes the commit
   auto first1 = opt::get(first0.handle(commit));

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -318,6 +318,7 @@ TEST_CASE_FIXTURE(StateTest, "External Join")
 
   // Initialize the second participant as an external joiner
   auto [commit, second0] = State::external_join(fresh_secret(),
+                                                init_privs[1],
                                                 identity_privs[1],
                                                 key_packages[1],
                                                 group_info,
@@ -344,8 +345,13 @@ TEST_CASE_FIXTURE(StateTest, "External Join with External Tree")
   auto tree = first0.tree();
 
   // Initialize the second participant as an external joiner
-  auto [commit, second0] = State::external_join(
-    fresh_secret(), identity_privs[1], key_packages[1], group_info, tree, {});
+  auto [commit, second0] = State::external_join(fresh_secret(),
+                                                init_privs[1],
+                                                identity_privs[1],
+                                                key_packages[1],
+                                                group_info,
+                                                tree,
+                                                {});
 
   // Creator processes the commit
   auto first1 = opt::get(first0.handle(commit));
@@ -602,7 +608,8 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Update Everyone in a Group")
     auto& updater = states.at(i);
     auto& committer = states.at(committer_index);
 
-    auto update = updater.update(fresh_secret(), {}, {});
+    auto update_priv = HPKEPrivateKey::generate(suite);
+    auto update = updater.update(std::move(update_priv), {}, {});
 
     committer.handle(update);
     auto [commit, welcome, new_state] =

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -64,8 +64,8 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Private Key")
   const auto index = LeafIndex{ 2 };
   const auto intersect = NodeIndex{ 3 };
   const auto random = random_bytes(32);
-  const auto random2 = random_bytes(32);
   const auto priv = HPKEPrivateKey::derive(suite, random);
+  const auto priv2 = HPKEPrivateKey::generate(suite);
   const auto hash_size = suite.digest().hash_size;
 
   // Create a tree with N blank leaves
@@ -101,9 +101,9 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Private Key")
   REQUIRE(priv_joiner.update_secret.size() == hash_size);
   auto last_update_secret = priv_joiner.update_secret;
 
-  // set_leaf_secret() properly sets the leaf secret
-  priv_joiner.set_leaf_secret(random2);
-  REQUIRE(priv_joiner.path_secrets.find(NodeIndex(index))->second == random2);
+  // set_leaf_priv() properly sets the leaf secret
+  priv_joiner.set_leaf_priv(priv2);
+  REQUIRE(priv_joiner.private_key(NodeIndex(index)) == priv2);
   REQUIRE(priv_joiner.update_secret.size() == hash_size);
   REQUIRE(priv_joiner.update_secret == last_update_secret);
 


### PR DESCRIPTION
This PR began as an effort to enforce the [proposal validation rules](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-17.html#name-proposal-list-validation).  This caused a few other bugs to come to the surface:

* External joins were still being done in an old way (using Add instead of the path)
* Tests were only covering updates that were committed by the updater
* ... and the actual update logic was broken (two different secret -> key pair translations!)

As a result, this PR also fixes those bugs.