### PR TITLE
Add support for reinitialization

### DIFF
--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -84,9 +84,9 @@ public:
   Proposal group_context_extensions_proposal(ExtensionList exts) const;
   Proposal pre_shared_key_proposal(const bytes& external_psk_id) const;
   static Proposal reinit_proposal(bytes group_id,
-                           ProtocolVersion version,
-                           CipherSuite cipher_suite,
-                           ExtensionList extensions);
+                                  ProtocolVersion version,
+                                  CipherSuite cipher_suite,
+                                  ExtensionList extensions);
 
   MLSMessage add(const KeyPackage& key_package, const MessageOpts& msg_opts);
   MLSMessage update(HPKEPrivateKey leaf_priv,
@@ -300,9 +300,10 @@ protected:
     const MessageOpts& msg_opts,
     CommitParams params);
 
-  std::optional<State> handle(const MLSMessage& msg,
-                              std::optional<State> cached_state,
-                              const std::optional<CommitParams>& expected_params);
+  std::optional<State> handle(
+    const MLSMessage& msg,
+    std::optional<State> cached_state,
+    const std::optional<CommitParams>& expected_params);
 
   // Create an MLSMessage encapsulating some content
   template<typename Inner>

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -83,10 +83,10 @@ public:
   Proposal remove_proposal(LeafIndex removed) const;
   Proposal group_context_extensions_proposal(ExtensionList exts) const;
   Proposal pre_shared_key_proposal(const bytes& external_psk_id) const;
-  Proposal reinit_proposal(bytes group_id,
+  static Proposal reinit_proposal(bytes group_id,
                            ProtocolVersion version,
                            CipherSuite cipher_suite,
-                           ExtensionList extensions) const;
+                           ExtensionList extensions);
 
   MLSMessage add(const KeyPackage& key_package, const MessageOpts& msg_opts);
   MLSMessage update(HPKEPrivateKey leaf_priv,
@@ -188,7 +188,7 @@ public:
     TLS_SERIALIZABLE(prior_group_id, prior_epoch, resumption_psk, reinit);
 
   private:
-    Tombstone(const State& state_in, const ReInit& reinit_in);
+    Tombstone(const State& state_in, ReInit reinit_in);
 
     bytes prior_group_id;
     epoch_t prior_epoch;
@@ -302,7 +302,7 @@ protected:
 
   std::optional<State> handle(const MLSMessage& msg,
                               std::optional<State> cached_state,
-                              std::optional<CommitParams> expected_params);
+                              const std::optional<CommitParams>& expected_params);
 
   // Create an MLSMessage encapsulating some content
   template<typename Inner>

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -486,7 +486,9 @@ State::reinit(bytes group_id,
               const MessageOpts& msg_opts)
 {
   return protect_full(
-    reinit_proposal(std::move(group_id), version, cipher_suite, std::move(extensions)), msg_opts);
+    reinit_proposal(
+      std::move(group_id), version, cipher_suite, std::move(extensions)),
+    msg_opts);
 }
 
 std::tuple<MLSMessage, Welcome, State>
@@ -1011,7 +1013,8 @@ State::reinit_commit(const bytes& leaf_secret,
 State::Tombstone
 State::handle_reinit_commit(const MLSMessage& commit_msg)
 {
-  auto new_state = opt::get(handle(commit_msg, std::nullopt, ReInitCommitParams{}));
+  auto new_state =
+    opt::get(handle(commit_msg, std::nullopt, ReInitCommitParams{}));
 
   // XXX(RLB): This is pretty brute force, replicating a bunch of logic in
   // State::handle() so that we can find the ReInit commit.  There is probably a
@@ -1777,9 +1780,10 @@ State::valid_external(const std::vector<CachedProposal>& proposals) const
 }
 
 State::CommitParams
-State::infer_commit_type(const std::optional<LeafIndex>& sender,
-                         const std::vector<CachedProposal>& proposals,
-    const std::optional<CommitParams>& expected_params) const
+State::infer_commit_type(
+  const std::optional<LeafIndex>& sender,
+  const std::vector<CachedProposal>& proposals,
+  const std::optional<CommitParams>& expected_params) const
 {
   // If an expected type was provided, validate against it
   if (expected_params) {


### PR DESCRIPTION
This commit adds support for reinitialization.  It ended up being a little more involved than expected, but I think the result is good.  The major change is that the appropriate information is now channeled through so that `reinit` and `branch` PSKs can only be used in the context of those operations.


Depends on #318 
Depends on #319 
Depends on #320 