### PR TITLE
Don't double-handle ReInit Commits

### DIFF
--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -315,6 +315,10 @@ protected:
     const MLSMessage& msg,
     std::optional<State> cached_state,
     const std::optional<CommitParams>& expected_params);
+  std::optional<State> handle(
+    const AuthenticatedContent& msg,
+    std::optional<State> cached_state,
+    const std::optional<CommitParams>& expected_params);
 
   // Create an MLSMessage encapsulating some content
   template<typename Inner>

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -316,7 +316,7 @@ protected:
     std::optional<State> cached_state,
     const std::optional<CommitParams>& expected_params);
   std::optional<State> handle(
-    const AuthenticatedContent& msg,
+    const AuthenticatedContent& content_auth,
     std::optional<State> cached_state,
     const std::optional<CommitParams>& expected_params);
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -724,7 +724,7 @@ State::handle(const MLSMessage& msg,
     throw InvalidParameterError("Message signature failed to verify");
   }
 
-  return handle(content_auth, cached_state, expected_params);
+  return handle(content_auth, std::move(cached_state), expected_params);
 }
 
 std::optional<State>


### PR DESCRIPTION
ReInit commit handling needs to extract the ReInit proposal so that its parameters can be cached.  In the initial implementation, we did this by unprotecting the MLSMessage twice.  This work for commits sent as unencrypted PublicMessage, but for encrypted PrivateMessage, it causes an error "Request for expired key", because the decryption key is deleted after decryption for forward secrecy.  This PR instead unprotects the MLSMessage once, and then provides the unprotected value to the handling code and uses it to extract the ReInit.