### PR TITLE
Add interop testing to CI

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -36,14 +36,12 @@ jobs:
 
     - name: Build interop harness
       run: |
-        cd cmd/interop
-        cmake -B build -DSANITIZERS=ON -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}" .
-        cmake --build build
+        make -C cmd/interop
 
     - name: Test self-interop
       run: |
-        make self-test
+        make -C cmd/interop self-test
 
     - name: Test interop on test vectors
       run: |
-        make interop-test
+        make -C cmd/interop interop-test

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -36,7 +36,9 @@ jobs:
 
     - name: Build interop harness
       run: |
-        make -C cmd/interop
+        cd cmd/interop
+        cmake -B build -DSANITIZERS=ON -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}" .
+        cmake --build build
 
     - name: Test self-interop
       run: |

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -1,4 +1,4 @@
-name: Build the interop harness
+name: Test interoperability
 
 on:
   push:
@@ -36,6 +36,14 @@ jobs:
 
     - name: Build interop harness
       run: |
-         cd cmd/interop
-         cmake -B build -DSANITIZERS=ON -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}" .
-         cmake --build build
+        cd cmd/interop
+        cmake -B build -DSANITIZERS=ON -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}" .
+        cmake --build build
+
+    - name: Test self-interop
+      run: |
+        make self-test
+
+    - name: Test interop on test vectors
+      run: |
+        make interop-test

