### PR TITLE
Miscellaneous interop improvements 

### DIFF
--- a/cmd/interop/Makefile
+++ b/cmd/interop/Makefile
@@ -13,7 +13,7 @@ ${BUILD_DIR}/${APP_NAME}: ${BUILD_DIR} src/*.cpp
 	cmake --build ${BUILD_DIR} --target ${APP_NAME}
 
 run: ${BUILD_DIR}/${APP_NAME}
-	./${BUILD_DIR}/${APP_NAME} -port 50001
+	./${BUILD_DIR}/${APP_NAME} -live 50001
 
 self-test: ${BUILD_DIR}/${APP_NAME}
 	# TODO(RLB) Extend to 13 to cover passive client tests

--- a/cmd/interop/src/main.cpp
+++ b/cmd/interop/src/main.cpp
@@ -240,10 +240,6 @@ verify_test_vector(uint64_t type)
   }
 }
 
-#define NO_SAMPLE 0xffffffffffffffff
-DEFINE_uint64(sample, NO_SAMPLE, "Generate a sample JSON file (by enum value)");
-DEFINE_uint64(port, 50001, "Listen for gRPC on this port");
-
 #define NO_U64 0xffffffffffffffff
 DEFINE_uint64(gen, NO_U64, "Generate test vectors of a given type");
 DEFINE_uint64(ver, NO_U64, "Verify test vectors of a given type");
@@ -299,7 +295,7 @@ main(int argc, char* argv[])
   if (do_live) {
     auto service = MLSClientImpl{};
     auto addr_stream = std::stringstream{};
-    addr_stream << "0.0.0.0:" << FLAGS_port;
+    addr_stream << "0.0.0.0:" << FLAGS_live;
     auto server_address = addr_stream.str();
 
     grpc::EnableDefaultHealthCheckService(true);

--- a/cmd/interop/src/mls_client_impl.cpp
+++ b/cmd/interop/src/mls_client_impl.cpp
@@ -406,7 +406,8 @@ Status
 MLSClientImpl::external_join(const ExternalJoinRequest* request,
                              ExternalJoinResponse* response)
 {
-  const auto group_info = unmarshal_message<mls::GroupInfo>(request->public_group_state());
+  const auto group_info =
+    unmarshal_message<mls::GroupInfo>(request->public_group_state());
   const auto suite = group_info.group_context.cipher_suite;
 
   auto init_priv = mls::HPKEPrivateKey::generate(suite);

--- a/cmd/interop/src/mls_client_impl.cpp
+++ b/cmd/interop/src/mls_client_impl.cpp
@@ -263,7 +263,7 @@ MLSClientImpl::load_join(uint32_t join_id)
 mls::MessageOpts
 MLSClientImpl::CachedState::message_opts() const
 {
-  return { {}, encrypt_handshake, 0 };
+  return { encrypt_handshake, {}, 0 };
 }
 
 void

--- a/cmd/interop/src/mls_client_impl.h
+++ b/cmd/interop/src/mls_client_impl.h
@@ -56,6 +56,9 @@ class MLSClientImpl final : public MLSClient::Service
   Status AddProposal(ServerContext* context,
                      const AddProposalRequest* request,
                      ProposalResponse* response) override;
+  Status UpdateProposal(ServerContext* context,
+                        const UpdateProposalRequest* request,
+                        ProposalResponse* response) override;
   Status RemoveProposal(ServerContext* context,
                         const RemoveProposalRequest* request,
                         ProposalResponse* response) override;
@@ -65,9 +68,9 @@ class MLSClientImpl final : public MLSClient::Service
   Status HandleCommit(ServerContext* context,
                       const HandleCommitRequest* request,
                       HandleCommitResponse* response) override;
-  Status HandleExternalCommit(ServerContext* context,
-                              const HandleExternalCommitRequest* request,
-                              HandleExternalCommitResponse* response) override;
+  Status HandlePendingCommit(ServerContext* context,
+                             const HandlePendingCommitRequest* request,
+                             HandleCommitResponse* response) override;
 
 private:
   // Wrapper for methods that rely on state
@@ -144,16 +147,19 @@ private:
   Status add_proposal(CachedState& entry,
                       const AddProposalRequest* request,
                       ProposalResponse* response);
+  Status update_proposal(CachedState& entry,
+                         const UpdateProposalRequest* request,
+                         ProposalResponse* response);
   Status remove_proposal(CachedState& entry,
-                      const RemoveProposalRequest* request,
-                      ProposalResponse* response);
+                         const RemoveProposalRequest* request,
+                         ProposalResponse* response);
   Status commit(CachedState& entry,
                 const CommitRequest* request,
                 CommitResponse* response);
   Status handle_commit(CachedState& entry,
                        const HandleCommitRequest* request,
                        HandleCommitResponse* response);
-  Status handle_external_commit(CachedState& entry,
-                                const HandleExternalCommitRequest* request,
-                                HandleExternalCommitResponse* response);
+  Status handle_pending_commit(CachedState& entry,
+                               const HandlePendingCommitRequest* request,
+                               HandleCommitResponse* response);
 };

--- a/cmd/interop/src/mls_client_impl.h
+++ b/cmd/interop/src/mls_client_impl.h
@@ -56,6 +56,9 @@ class MLSClientImpl final : public MLSClient::Service
   Status AddProposal(ServerContext* context,
                      const AddProposalRequest* request,
                      ProposalResponse* response) override;
+  Status RemoveProposal(ServerContext* context,
+                        const RemoveProposalRequest* request,
+                        ProposalResponse* response) override;
   Status Commit(ServerContext* context,
                 const CommitRequest* request,
                 CommitResponse* response) override;
@@ -140,6 +143,9 @@ private:
   // Operations on a running group
   Status add_proposal(CachedState& entry,
                       const AddProposalRequest* request,
+                      ProposalResponse* response);
+  Status remove_proposal(CachedState& entry,
+                      const RemoveProposalRequest* request,
                       ProposalResponse* response);
   Status commit(CachedState& entry,
                 const CommitRequest* request,


### PR DESCRIPTION
In `/src`
* Refuse to generate remove proposals removing the client itself
* Don't add proposals to the cache that are already cached

In `/cmd/interop`
* Implement RemoveProposal and UpdateProposal RPCs
* Remove HandleExternalCommit RPC, since this just follows normal Commit handling
* Implement HandlePendingCommit RPC
* Use identities provided by the test runner
* Use MLSMessage whenever possible
* Use the correct initialization order for MessageOpts so that the client emits PrivateMessage when required