### PR TITLE
GREASE

### DIFF
--- a/include/mls/credential.h
+++ b/include/mls/credential.h
@@ -61,6 +61,23 @@ enum struct CredentialType : uint16_t
   reserved = 0,
   basic = 1,
   x509 = 2,
+
+  // GREASE values, included here mainly so that debugger output looks nice
+  GREASE_0 = 0x0A0A,
+  GREASE_1 = 0x1A1A,
+  GREASE_2 = 0x2A2A,
+  GREASE_3 = 0x3A3A,
+  GREASE_4 = 0x4A4A,
+  GREASE_5 = 0x5A5A,
+  GREASE_6 = 0x6A6A,
+  GREASE_7 = 0x7A7A,
+  GREASE_8 = 0x8A8A,
+  GREASE_9 = 0x9A9A,
+  GREASE_A = 0xAAAA,
+  GREASE_B = 0xBABA,
+  GREASE_C = 0xCACA,
+  GREASE_D = 0xDADA,
+  GREASE_E = 0xEAEA,
 };
 
 // struct {

--- a/include/mls/crypto.h
+++ b/include/mls/crypto.h
@@ -52,6 +52,23 @@ struct CipherSuite
     P521_AES256GCM_SHA512_P521 = 0x0005,
     X448_CHACHA20POLY1305_SHA512_Ed448 = 0x0006,
     P384_AES256GCM_SHA384_P384 = 0x0007,
+
+    // GREASE values, included here mainly so that debugger output looks nice
+    GREASE_0 = 0x0A0A,
+    GREASE_1 = 0x1A1A,
+    GREASE_2 = 0x2A2A,
+    GREASE_3 = 0x3A3A,
+    GREASE_4 = 0x4A4A,
+    GREASE_5 = 0x5A5A,
+    GREASE_6 = 0x6A6A,
+    GREASE_7 = 0x7A7A,
+    GREASE_8 = 0x8A8A,
+    GREASE_9 = 0x9A9A,
+    GREASE_A = 0xAAAA,
+    GREASE_B = 0xBABA,
+    GREASE_C = 0xCACA,
+    GREASE_D = 0xDADA,
+    GREASE_E = 0xEAEA,
   };
 
   CipherSuite();

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -1,6 +1,8 @@
 #include "mls/core_types.h"
 #include "mls/messages.h"
 
+#include "grease.h"
+
 #include <set>
 
 namespace mls {
@@ -132,9 +134,9 @@ LeafNode::LeafNode(CipherSuite cipher_suite,
   : encryption_key(std::move(encryption_key_in))
   , signature_key(std::move(signature_key_in))
   , credential(std::move(credential_in))
-  , capabilities(std::move(capabilities_in))
+  , capabilities(grease(std::move(capabilities_in)))
   , content(lifetime_in)
-  , extensions(std::move(extensions_in))
+  , extensions(grease(std::move(extensions_in)))
 {
   sign(cipher_suite, sig_priv, std::nullopt);
 }
@@ -372,7 +374,7 @@ KeyPackage::KeyPackage(CipherSuite suite_in,
   , cipher_suite(suite_in)
   , init_key(std::move(init_key_in))
   , leaf_node(std::move(leaf_node_in))
-  , extensions(std::move(extensions_in))
+  , extensions(grease(std::move(extensions_in)))
 {
   sign(sig_priv_in);
 }

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -3,6 +3,8 @@
 #include <mls/state.h>
 #include <mls/treekem.h>
 
+#include "grease.h"
+
 namespace mls {
 
 // Extensions
@@ -44,7 +46,7 @@ GroupInfo::GroupInfo(GroupContext group_context_in,
                      ExtensionList extensions_in,
                      bytes confirmation_tag_in)
   : group_context(std::move(group_context_in))
-  , extensions(std::move(extensions_in))
+  , extensions(grease(std::move(extensions_in)))
   , confirmation_tag(std::move(confirmation_tag_in))
   , signer(0)
 {

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -1014,14 +1014,14 @@ TreeKEMPublicKey::parent_hash_valid(LeafIndex from,
 tls::ostream&
 operator<<(tls::ostream& str, const TreeKEMPublicKey& obj)
 {
+  // Empty tree
+  if (obj.size.val == 0) {
+    return str << std::vector<OptionalNode>{};
+  }
+
   LeafIndex cut = LeafIndex{ obj.size.val - 1 };
   while (cut.val > 0 && obj.node_at(cut).blank()) {
     cut.val -= 1;
-  }
-
-  if (obj.node_at(cut).blank()) {
-    // Empty tree
-    return str << std::vector<OptionalNode>{};
   }
 
   const auto begin = obj.nodes.begin();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ file(GLOB TEST_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
 add_executable(${TEST_APP_NAME} ${TEST_SOURCES})
 add_dependencies(${TEST_APP_NAME} ${LIB_NAME} bytes tls_syntax mls_vectors)
+target_include_directories(${TEST_APP_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)
 target_link_libraries(${TEST_APP_NAME} ${LIB_NAME} 
   bytes tls_syntax mls_vectors
   doctest::doctest OpenSSL::Crypto)


### PR DESCRIPTION
This PR implements the GREASE strategy from https://github.com/mlswg/mls-protocol/pull/869.  The main effect is that GREASE values are added to:

* `LeafNode.capabilities`
* The extensions in `LeafNode`, `KeyPackage`, and `GroupInfo`

There is also a drive-by fix in here for a bug in RatchetTree serialization, where a zero-size tree was not handled correctly (causing an integer underflow).