### PR TITLE
Add a shell script to test that the gRPC interface works

### DIFF
--- a/cmd/interop/grpc-self-test.sh
+++ b/cmd/interop/grpc-self-test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+BIN=./build/mlspp_client
+PORT=50001
+INTEROP_DIR=./build/third_party/src/mls-interop-extern/interop/
+
+# Launch the interop client
+make
+${BIN} -live ${PORT} &
+BIN_PID=$!
+sleep 1
+
+# Run the test scenarios
+cd ${INTEROP_DIR}
+go mod tidy
+make test-runner/test-runner
+for CONFIG in `ls configs`;
+do
+  echo "Running ${CONFIG}..."
+  ./test-runner/test-runner -client localhost:${PORT} -config configs/${CONFIG} -public -suite 1 \
+        | grep -i error
+done
+
+# Clean up
+kill ${BIN_PID}


### PR DESCRIPTION
This should eventually be added to the interop CI workflow, but I would like to get things more stable before we lock it in like that.  (In that setting, we'll also want a clearer signal of failure, as oppose to just printing out the error lines.)  So for now, this is being added as a local development tool.