### PR TITLE
Add external PSK support

### DIFF
--- a/cmd/interop/src/mls_client_impl.cpp
+++ b/cmd/interop/src/mls_client_impl.cpp
@@ -477,7 +477,8 @@ MLSClientImpl::join_group(const JoinGroupRequest* request,
                           std::move(join->sig_priv),
                           join->key_package,
                           welcome,
-                          std::nullopt);
+                          std::nullopt,
+                          {});
   auto state_id = store_state(std::move(state), request->encrypt_handshake());
 
   response->set_state_id(state_id);

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -249,6 +249,7 @@ struct Welcome
 
 private:
   bytes _joiner_secret;
+  PreSharedKeys _psks;
   static KeyAndNonce group_info_key_nonce(
     CipherSuite suite,
     const bytes& joiner_secret,

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -31,11 +31,6 @@ struct MessageOpts
   size_t padding_size = 0;
 };
 
-struct PSKStore
-{
-  virtual bytes get_psk_secret(const PreSharedKeyID& id) const = 0;
-};
-
 class State
 {
 public:
@@ -57,7 +52,8 @@ public:
         SignaturePrivateKey sig_priv,
         const KeyPackage& key_package,
         const Welcome& welcome,
-        const std::optional<TreeKEMPublicKey>& tree);
+        const std::optional<TreeKEMPublicKey>& tree,
+        std::map<bytes, bytes> psks);
 
   // Join a group from outside
   // XXX(RLB) To be fully general, we would need a few more options here, e.g.,
@@ -86,6 +82,7 @@ public:
   Proposal remove_proposal(RosterIndex index) const;
   Proposal remove_proposal(LeafIndex removed) const;
   Proposal group_context_extensions_proposal(ExtensionList exts) const;