--- a/cmd/interop/CMakeLists.txt
+++ b/cmd/interop/CMakeLists.txt
@@ -59,9 +59,9 @@ set_directory_properties( PROPERTIES EP_PREFIX ${CMAKE_BINARY_DIR}/third_party )
 ExternalProject_Add(
     mls-interop-extern
     GIT_REPOSITORY ${MLS_IMPLEMENTATIONS_REPO_URL}
-    GIT_TAG origin/mlspp
+    GIT_TAG origin/main
     TIMEOUT 10
-    UPDATE_COMMAND ${GIT_EXECUTABLE} pull origin mlspp
+    UPDATE_COMMAND ${GIT_EXECUTABLE} pull origin main
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""

--- a/cmd/interop/Makefile
+++ b/cmd/interop/Makefile
@@ -34,7 +34,7 @@ interop-test: ${BUILD_DIR}/${APP_NAME}
 	./${BUILD_DIR}/${APP_NAME} -ver 9 <${TEST_VECTOR_DIR}/welcome.json
 	./${BUILD_DIR}/${APP_NAME} -ver 10 <${TEST_VECTOR_DIR}/tree-operations.json
 	./${BUILD_DIR}/${APP_NAME} -ver 11 <${TEST_VECTOR_DIR}/treekem.json
-	./${BUILD_DIR}/${APP_NAME} -ver 12 <${TEST_VECTOR_DIR}/messages.json
+	#./${BUILD_DIR}/${APP_NAME} -ver 12 <${TEST_VECTOR_DIR}/messages.json
 	./${BUILD_DIR}/${APP_NAME} -ver 13 <${TEST_VECTOR_DIR}/passive-client.json
 
 format:

--- a/cmd/interop/Makefile
+++ b/cmd/interop/Makefile
@@ -34,8 +34,10 @@ interop-test: ${BUILD_DIR}/${APP_NAME}
 	./${BUILD_DIR}/${APP_NAME} -ver 9 <${TEST_VECTOR_DIR}/welcome.json
 	./${BUILD_DIR}/${APP_NAME} -ver 10 <${TEST_VECTOR_DIR}/tree-operations.json
 	./${BUILD_DIR}/${APP_NAME} -ver 11 <${TEST_VECTOR_DIR}/treekem.json
+	# TODO(RLB) Uncomment once the messages test vectors are fixed
 	#./${BUILD_DIR}/${APP_NAME} -ver 12 <${TEST_VECTOR_DIR}/messages.json
-	./${BUILD_DIR}/${APP_NAME} -ver 13 <${TEST_VECTOR_DIR}/passive-client.json
+	./${BUILD_DIR}/${APP_NAME} -ver 13 <${TEST_VECTOR_DIR}/passive-client-welcome.json
+	./${BUILD_DIR}/${APP_NAME} -ver 13 <${TEST_VECTOR_DIR}/passive-client-handling-commit.json
 
 format:
 	clang-format -i -style=Mozilla src/*.cpp src/*.h

--- a/cmd/interop/Makefile
+++ b/cmd/interop/Makefile
@@ -1,4 +1,5 @@
 BUILD_DIR=build
+TEST_VECTOR_DIR=${BUILD_DIR}/third_party/src/mls-interop-extern/test-vectors
 APP_NAME=mlspp_client
 
 .PHONY: all run format clean cclean
@@ -13,6 +14,26 @@ ${BUILD_DIR}/${APP_NAME}: ${BUILD_DIR} src/*.cpp
 
 run: ${BUILD_DIR}/${APP_NAME}
 	./${BUILD_DIR}/${APP_NAME} -port 50001
+
+self-test: ${BUILD_DIR}/${APP_NAME}
+	for tv_type in {1..13}; do \
+		echo Self-test on test vector type $$tv_type; \
+		./${BUILD_DIR}/${APP_NAME} -gen $$tv_type | ./${BUILD_DIR}/${APP_NAME} -ver $$tv_type; \
+	done
+
+interop-test: ${BUILD_DIR}/${APP_NAME}
+	./${BUILD_DIR}/${APP_NAME} -ver 1 <${TEST_VECTOR_DIR}/tree-math.json
+	./${BUILD_DIR}/${APP_NAME} -ver 2 <${TEST_VECTOR_DIR}/crypto-basics.json
+	./${BUILD_DIR}/${APP_NAME} -ver 3 <${TEST_VECTOR_DIR}/secret-tree.json
+	./${BUILD_DIR}/${APP_NAME} -ver 4 <${TEST_VECTOR_DIR}/message-protection.json
+	./${BUILD_DIR}/${APP_NAME} -ver 5 <${TEST_VECTOR_DIR}/key-schedule.json
+	./${BUILD_DIR}/${APP_NAME} -ver 6 <${TEST_VECTOR_DIR}/psk_secret.json
+	./${BUILD_DIR}/${APP_NAME} -ver 7 <${TEST_VECTOR_DIR}/tree-validation.json
+	./${BUILD_DIR}/${APP_NAME} -ver 8 <${TEST_VECTOR_DIR}/transcript-hashes.json
+	./${BUILD_DIR}/${APP_NAME} -ver 9 <${TEST_VECTOR_DIR}/welcome.json
+	./${BUILD_DIR}/${APP_NAME} -ver 10 <${TEST_VECTOR_DIR}/tree-operations.json
+	./${BUILD_DIR}/${APP_NAME} -ver 11 <${TEST_VECTOR_DIR}/treekem.json
+	./${BUILD_DIR}/${APP_NAME} -ver 12 <${TEST_VECTOR_DIR}/messages.json
 
 format:
 	clang-format -i -style=Mozilla src/*.cpp src/*.h

--- a/cmd/interop/Makefile
+++ b/cmd/interop/Makefile
@@ -17,7 +17,7 @@ run: ${BUILD_DIR}/${APP_NAME}
 
 self-test: ${BUILD_DIR}/${APP_NAME}
 	# TODO(RLB) Extend to 13 to cover passive client tests
-	for tv_type in {1..12}; do \
+	for tv_type in 1 2 3 4 5 6 7 8 9 10 11 12; do \
 		echo Self-test on test vector type $$tv_type; \
 		./${BUILD_DIR}/${APP_NAME} -gen $$tv_type | ./${BUILD_DIR}/${APP_NAME} -ver $$tv_type; \
 	done

--- a/cmd/interop/Makefile
+++ b/cmd/interop/Makefile
@@ -16,7 +16,8 @@ run: ${BUILD_DIR}/${APP_NAME}
 	./${BUILD_DIR}/${APP_NAME} -port 50001
 
 self-test: ${BUILD_DIR}/${APP_NAME}
-	for tv_type in {1..13}; do \
+	# TODO(RLB) Extend to 13 to cover passive client tests
+	for tv_type in {1..12}; do \
 		echo Self-test on test vector type $$tv_type; \
 		./${BUILD_DIR}/${APP_NAME} -gen $$tv_type | ./${BUILD_DIR}/${APP_NAME} -ver $$tv_type; \
 	done
@@ -34,6 +35,7 @@ interop-test: ${BUILD_DIR}/${APP_NAME}
 	./${BUILD_DIR}/${APP_NAME} -ver 10 <${TEST_VECTOR_DIR}/tree-operations.json
 	./${BUILD_DIR}/${APP_NAME} -ver 11 <${TEST_VECTOR_DIR}/treekem.json
 	./${BUILD_DIR}/${APP_NAME} -ver 12 <${TEST_VECTOR_DIR}/messages.json
+	./${BUILD_DIR}/${APP_NAME} -ver 13 <${TEST_VECTOR_DIR}/passive-client.json
 
 format:
 	clang-format -i -style=Mozilla src/*.cpp src/*.h

--- a/cmd/interop/src/json_details.h
+++ b/cmd/interop/src/json_details.h
@@ -336,6 +336,9 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(MessagesTestVector,
                                    public_message_commit,
                                    private_message)
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PassiveClientTestVector::PSK,
+                                   psk_id,
+                                   psk)
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PassiveClientTestVector::Epoch,
                                    proposals,
                                    commit,
@@ -346,7 +349,9 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PassiveClientTestVector,
                                    signature_priv,
                                    encryption_priv,
                                    init_priv,
+                                   external_psks,
                                    welcome,
+                                   ratchet_tree,
                                    initial_epoch_authenticator,
                                    epochs)
 

--- a/cmd/interop/src/json_details.h
+++ b/cmd/interop/src/json_details.h
@@ -336,9 +336,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(MessagesTestVector,
                                    public_message_commit,
                                    private_message)
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PassiveClientTestVector::PSK,
-                                   psk_id,
-                                   psk)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PassiveClientTestVector::PSK, psk_id, psk)
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PassiveClientTestVector::Epoch,
                                    proposals,
                                    commit,

--- a/cmd/interop/src/main.cpp
+++ b/cmd/interop/src/main.cpp
@@ -19,7 +19,8 @@ using namespace mls_vectors;
 
 // Values used on the command line to indicate the type of test vector to be
 // generated / verified
-enum struct TestVectorClass {
+enum struct TestVectorClass
+{
   tree_math = 1,
   crypto_basics = 2,
   secret_tree = 3,
@@ -53,8 +54,6 @@ make_test_vector(uint64_t type)
 
       return cases;
     }
-
-    // XXX crypto_basics?
 
     case TestVectorClass::secret_tree: {
       auto cases = std::vector<SecretTreeTestVector>();
@@ -157,7 +156,7 @@ make_test_vector(uint64_t type)
         MessagesTestVector(),
       };
 
-    // TODO(RLB) TestVectorClass::passive_client_scenarios
+      // TODO(RLB) TestVectorClass::passive_client_scenarios
 
     default:
       return nullptr;

--- a/cmd/interop/src/main.cpp
+++ b/cmd/interop/src/main.cpp
@@ -17,61 +17,34 @@ using nlohmann::json;
 using namespace mls_client;
 using namespace mls_vectors;
 
-static constexpr uint64_t CRYPTO_BASICS = 10;
-static constexpr uint64_t SECRET_TREE = 11;
-static constexpr uint64_t MESSAGE_PROTECTION = 12;
-static constexpr uint64_t PSK_SECRET = 13;
-static constexpr uint64_t WELCOME = 14;
-static constexpr uint64_t TREE_HASHES = 15;
-static constexpr uint64_t TREE_OPERATIONS = 16;
-static constexpr uint64_t PASSIVE_CLIENT = 17;
+// Values used on the command line to indicate the type of test vector to be
+// generated / verified
+enum struct TestVectorClass {
+  tree_math = 1,
+  crypto_basics = 2,
+  secret_tree = 3,
+  message_protection = 4,
+  key_schedule = 5,
+  pre_shared_keys = 6,
+  tree_validation = 7,
+  transcript_hash = 8,
+  welcome = 9,
+  tree_modifications = 10,
+  treekem = 11,
+  messages = 12,
+  passive_client_scenarios = 13,
+};
 
 static json
 make_test_vector(uint64_t type)
 {
   auto n = uint32_t(5);
-  switch (type) {
-    case TestVectorType::TREE_MATH:
-      return TreeMathTestVector{ n };
+  auto tv_class = static_cast<TestVectorClass>(type);
+  switch (tv_class) {
+    case TestVectorClass::tree_math:
+      return std::vector<TreeMathTestVector>{ { n } };
 
-    case TestVectorType::KEY_SCHEDULE: {
-      auto cases = std::vector<KeyScheduleTestVector>();
-
-      for (const auto& suite : mls::all_supported_suites) {
-        cases.emplace_back(suite, n);
-      }
-
-      return cases;
-    }
-
-    case TestVectorType::TRANSCRIPT: {
-      auto cases = std::vector<TranscriptTestVector>();
-
-      for (const auto& suite : mls::all_supported_suites) {
-        cases.emplace_back(suite);
-      }
-
-      return cases;
-    }
-
-    case TestVectorType::TREEKEM: {
-      auto cases = std::vector<TreeKEMTestVector>();
-
-      for (const auto& suite : mls::all_supported_suites) {
-        for (const auto& tree_structure : treekem_test_tree_structures) {
-          cases.emplace_back(suite, tree_structure);
-        }
-      }
-
-      return cases;
-    }
-
-    case TestVectorType::MESSAGES:
-      return std::vector<MessagesTestVector>{
-        MessagesTestVector(),
-      };
-
-    case CRYPTO_BASICS: {
+    case TestVectorClass::crypto_basics: {
       auto cases = std::vector<CryptoBasicsTestVector>();
 
       for (const auto& suite : mls::all_supported_suites) {
@@ -81,7 +54,9 @@ make_test_vector(uint64_t type)
       return cases;
     }
 
-    case SECRET_TREE: {
+    // XXX crypto_basics?
+
+    case TestVectorClass::secret_tree: {
       auto cases = std::vector<SecretTreeTestVector>();
       auto generations = std::vector<uint32_t>{ 1, 15 };
 
@@ -92,7 +67,7 @@ make_test_vector(uint64_t type)
       return cases;
     }
 
-    case MESSAGE_PROTECTION: {
+    case TestVectorClass::message_protection: {
       auto cases = std::vector<MessageProtectionTestVector>();
 
       for (const auto& suite : mls::all_supported_suites) {
@@ -102,7 +77,17 @@ make_test_vector(uint64_t type)
       return cases;
     }
 
-    case PSK_SECRET: {
+    case TestVectorClass::key_schedule: {
+      auto cases = std::vector<KeyScheduleTestVector>();
+
+      for (const auto& suite : mls::all_supported_suites) {
+        cases.emplace_back(suite, n);
+      }
+
+      return cases;
+    }
+
+    case TestVectorClass::pre_shared_keys: {
       auto cases = std::vector<PSKSecretTestVector>();
 
       for (const auto& suite : mls::all_supported_suites) {
@@ -112,17 +97,7 @@ make_test_vector(uint64_t type)
       return cases;
     }
 
-    case WELCOME: {
-      auto cases = std::vector<WelcomeTestVector>();
-
-      for (const auto& suite : mls::all_supported_suites) {
-        cases.emplace_back(suite);
-      }
-
-      return cases;
-    }
-
-    case TREE_HASHES: {
+    case TestVectorClass::tree_validation: {
       auto cases = std::vector<TreeHashTestVector>();
 
       for (const auto& suite : mls::all_supported_suites) {
@@ -134,7 +109,27 @@ make_test_vector(uint64_t type)
       return cases;
     }
 
-    case TREE_OPERATIONS: {
+    case TestVectorClass::transcript_hash: {
+      auto cases = std::vector<TranscriptTestVector>();
+
+      for (const auto& suite : mls::all_supported_suites) {
+        cases.emplace_back(suite);
+      }
+
+      return cases;
+    }
+
+    case TestVectorClass::welcome: {
+      auto cases = std::vector<WelcomeTestVector>();
+
+      for (const auto& suite : mls::all_supported_suites) {
+        cases.emplace_back(suite);
+      }
+
+      return cases;
+    }
+
+    case TestVectorClass::tree_modifications: {
       auto cases = std::vector<TreeOperationsTestVector>();
 
       auto suite = mls::CipherSuite::ID::X25519_AES128GCM_SHA256_Ed25519;
@@ -144,6 +139,25 @@ make_test_vector(uint64_t type)
 
       return cases;
     }
+
+    case TestVectorClass::treekem: {
+      auto cases = std::vector<TreeKEMTestVector>();
+
+      for (const auto& suite : mls::all_supported_suites) {
+        for (const auto& tree_structure : treekem_test_tree_structures) {
+          cases.emplace_back(suite, tree_structure);
+        }
+      }
+
+      return cases;
+    }
+
+    case TestVectorClass::messages:
+      return std::vector<MessagesTestVector>{
+        MessagesTestVector(),
+      };
+
+    // TODO(RLB) TestVectorClass::passive_client_scenarios
 
     default:
       return nullptr;
@@ -181,45 +195,45 @@ static std::optional<std::string>
 verify_test_vector(uint64_t type)
 {
   auto j = json::parse(std::cin);
-  switch (type) {
-    case TestVectorType::TREE_MATH:
+  auto tv_class = static_cast<TestVectorClass>(type);
+  switch (tv_class) {
+    case TestVectorClass::tree_math:
       return verify_test_vector<TreeMathTestVector>(j);
 
-    case TestVectorType::KEY_SCHEDULE:
-      return verify_test_vector<KeyScheduleTestVector>(j);
-
-    case TestVectorType::TRANSCRIPT:
-      return verify_test_vector<TranscriptTestVector>(j);
-
-    case TestVectorType::TREEKEM:
-      return verify_test_vector<TreeKEMTestVector>(j);
-
-    case TestVectorType::MESSAGES:
-      return verify_test_vector<MessagesTestVector>(j);
-
-    case CRYPTO_BASICS:
+    case TestVectorClass::crypto_basics:
       return verify_test_vector<CryptoBasicsTestVector>(j);
 
-    case SECRET_TREE:
+    case TestVectorClass::secret_tree:
       return verify_test_vector<SecretTreeTestVector>(j);
 
-    case MESSAGE_PROTECTION:
+    case TestVectorClass::message_protection:
       return verify_test_vector<MessageProtectionTestVector>(j);
 
-    case PSK_SECRET:
+    case TestVectorClass::key_schedule:
+      return verify_test_vector<KeyScheduleTestVector>(j);
+
+    case TestVectorClass::pre_shared_keys:
       return verify_test_vector<PSKSecretTestVector>(j);
 
-    case WELCOME:
-      return verify_test_vector<WelcomeTestVector>(j);
-
-    case TREE_OPERATIONS:
-      return verify_test_vector<TreeOperationsTestVector>(j);
-
-    case TREE_HASHES:
+    case TestVectorClass::tree_validation:
       return verify_test_vector<TreeHashTestVector>(j);
 
-    case PASSIVE_CLIENT:
-      return verify_test_vector<PassiveClientTestVector>(j);
+    case TestVectorClass::transcript_hash:
+      return verify_test_vector<TranscriptTestVector>(j);
+
+    case TestVectorClass::welcome:
+      return verify_test_vector<WelcomeTestVector>(j);
+
+    case TestVectorClass::tree_modifications:
+      return verify_test_vector<TreeOperationsTestVector>(j);
+
+    case TestVectorClass::treekem:
+      return verify_test_vector<TreeKEMTestVector>(j);
+
+    case TestVectorClass::messages:
+      return verify_test_vector<MessagesTestVector>(j);
+
+    // TODO TestVectorClass::passive_client_scenarios
 
     default:
       return "Invalid test vector type";

--- a/cmd/interop/src/main.cpp
+++ b/cmd/interop/src/main.cpp
@@ -233,7 +233,8 @@ verify_test_vector(uint64_t type)
     case TestVectorClass::messages:
       return verify_test_vector<MessagesTestVector>(j);
 
-    // TODO TestVectorClass::passive_client_scenarios
+    case TestVectorClass::passive_client_scenarios:
+      return verify_test_vector<PassiveClientTestVector>(j);
 
     default:
       return "Invalid test vector type";

--- a/cmd/interop/src/main.cpp
+++ b/cmd/interop/src/main.cpp
@@ -249,14 +249,14 @@ main(int argc, char* argv[])
 
   // Need some action to do
   if (!do_gen && !do_ver && !do_live) {
-    gflags::ShowUsageWithFlags(nullptr);
+    gflags::ShowUsageWithFlags(argv[0]);
     return 1;
   }
 
   // Can only do one action per run
   if ((do_gen && do_ver) || (do_ver && do_live) || (do_gen && do_live)) {
     std::cout << "Please choose exactly one action" << std::endl;
-    gflags::ShowUsageWithFlags(nullptr);
+    gflags::ShowUsageWithFlags(argv[0]);
     return 1;
   }
 

--- a/cmd/interop/src/mls_client_impl.h
+++ b/cmd/interop/src/mls_client_impl.h
@@ -21,13 +21,6 @@ class MLSClientImpl final : public MLSClient::Service
                                const SupportedCiphersuitesRequest* request,
                                SupportedCiphersuitesResponse* reply) override;
 
-  Status GenerateTestVector(ServerContext* context,
-                            const GenerateTestVectorRequest* request,
-                            GenerateTestVectorResponse* reply) override;
-  Status VerifyTestVector(ServerContext* context,
-                          const VerifyTestVectorRequest* request,
-                          VerifyTestVectorResponse* reply) override;
-
   // Ways to become a member of a group
   Status CreateGroup(ServerContext* context,
                      const CreateGroupRequest* request,
@@ -116,11 +109,6 @@ private:
   uint32_t store_state(mls::State&& state, bool encrypt_handshake);
   CachedState* load_state(uint32_t state_id);
   void remove_state(uint32_t state_id);
-
-  // Fallible method implementations, wrapped before being exposed to gRPC
-  Status verify_test_vector(const VerifyTestVectorRequest* request);
-  Status generate_test_vector(const GenerateTestVectorRequest* request,
-                              GenerateTestVectorResponse* reply);
 
   // Ways to join a group
   Status create_group(const CreateGroupRequest* request,

--- a/lib/mls_vectors/include/mls_vectors/mls_vectors.h
+++ b/lib/mls_vectors/include/mls_vectors/mls_vectors.h
@@ -525,6 +525,12 @@ struct MessagesTestVector : PseudoRandom
 
 struct PassiveClientTestVector : PseudoRandom
 {
+  struct PSK
+  {
+    bytes psk_id;
+    bytes psk;
+  };
+
   struct Epoch
   {
     std::vector<mls::MLSMessage> proposals;
@@ -539,7 +545,10 @@ struct PassiveClientTestVector : PseudoRandom
   mls::HPKEPrivateKey encryption_priv;
   mls::HPKEPrivateKey init_priv;
 
+  std::vector<PSK> external_psks;
+
   mls::MLSMessage welcome;
+  std::optional<mls::TreeKEMPublicKey> ratchet_tree;
   bytes initial_epoch_authenticator;
 
   std::vector<Epoch> epochs;

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -1980,13 +1980,18 @@ PassiveClientTestVector::verify()
   const auto& key_package_raw = var::get<KeyPackage>(key_package.message);
   const auto& welcome_raw = var::get<Welcome>(welcome.message);
 
+  auto ext_psks = std::map<bytes, bytes>{};
+  for (const auto& [id, psk] : external_psks) {
+    ext_psks.insert_or_assign(id, psk);
+  }
+
   auto state = State(init_priv,
                      encryption_priv,
                      signature_priv,
                      key_package_raw,
                      welcome_raw,
-                     std::nullopt,
-                     {});
+                     ratchet_tree,
+                     ext_psks);
   VERIFY_EQUAL(
     "initial epoch", state.epoch_authenticator(), initial_epoch_authenticator);
 

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -1161,6 +1161,7 @@ struct TreeTestCase
   TreeTestCase(CipherSuite suite_in, PseudoRandom::Generator&& prg_in)
     : suite(suite_in)
     , prg(prg_in)
+    , group_id(prg.secret("group_id"))
     , pub(suite)
   {
     auto [where, enc_priv, sig_priv] = add_leaf();
@@ -1606,13 +1607,6 @@ TreeKEMTestVector::TreeKEMTestVector(mls::CipherSuite suite,
   }
 
   // Create test update paths
-  auto group_context = GroupContext{ cipher_suite,
-                                     group_id,
-                                     epoch,
-                                     tc.pub.root_hash(),
-                                     confirmed_transcript_hash,
-                                     {} };
-  auto ctx = tls::marshal(group_context);
   for (LeafIndex sender{ 0 }; sender < ratchet_tree.size; sender.val++) {
     if (!tc.pub.has_leaf(sender)) {
       continue;
@@ -1624,6 +1618,15 @@ TreeKEMTestVector::TreeKEMTestVector(mls::CipherSuite suite,
     auto pub = tc.pub;
     auto new_sender_priv =
       pub.update(sender, leaf_secret, group_id, sig_priv, {});
+
+    auto group_context = GroupContext{ cipher_suite,
+                                       group_id,
+                                       epoch,
+                                       pub.root_hash(),
+                                       confirmed_transcript_hash,
+                                       {} };
+    auto ctx = tls::marshal(group_context);
+
     auto path = pub.encap(new_sender_priv, ctx, {});
 
     auto path_secrets = std::vector<std::optional<bytes>>{};
@@ -1694,13 +1697,6 @@ TreeKEMTestVector::verify()
     sig_privs.insert_or_assign(info.index, sig_priv);
   }
 
-  auto group_context = GroupContext{ cipher_suite,
-                                     group_id,
-                                     epoch,
-                                     ratchet_tree.root_hash(),
-                                     confirmed_transcript_hash,
-                                     {} };
-  auto ctx = tls::marshal(group_context);
   for (const auto& info : update_paths) {
     // Test decap of the existing group secrets
     const auto& from = info.sender;
@@ -1708,43 +1704,52 @@ TreeKEMTestVector::verify()
     VERIFY("path parent hash valid",
            ratchet_tree.parent_hash_valid(from, path));
 
-    for (LeafIndex to{ 0 }; to < ratchet_tree.size; to.val++) {
-      if (to == from || !ratchet_tree.has_leaf(to)) {
+    auto ratchet_tree_after = ratchet_tree;
+    ratchet_tree_after.merge(from, path);
+    ratchet_tree_after.set_hash_all();
+    VERIFY_EQUAL(
+      "tree hash after", ratchet_tree_after.root_hash(), info.tree_hash_after);
+
+    auto group_context = GroupContext{ cipher_suite,
+                                       group_id,
+                                       epoch,
+                                       ratchet_tree_after.root_hash(),
+                                       confirmed_transcript_hash,
+                                       {} };
+    auto ctx = tls::marshal(group_context);
+
+    for (LeafIndex to{ 0 }; to < ratchet_tree_after.size; to.val++) {
+      if (to == from || !ratchet_tree_after.has_leaf(to)) {
         continue;
       }
 
       auto priv = tree_privs.at(to);
-      priv.decap(from, ratchet_tree, ctx, path, {});
+      priv.decap(from, ratchet_tree_after, ctx, path, {});
       VERIFY_EQUAL("commit secret", priv.update_secret, info.commit_secret);
 
       auto [overlap, path_secret, ok] = priv.shared_path_secret(from);
       silence_unused(overlap);
       silence_unused(ok);
       VERIFY_EQUAL("path secret", path_secret, info.path_secrets[to.val]);
-
-      auto pub = ratchet_tree;
-      pub.merge(from, path);
-      pub.set_hash_all();
-      VERIFY_EQUAL("tree hash after", pub.root_hash(), info.tree_hash_after);
     }
 
     // Test encap/decap
-    auto pub = ratchet_tree;
+    auto ratchet_tree_encap = ratchet_tree;
     auto leaf_secret = random_bytes(cipher_suite.secret_size());
     const auto& sig_priv = sig_privs.at(from);
     auto new_sender_priv =
-      pub.update(from, leaf_secret, group_id, sig_priv, {});
-    auto new_path = pub.encap(new_sender_priv, ctx, {});
+      ratchet_tree_encap.update(from, leaf_secret, group_id, sig_priv, {});
+    auto new_path = ratchet_tree_encap.encap(new_sender_priv, ctx, {});
     VERIFY("new path parent hash valid",
            ratchet_tree.parent_hash_valid(from, path));
 
-    for (LeafIndex to{ 0 }; to < ratchet_tree.size; to.val++) {
-      if (to == from || !ratchet_tree.has_leaf(to)) {
+    for (LeafIndex to{ 0 }; to < ratchet_tree_encap.size; to.val++) {
+      if (to == from || !ratchet_tree_encap.has_leaf(to)) {
         continue;
       }
 
       auto priv = tree_privs.at(to);
-      priv.decap(from, ratchet_tree, ctx, new_path, {});
+      priv.decap(from, ratchet_tree_encap, ctx, new_path, {});
       VERIFY_EQUAL(
         "commit secret", priv.update_secret, new_sender_priv.update_secret);
     }

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -415,7 +415,7 @@ KeyScheduleEpoch::do_export(const std::string& label,
 {
   auto secret = suite.derive_secret(exporter_secret, label);
   auto context_hash = suite.digest().hash(context);
-  return suite.expand_with_label(secret, "exporter", context_hash, size);
+  return suite.expand_with_label(secret, "exported", context_hash, size);
 }
 
 PSKWithSecret

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -196,9 +196,6 @@ Welcome::group_info_key_nonce(CipherSuite suite,
                               const bytes& joiner_secret,
                               const std::vector<PSKWithSecret>& psks)
 {
-  static const auto key_label = from_ascii("key");
-  static const auto nonce_label = from_ascii("nonce");
-
   auto welcome_secret =
     KeyScheduleEpoch::welcome_secret(suite, joiner_secret, psks);
 
@@ -206,9 +203,9 @@ Welcome::group_info_key_nonce(CipherSuite suite,
   // instead, for better domain separation? (In particular, including "mls10")
   // That is what we do for the sender data key/nonce.
   auto key =
-    suite.hpke().kdf.expand(welcome_secret, key_label, suite.key_size());
+    suite.expand_with_label(welcome_secret, "key", {}, suite.key_size());
   auto nonce =
-    suite.hpke().kdf.expand(welcome_secret, nonce_label, suite.nonce_size());
+    suite.expand_with_label(welcome_secret, "nonce", {}, suite.nonce_size());
   return { std::move(key), std::move(nonce) };
 }
 


### PR DESCRIPTION
This PR fixes several minor issues:

* Fixes a segfault on displaying the usage message (need to pass `argv[0]` instead of `nullptr`)
* Follows the `main` branch of the interop repo instead of a special `mlspp` branch
* Pulls the test vector type IDs into an enum owned by this tool (instead of pulling from the gRPC definition)
* Adds `make` targets to run self-test and interop tests
* Adds a CI run that runs the self-test and interop tests
* Updates TreeKEMPublicKey to enforce a minimal encoding (https://github.com/mlswg/mls-protocol/pull/868)

Interop tests in CI will fail for now, because this branch discovered some errors in the test vectors.