### PR TITLE
Add support for subgroup branching

### DIFF
--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -70,7 +70,7 @@ struct TreeKEMPrivateKey
 
   static TreeKEMPrivateKey solo(CipherSuite suite,
                                 LeafIndex index,
-                                const HPKEPrivateKey& leaf_priv);
+                                HPKEPrivateKey leaf_priv);
   static TreeKEMPrivateKey create(const TreeKEMPublicKey& pub,
                                   LeafIndex from,
                                   const bytes& leaf_secret);

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -63,10 +63,10 @@ Node::parent_hash() const
 TreeKEMPrivateKey
 TreeKEMPrivateKey::solo(CipherSuite suite,
                         LeafIndex index,
-                        const HPKEPrivateKey& leaf_priv)
+                        HPKEPrivateKey leaf_priv)
 {
   auto priv = TreeKEMPrivateKey{ suite, index, {}, {}, {} };
-  priv.private_key_cache.insert({ NodeIndex(index), leaf_priv });
+  priv.private_key_cache.insert({ NodeIndex(index), std::move(leaf_priv) });
   return priv;
 }
 


### PR DESCRIPTION
This PR extends the PSK support in #319 to support subgroup branching using PSK with `ResumptionPSKUsage::branch`. The approach is similar to external PSKs, in that the resumption PSKs are stored on the state object.

There are two checks called for in the spec that we do not implement here:

* Checking that a `branch` PSK is only used in the context of a branch operation (because checking this would require plumbing through the context of the branch operation few a layers of the call stack)
* Checking that the key packages in a subgroup actually represent a subset of the original group's members (because we don't have a way right now to ask the application if two KeyPackages represent the same member)

I think these are OK to omit for now.  Neither has urgently important security implications.  The former is implicitly enforced because the method to install a `branch` PSK is private, which means that using a `branch` PSK outside the expected context will fail. The latter is really just a check that the application's instructions make sense, since it's the application providing the key packages in the first place.

Depends on #318 
Depends on #319 