### PR TITLE
Better update cache management

### DIFF
--- a/src/state.cpp
+++ b/src/state.cpp
@@ -390,7 +390,7 @@ Proposal
 State::update_proposal(HPKEPrivateKey leaf_priv, const LeafNodeOptions& opts)
 {
   if (_cached_update) {
-    return { opt::get(_cached_update).proposal };
+    throw ProtocolError("Only one update may be generated per epoch");
   }
 
   auto leaf = opt::get(_tree.leaf_node(_index));
@@ -1291,6 +1291,10 @@ State::apply(const std::vector<CachedProposal>& proposals,
         throw ProtocolError("Unsupported proposal type");
     }
   }
+
+  // The cached update needs to be reset after applying proposals, so that it is
+  // in a clean state for the next epoch.
+  _cached_update.reset();
 
   return locations;
 }


### PR DESCRIPTION
Right now, MLSpp behaves incorrectly if the same client is asked to produce an update proposal in different epochs.  Both Updates will be the same, because the cached update is never cleared.  This results in a duplicate key in the tree, which is forbidden.  It's also odd because the update returned from the method call has a different `encryption_key` field than the caller asked for!

This PR clears the cache at the appropriate moment (after all proposals are applied), and forbids the production of multiple Update proposals in a single epoch.