### PR TITLE
Add passive client scenario test vectors

### DIFF
--- a/cmd/interop/src/json_details.h
+++ b/cmd/interop/src/json_details.h
@@ -336,4 +336,19 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(MessagesTestVector,
                                    public_message_commit,
                                    private_message)
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PassiveClientTestVector::Epoch,
+                                   proposals,
+                                   commit,
+                                   epoch_authenticator)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PassiveClientTestVector,
+                                   cipher_suite,
+                                   key_package,
+                                   signature_priv,
+                                   encryption_priv,
+                                   init_priv,
+                                   welcome,
+                                   initial_epoch_authenticator,
+                                   epochs)
+
+
 } // namespace mls_vectors

--- a/cmd/interop/src/json_details.h
+++ b/cmd/interop/src/json_details.h
@@ -350,5 +350,4 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PassiveClientTestVector,
                                    initial_epoch_authenticator,
                                    epochs)
 
-
 } // namespace mls_vectors

--- a/cmd/interop/src/main.cpp
+++ b/cmd/interop/src/main.cpp
@@ -24,6 +24,7 @@ static constexpr uint64_t PSK_SECRET = 13;
 static constexpr uint64_t WELCOME = 14;
 static constexpr uint64_t TREE_HASHES = 15;
 static constexpr uint64_t TREE_OPERATIONS = 16;
+static constexpr uint64_t PASSIVE_CLIENT = 17;
 
 static json
 make_test_vector(uint64_t type)
@@ -216,6 +217,9 @@ verify_test_vector(uint64_t type)
 
     case TREE_HASHES:
       return verify_test_vector<TreeHashTestVector>(j);
+
+    case PASSIVE_CLIENT:
+      return verify_test_vector<PassiveClientTestVector>(j);
 
     default:
       return "Invalid test vector type";

--- a/lib/mls_vectors/include/mls_vectors/mls_vectors.h
+++ b/lib/mls_vectors/include/mls_vectors/mls_vectors.h
@@ -545,7 +545,7 @@ struct PassiveClientTestVector : PseudoRandom
   std::vector<Epoch> epochs;
 
   PassiveClientTestVector() = default;
-  std::optional<std::string> verify() const;
+  std::optional<std::string> verify();
 };
 
 } // namespace mls_vectors

--- a/lib/mls_vectors/include/mls_vectors/mls_vectors.h
+++ b/lib/mls_vectors/include/mls_vectors/mls_vectors.h
@@ -523,4 +523,29 @@ struct MessagesTestVector : PseudoRandom
   std::optional<std::string> verify() const;
 };
 
+struct PassiveClientTestVector : PseudoRandom
+{
+  struct Epoch
+  {
+    std::vector<mls::MLSMessage> proposals;
+    mls::MLSMessage commit;
+    bytes epoch_authenticator;
+  };
+
+  mls::CipherSuite cipher_suite;
+
+  mls::MLSMessage key_package;
+  mls::SignaturePrivateKey signature_priv;
+  mls::HPKEPrivateKey encryption_priv;
+  mls::HPKEPrivateKey init_priv;
+
+  mls::MLSMessage welcome;
+  bytes initial_epoch_authenticator;
+
+  std::vector<Epoch> epochs;
+
+  PassiveClientTestVector() = default;
+  std::optional<std::string> verify() const;
+};
+
 } // namespace mls_vectors

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -1980,7 +1980,8 @@ PassiveClientTestVector::verify()
                      signature_priv,
                      key_package_raw,
                      welcome_raw,
-                     std::nullopt);
+                     std::nullopt,
+                     {});
   VERIFY_EQUAL(
     "initial epoch", state.epoch_authenticator(), initial_epoch_authenticator);
 

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -1965,8 +1965,13 @@ MessagesTestVector::verify() const
 }
 
 std::optional<std::string>
-PassiveClientTestVector::verify() const
+PassiveClientTestVector::verify()
 {
+  // Import everything
+  signature_priv.set_public_key(cipher_suite);
+  encryption_priv.set_public_key(cipher_suite);
+  init_priv.set_public_key(cipher_suite);
+
   const auto& key_package_raw = var::get<KeyPackage>(key_package.message);
   const auto& welcome_raw = var::get<Welcome>(welcome.message);
 

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -1964,4 +1964,32 @@ MessagesTestVector::verify() const
   return std::nullopt;
 }
 
+std::optional<std::string>
+PassiveClientTestVector::verify() const
+{
+  const auto& key_package_raw = var::get<KeyPackage>(key_package.message);
+  const auto& welcome_raw = var::get<Welcome>(welcome.message);
+
+  auto state = State(init_priv,
+                     encryption_priv,
+                     signature_priv,
+                     key_package_raw,
+                     welcome_raw,
+                     std::nullopt);
+  VERIFY_EQUAL(
+    "initial epoch", state.epoch_authenticator(), initial_epoch_authenticator);
+
+  for (const auto& tve : epochs) {
+    for (const auto& proposal : tve.proposals) {
+      state.handle(proposal);
+    }
+
+    state = opt::get(state.handle(tve.commit));
+    VERIFY_EQUAL(
+      "epoch auth", state.epoch_authenticator(), tve.epoch_authenticator)
+  }
+
+  return std::nullopt;
+}
+
 } // namespace mls_vectors

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -186,9 +186,17 @@ TreeKEMPrivateKey::dump() const
   std::cout << "  Index: " << NodeIndex(index).val << std::endl;
 
   std::cout << "  Secrets: " << std::endl;
-  for (const auto& [n, secret] : path_secrets) {
-    auto sk = opt::get(private_key(n));
-    auto ssm = to_hex(secret).substr(0, 8);
+  for (const auto& [n, path_secret] : path_secrets) {
+    auto node_secret = suite.derive_secret(path_secret, "node");
+    auto sk = HPKEPrivateKey::derive(suite, node_secret);
+
+    auto psm = to_hex(path_secret).substr(0, 8);
+    auto pkm = to_hex(sk.public_key.data).substr(0, 8);
+    std::cout << "    " << n.val << " => " << psm << " => " << pkm << std::endl;
+  }
+
+  std::cout << "  Cached key pairs: " << std::endl;
+  for (const auto& [n, sk] : private_key_cache) {
     auto pkm = to_hex(sk.public_key.data).substr(0, 8);
     std::cout << "    " << n.val << " => " << ssm << " = " << pkm << std::endl;
   }

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -198,7 +198,7 @@ TreeKEMPrivateKey::dump() const
   std::cout << "  Cached key pairs: " << std::endl;
   for (const auto& [n, sk] : private_key_cache) {
     auto pkm = to_hex(sk.public_key.data).substr(0, 8);
-    std::cout << "    " << n.val << " => " << ssm << " = " << pkm << std::endl;
+    std::cout << "    " << n.val << " => " << pkm << std::endl;
   }
 }
 


### PR DESCRIPTION
Right now, we only implement the verify side.

Documentation: https://github.com/mlswg/mls-implementations/blob/main/test-vectors.md#passive-client-scenarios

Corresponds to https://github.com/mlswg/mls-implementations/pull/108