### PR TITLE
Add gRPC self-test to CI

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -47,3 +47,7 @@ jobs:
     - name: Test interop on test vectors
       run: |
         make -C cmd/interop interop-test
+
+    - name: Test gRPC live interop with self
+      run: |
+        ./grpc-self-test.sh

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -50,4 +50,5 @@ jobs:
 
     - name: Test gRPC live interop with self
       run: |
+        cd cmd/interop
         ./grpc-self-test.sh

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1270,6 +1270,7 @@ State::apply(const std::vector<CachedProposal>& proposals,
         }
 
         apply(target, update, cached_update.update_priv);
+        _cached_update.reset();
         locations.push_back(target);
         break;
       }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -390,7 +390,7 @@ Proposal
 State::update_proposal(HPKEPrivateKey leaf_priv, const LeafNodeOptions& opts)
 {
   if (_cached_update) {
-    return { opt::get(_cached_update).proposal };
+    throw ProtocolError("Only one update may be generated per epoch");
   }
 
   auto leaf = opt::get(_tree.leaf_node(_index));
@@ -1270,7 +1270,6 @@ State::apply(const std::vector<CachedProposal>& proposals,
         }
 
         apply(target, update, cached_update.update_priv);
-        _cached_update.reset();
         locations.push_back(target);
         break;
       }
@@ -1292,6 +1291,10 @@ State::apply(const std::vector<CachedProposal>& proposals,
         throw ProtocolError("Unsupported proposal type");
     }
   }
+
+  // The cached update needs to be reset after applying proposals, so that it is
+  // in a clean state for the next epoch.
+  _cached_update.reset();
 
   return locations;
 }


### PR DESCRIPTION
In #330, we added a shell script that tests self-interop on all the gRPC based live test configs in the `mls-implementations` repo.  This PR updates that script so that it is compatible with being run in CI, and updates the `interop` CI job to invoke the script.