### PR TITLE
Verify that CI passes on current main

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ Conventions
   * Snake case for variables, functions, members (`derive_epoch_keys`)
   * Private member variables start with underscore (`_`)
   * In general, prefer descriptive names
+


### PR DESCRIPTION
In #327 there is some indication that the Windows CI build is broken, possibly to the `builtin-baseline` in `vcpkg.json` being too old.  This PR is to verify that this is the problem and hopefully resolve it.