+  Proposal pre_shared_key_proposal(const bytes& external_psk_id) const;
 
   MLSMessage add(const KeyPackage& key_package, const MessageOpts& msg_opts);
   MLSMessage update(HPKEPrivateKey leaf_priv,
@@ -95,6 +92,8 @@ public:
   MLSMessage remove(LeafIndex removed, const MessageOpts& msg_opts);
   MLSMessage group_context_extensions(ExtensionList exts,
                                       const MessageOpts& msg_opts);
+  MLSMessage pre_shared_key(const bytes& external_psk_id,
+                            const MessageOpts& msg_opts);
 
   std::tuple<MLSMessage, Welcome, State> commit(
     const bytes& leaf_secret,
@@ -107,6 +106,12 @@ public:
   std::optional<State> handle(const MLSMessage& msg);
   std::optional<State> handle(const MLSMessage& msg,
                               std::optional<State> cached);
+
+  ///
+  /// PSK management
+  ///
+  void add_external_psk(const bytes& id, const bytes& secret);
+  void remove_external_psk(const bytes& id);
 
   ///
   /// Accessors
@@ -156,6 +161,9 @@ protected:
   // Per-participant state
   LeafIndex _index;
   SignaturePrivateKey _identity_priv;
+
+  // Storage for PSKs
+  std::map<bytes, bytes> _external_psks;
 
   // Cache of Proposals and update secrets
   struct CachedProposal
@@ -214,7 +222,8 @@ protected:
   void apply(const GroupContextExtensions& gce);
   std::vector<LeafIndex> apply(const std::vector<CachedProposal>& proposals,
                                Proposal::Type required_type);
-  std::vector<LeafIndex> apply(const std::vector<CachedProposal>& proposals);
+  std::tuple<std::vector<LeafIndex>, std::vector<PSKWithSecret>> apply(
+    const std::vector<CachedProposal>& proposals);
 
   // Verify that a specific key package or all members support a given set of
   // extensions
@@ -237,7 +246,7 @@ protected:
   bool valid(const Add& add) const;
   bool valid(LeafIndex sender, const Update& update) const;
   bool valid(const Remove& remove) const;
-  static bool valid(const PreSharedKey& psk);
+  bool valid(const PreSharedKey& psk) const;
   static bool valid(const ReInit& reinit);
   bool valid(const ExternalInit& external_init) const;
   bool valid(const GroupContextExtensions& gce) const;

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -31,6 +31,11 @@ struct MessageOpts
   size_t padding_size = 0;
 };
 
+struct PSKStore
+{
+  virtual bytes get_psk_secret(const PreSharedKeyID& id) const = 0;
+};
+
 class State
 {
 public:

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -129,8 +129,8 @@ Welcome::Welcome(CipherSuite suite,
   , _joiner_secret(joiner_secret)
 {
   // Cache the list of PSK IDs
-  for (const auto& psks : psks) {
-    _psks.psks.push_back(psks.id);
+  for (const auto& psk : psks) {
+    _psks.psks.push_back(psk.id);
   }
 
   // Pre-encrypt the GroupInfo

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -128,6 +128,12 @@ Welcome::Welcome(CipherSuite suite,
   : cipher_suite(suite)
   , _joiner_secret(joiner_secret)
 {
+  // Cache the list of PSK IDs
+  for (const auto& psks : psks) {
+    _psks.psks.push_back(psks.id);
+  }
+
+  // Pre-encrypt the GroupInfo
   auto [key, nonce] = group_info_key_nonce(suite, joiner_secret, psks);
   auto group_info_data = tls::marshal(group_info);
   encrypted_group_info =
@@ -149,7 +155,7 @@ Welcome::find(const KeyPackage& kp) const
 void
 Welcome::encrypt(const KeyPackage& kp, const std::optional<bytes>& path_secret)
 {
-  auto gs = GroupSecrets{ _joiner_secret, std::nullopt, {} };
+  auto gs = GroupSecrets{ _joiner_secret, std::nullopt, _psks };
   if (path_secret) {
     gs.path_secret = { opt::get(path_secret) };
   }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -182,7 +182,7 @@ Session::Inner::join(const HPKEPrivateKey& init_priv,
   auto welcome = tls::get<Welcome>(welcome_data);
 
   auto state =
-    State(init_priv, leaf_priv, sig_priv, key_package, welcome, std::nullopt);
+    State(init_priv, leaf_priv, sig_priv, key_package, welcome, std::nullopt, {});
   auto inner = std::make_unique<Inner>(state);
   return { inner.release() };
 }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -181,8 +181,8 @@ Session::Inner::join(const HPKEPrivateKey& init_priv,
 {
   auto welcome = tls::get<Welcome>(welcome_data);
 
-  auto state =
-    State(init_priv, leaf_priv, sig_priv, key_package, welcome, std::nullopt, {});
+  auto state = State(
+    init_priv, leaf_priv, sig_priv, key_package, welcome, std::nullopt, {});
   auto inner = std::make_unique<Inner>(state);
   return { inner.release() };
 }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -189,8 +189,8 @@ State::State(const HPKEPrivateKey& init_priv,
 
   // Ratchet forward into the current epoch
   auto group_ctx = tls::marshal(group_context());
-  _key_schedule = KeyScheduleEpoch::joiner(
-    _suite, secrets.joiner_secret, psks, group_ctx);
+  _key_schedule =
+    KeyScheduleEpoch::joiner(_suite, secrets.joiner_secret, psks, group_ctx);
   _keys = _key_schedule.encryption_keys(_tree.size);
 
   // Verify the confirmation

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -128,9 +128,6 @@ State::State(const HPKEPrivateKey& init_priv,
 
   // Decrypt the GroupSecrets
   auto secrets = welcome.decrypt_secrets(kpi, init_priv);
-  if (!secrets.psks.psks.empty()) {
-    throw NotImplementedError(/* PSKs are not supported */);
-  }
 
   // Look up PSKs
   auto psks =
@@ -193,7 +190,7 @@ State::State(const HPKEPrivateKey& init_priv,
   // Ratchet forward into the current epoch
   auto group_ctx = tls::marshal(group_context());
   _key_schedule = KeyScheduleEpoch::joiner(
-    _suite, secrets.joiner_secret, { /* no PSKs */ }, group_ctx);
+    _suite, secrets.joiner_secret, psks, group_ctx);
   _keys = _key_schedule.encryption_keys(_tree.size);
 
   // Verify the confirmation

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -137,8 +137,13 @@ TEST_CASE_FIXTURE(StateTest, "Two Person")
   auto first1 = first1_;
 
   // Initialize the second participant from the Welcome
-  auto second0 = State{ init_privs[1],   leaf_privs[1], identity_privs[1],
-                        key_packages[1], welcome,       std::nullopt, {}};
+  auto second0 = State{ init_privs[1],
+                        leaf_privs[1],
+                        identity_privs[1],
+                        key_packages[1],
+                        welcome,
+                        std::nullopt,
+                        {} };
   REQUIRE(first1 == second0);
 
   auto group = std::vector<State>{ first1, second0 };
@@ -165,8 +170,13 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with New Member Add")
   auto first1 = first1_;
 
   // Initialize the second participant from the Welcome
-  auto second0 = State{ init_privs[1],   leaf_privs[1], identity_privs[1],
-                        key_packages[1], welcome,       std::nullopt, {} };
+  auto second0 = State{ init_privs[1],
+                        leaf_privs[1],
+                        identity_privs[1],
+                        key_packages[1],
+                        welcome,
+                        std::nullopt,
+                        {} };
   REQUIRE(first1 == second0);
 
   auto group = std::vector<State>{ first1, second0 };
@@ -205,8 +215,13 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with External Proposal")
   auto first1 = first1_;
 
   // Initialize the second participant from the Welcome
-  auto second0 = State{ init_privs[1],   leaf_privs[1], identity_privs[1],
-                        key_packages[1], welcome,       std::nullopt, {} };
+  auto second0 = State{ init_privs[1],
+                        leaf_privs[1],
+                        identity_privs[1],
+                        key_packages[1],
+                        welcome,
+                        std::nullopt,
+                        {} };
   REQUIRE(first1 == second0);
 
   auto group = std::vector<State>{ first1, second0 };
@@ -234,8 +249,13 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with custom extensions")
   silence_unused(commit1);
 
   // Initialize the second participant from the Welcome
-  auto second1 = State{ init_privs[1],   leaf_privs[1], identity_privs[1],
-                        key_packages[1], welcome1,      std::nullopt, {} };
+  auto second1 = State{ init_privs[1],
+                        leaf_privs[1],
+                        identity_privs[1],
+                        key_packages[1],
+                        welcome1,
+                        std::nullopt,
+                        {} };
   REQUIRE(first1 == second1);
   REQUIRE(first1.extensions() == first_exts);
 
@@ -283,7 +303,8 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with external tree for welcome")
                         identity_privs[1],
                         key_packages[1],
                         welcome,
-                        std::nullopt, {}),
+                        std::nullopt,
+                        {}),
                   InvalidParameterError);
 
   auto incorrect_tree = TreeKEMPublicKey(suite);
@@ -294,11 +315,17 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with external tree for welcome")
                         identity_privs[1],
                         key_packages[1],
                         welcome,
-                        incorrect_tree, {}),
+                        incorrect_tree,
+                        {}),
                   InvalidParameterError);
 
-  auto second0 = State{ init_privs[1],   leaf_privs[1], identity_privs[1],
-                        key_packages[1], welcome,       first1.tree(), {} };
+  auto second0 = State{ init_privs[1],
+                        leaf_privs[1],
+                        identity_privs[1],
+                        key_packages[1],
+                        welcome,
+                        first1.tree(),
+                        {} };
   REQUIRE(first1 == second0);
 
   auto group = std::vector<State>{ first1, second0 };
@@ -309,7 +336,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with PSK")
 {
   const auto psk_id = from_ascii("external psk");
   const auto psk_secret = from_ascii("super secret");
-  const auto psks = std::map<bytes, bytes>{{psk_id, psk_secret}};
+  const auto psks = std::map<bytes, bytes>{ { psk_id, psk_secret } };
 
   // Initialize the creator's state
   auto first0 = State{ group_id,
@@ -325,14 +352,16 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with PSK")
   // Create a Commit over Add and PSK proposals
   auto add = first0.add_proposal(key_packages[1]);
   auto psk = first0.pre_shared_key_proposal(psk_id);
-  auto [commit, welcome, first1_] =
-    first0.commit(fresh_secret(), CommitOpts{ { add, psk }, true, false, {} }, {});
+  auto [commit, welcome, first1_] = first0.commit(
+    fresh_secret(), CommitOpts{ { add, psk }, true, false, {} }, {});
   silence_unused(commit);
   auto first1 = first1_;
 
   // Initialize the second participant from the Welcome
-  auto second0 = State{ init_privs[1],   leaf_privs[1], identity_privs[1],
-                        key_packages[1], welcome,       std::nullopt, psks};
+  auto second0 = State{
+    init_privs[1], leaf_privs[1], identity_privs[1], key_packages[1], welcome,
+    std::nullopt,  psks
+  };
   REQUIRE(first1 == second0);
 }
 
@@ -511,11 +540,12 @@ TEST_CASE_FIXTURE(StateTest, "Add Multiple Members")
   // Initialize the new joiners from the welcome
   for (size_t i = 1; i < group_size; i += 1) {
     states.push_back({ init_privs[i],
-                        leaf_privs[i],
-                        identity_privs[i],
-                        key_packages[i],
-                        welcome,
-                        std::nullopt, {} });
+                       leaf_privs[i],
+                       identity_privs[i],
+                       key_packages[i],
+                       welcome,
+                       std::nullopt,
+                       {} });
   }
 
   verify_group_functionality(states);
@@ -547,11 +577,12 @@ TEST_CASE_FIXTURE(StateTest, "Full Size Group")
     }
 
     states.push_back({ init_privs[i],
-                        leaf_privs[i],
-                        identity_privs[i],
-                        key_packages[i],
-                        welcome,
-                        std::nullopt, {} });
+                       leaf_privs[i],
+                       identity_privs[i],
+                       key_packages[i],
+                       welcome,
+                       std::nullopt,
+                       {} });
 
     // Check that everyone ended up in the same place
     for (const auto& state : states) {
@@ -587,11 +618,12 @@ protected:
     states[0] = new_state;
     for (size_t i = 1; i < group_size; i += 1) {
       states.push_back({ init_privs[i],
-                          leaf_privs[i],
-                          identity_privs[i],
-                          key_packages[i],
-                          welcome,
-                          std::nullopt, {} });
+                         leaf_privs[i],
+                         identity_privs[i],
+                         key_packages[i],
+                         welcome,
+                         std::nullopt,
+                         {} });
     }
 
     check_consistency();

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -138,7 +138,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person")
 
   // Initialize the second participant from the Welcome
   auto second0 = State{ init_privs[1],   leaf_privs[1], identity_privs[1],
-                        key_packages[1], welcome,       std::nullopt };
+                        key_packages[1], welcome,       std::nullopt, {}};
   REQUIRE(first1 == second0);
 
   auto group = std::vector<State>{ first1, second0 };
