### PR TITLE
Update to support the latest external proposal tests

### DIFF
--- a/cmd/interop/grpc-self-test.sh
+++ b/cmd/interop/grpc-self-test.sh
@@ -17,17 +17,23 @@ make test-runner/test-runner
 cd ../../../../..
 
 # Run the tests
-find ${INTEROP_DIR}/configs -name "*.json" \
-    | xargs ${INTEROP_DIR}/test-runner/test-runner -client localhost:50001 -public -suite 1 -config \
-    | grep error
-have_error=$?
+have_error=0
+for name in `find ${INTEROP_DIR}/configs -name "*.json"`;
+do
+    echo $name
+    ${INTEROP_DIR}/test-runner/test-runner -client localhost:50001 -public -suite 1 -config $name | grep error
+    if [ $? == 0 ]
+    then
+      have_error=1
+    fi
+done
 
 # Clean up
 kill ${BIN_PID}
 
 # Exit status is flipped from `grep` status, because `grep` succeeds when an
 # error line has been matched.
-if [ $have_error == 0 ]; 
+if [ $have_error == 1 ]; 
 then 
   echo FAIL
   exit 1

--- a/cmd/interop/src/mls_client_impl.h
+++ b/cmd/interop/src/mls_client_impl.h
@@ -116,7 +116,7 @@ class MLSClientImpl final : public MLSClient::Service
                             HandleReInitCommitResponse* response) override;
   Status ReInitWelcome(ServerContext* context,
                        const ReInitWelcomeRequest* request,
-                       ReInitWelcomeResponse* response) override;
+                       CreateSubgroupResponse* response) override;
   Status HandleReInitWelcome(ServerContext* context,
                              const HandleReInitWelcomeRequest* request,
                              JoinGroupResponse* response) override;
@@ -124,7 +124,7 @@ class MLSClientImpl final : public MLSClient::Service
   // Subgroup branching
   Status CreateBranch(ServerContext* context,
                       const CreateBranchRequest* request,
-                      CreateBranchResponse* response) override;
+                      CreateSubgroupResponse* response) override;
   Status HandleBranch(ServerContext* context,
                       const HandleBranchRequest* request,
                       HandleBranchResponse* response) override;
@@ -296,14 +296,14 @@ private:
                               const HandleCommitRequest* request,
                               HandleReInitCommitResponse* response);
   Status reinit_welcome(const ReInitWelcomeRequest* request,
-                        ReInitWelcomeResponse* response);
+                        CreateSubgroupResponse* response);
   Status handle_reinit_welcome(const HandleReInitWelcomeRequest* request,
                                JoinGroupResponse* response);
 
   // Subgroup branching
   Status create_branch(CachedState& entry,
                        const CreateBranchRequest* request,
-                       CreateBranchResponse* response);
+                       CreateSubgroupResponse* response);
   Status handle_branch(CachedState& entry,
                        const HandleBranchRequest* request,
                        HandleBranchResponse* response);


### PR DESCRIPTION
Corresponds to https://github.com/mlswg/mls-implementations/pull/157

Main changes are:
* Change some response types to CreateSubgroupResponse
* Add support for ReInit proposal descriptions
* Update the gRPC runner script so that it actually runs all of the configs