@@ -166,7 +166,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with New Member Add")
 
   // Initialize the second participant from the Welcome
   auto second0 = State{ init_privs[1],   leaf_privs[1], identity_privs[1],
-                        key_packages[1], welcome,       std::nullopt };
+                        key_packages[1], welcome,       std::nullopt, {} };
   REQUIRE(first1 == second0);
 
   auto group = std::vector<State>{ first1, second0 };
@@ -206,7 +206,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with External Proposal")
 
   // Initialize the second participant from the Welcome
   auto second0 = State{ init_privs[1],   leaf_privs[1], identity_privs[1],
-                        key_packages[1], welcome,       std::nullopt };
+                        key_packages[1], welcome,       std::nullopt, {} };
   REQUIRE(first1 == second0);
 
   auto group = std::vector<State>{ first1, second0 };
@@ -235,7 +235,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with custom extensions")
 
   // Initialize the second participant from the Welcome
   auto second1 = State{ init_privs[1],   leaf_privs[1], identity_privs[1],
-                        key_packages[1], welcome1,      std::nullopt };
+                        key_packages[1], welcome1,      std::nullopt, {} };
   REQUIRE(first1 == second1);
   REQUIRE(first1.extensions() == first_exts);
 
@@ -283,7 +283,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with external tree for welcome")
                         identity_privs[1],
                         key_packages[1],
                         welcome,
-                        std::nullopt),
+                        std::nullopt, {}),
                   InvalidParameterError);
 
   auto incorrect_tree = TreeKEMPublicKey(suite);
@@ -294,11 +294,11 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with external tree for welcome")
                         identity_privs[1],
                         key_packages[1],
                         welcome,
-                        incorrect_tree),
+                        incorrect_tree, {}),
                   InvalidParameterError);
 
   auto second0 = State{ init_privs[1],   leaf_privs[1], identity_privs[1],
-                        key_packages[1], welcome,       first1.tree() };
+                        key_packages[1], welcome,       first1.tree(), {} };
   REQUIRE(first1 == second0);
 
   auto group = std::vector<State>{ first1, second0 };
@@ -383,7 +383,7 @@ TEST_CASE_FIXTURE(StateTest, "SFrame Parameter Negotiation")
   auto first1 = first1_;
   silence_unused(commit);
 
-  auto second0 = State{ init1, leaf1, id1, kp1, welcome, std::nullopt };
+  auto second0 = State{ init1, leaf1, id1, kp1, welcome, std::nullopt, {} };
   REQUIRE(first1 == second0);
 
   auto group = std::vector<State>{ first1, second0 };
@@ -479,12 +479,12 @@ TEST_CASE_FIXTURE(StateTest, "Add Multiple Members")
 
   // Initialize the new joiners from the welcome
   for (size_t i = 1; i < group_size; i += 1) {
-    states.emplace_back(init_privs[i],
+    states.push_back({ init_privs[i],
                         leaf_privs[i],
                         identity_privs[i],
                         key_packages[i],
                         welcome,
-                        std::nullopt);
+                        std::nullopt, {} });
   }
 
   verify_group_functionality(states);
@@ -515,12 +515,12 @@ TEST_CASE_FIXTURE(StateTest, "Full Size Group")
       }
     }
 
-    states.emplace_back(init_privs[i],
+    states.push_back({ init_privs[i],
                         leaf_privs[i],
                         identity_privs[i],
                         key_packages[i],
                         welcome,
-                        std::nullopt);
+                        std::nullopt, {} });
 
     // Check that everyone ended up in the same place
     for (const auto& state : states) {
@@ -555,12 +555,12 @@ protected:
     silence_unused(commit);
     states[0] = new_state;
     for (size_t i = 1; i < group_size; i += 1) {
-      states.emplace_back(init_privs[i],
+      states.push_back({ init_privs[i],
                           leaf_privs[i],
                           identity_privs[i],
                           key_packages[i],
                           welcome,
-                          std::nullopt);
+                          std::nullopt, {} });
     }
 
     check_consistency();


### PR DESCRIPTION
This PR adds support for external PSKs.  (Resumption PSKs will be handled in follow-ons.)  The approach here is a little brute-force, since it copies the PSKs into the group state and carries them around there.  It would be more elegant to provide State a reference to a PSK store at the appropriate moments.  But this seems sufficient for now, and we can refactor the API later.

Depends on #318 