### PR TITLE
GREASE consistently

### DIFF
--- a/include/mls/core_types.h
+++ b/include/mls/core_types.h
@@ -212,6 +212,8 @@ struct LeafNode
                       const LeafNodeOptions& opts,
                       const SignaturePrivateKey& sig_priv_in) const;
 
+  void set_capabilities(Capabilities capabilities_in);
+
   LeafNodeSource source() const;
 
   struct MemberBinding

--- a/src/core_types.cpp
+++ b/src/core_types.cpp
@@ -134,11 +134,18 @@ LeafNode::LeafNode(CipherSuite cipher_suite,
   : encryption_key(std::move(encryption_key_in))
   , signature_key(std::move(signature_key_in))
   , credential(std::move(credential_in))
-  , capabilities(grease(std::move(capabilities_in)))
+  , capabilities(std::move(capabilities_in))
   , content(lifetime_in)
   , extensions(grease(std::move(extensions_in)))
 {
+  capabilities = grease(std::move(capabilities), extensions);
   sign(cipher_suite, sig_priv, std::nullopt);
+}
+
+void
+LeafNode::set_capabilities(Capabilities capabilities_in)
+{
+  capabilities = grease(std::move(capabilities_in), extensions);
 }
 
 LeafNode

--- a/src/grease.cpp
+++ b/src/grease.cpp
@@ -33,6 +33,12 @@ grease_value()
   return grease_values.at(where);
 }
 
+bool
+grease_value(uint16_t val)
+{
+  return ((val & 0x0F0F) == 0x0A0A) && val != 0xFAFA;
+}
+
 static std::set<uint16_t>
 grease_sample(size_t count)
 {
@@ -66,21 +72,39 @@ grease(std::vector<T>&& in)
 }
 
 Capabilities
-grease(Capabilities&& in)
+grease(Capabilities&& capabilities, const ExtensionList& extensions)
 {
-  return {
-    std::move(in.versions),
-    grease(std::move(in.cipher_suites)),
-    grease(std::move(in.extensions)),
-    grease(std::move(in.proposals)),
-    grease(std::move(in.credentials)),
+  auto capas = Capabilities{
+    std::move(capabilities.versions),
+    grease(std::move(capabilities.cipher_suites)),
+    grease(std::move(capabilities.extensions)),
+    grease(std::move(capabilities.proposals)),
+    grease(std::move(capabilities.credentials)),
   };
+
+  // Ensure that the GREASE extensions are reflected in Capabilities.extensions
+  for (const auto& ext : extensions.extensions) {
+    if (!grease_value(ext.type)) {
+      continue;
+    }
+
+    if (stdx::contains(capas.extensions, ext.type)) {
+      continue;
+    }
+
+    const auto where =
+      static_cast<ptrdiff_t>(rand_int(capas.extensions.size()));
+    const auto where_ptr = std::begin(capas.extensions) + where;
+    capas.extensions.insert(where_ptr, ext.type);
+  }
+
+  return capas;
 }
 
 ExtensionList
-grease(ExtensionList&& in)
+grease(ExtensionList&& extensions)
 {
-  auto ext = in.extensions;
+  auto ext = extensions.extensions;
 
   const auto count = std::max(size_t(1), rand_int(ext.size() >> log_p_grease));
   for (const auto ext_type : grease_sample(count)) {

--- a/src/grease.cpp
+++ b/src/grease.cpp
@@ -33,10 +33,11 @@ grease_value()
   return grease_values.at(where);
 }
 
-bool
+static bool
 grease_value(uint16_t val)
 {
-  return ((val & 0x0F0F) == 0x0A0A) && val != 0xFAFA;
+  static constexpr auto grease_mask = uint16_t(0x0F0F);
+  return ((val & grease_mask) == 0x0A0A) && val != 0xFAFA;
 }
 
 static std::set<uint16_t>

--- a/src/grease.h
+++ b/src/grease.h
@@ -5,8 +5,9 @@
 namespace mls {
 
 Capabilities
-grease(Capabilities&& in);
+grease(Capabilities&& capabilities, const ExtensionList& extensions);
+
 ExtensionList
-grease(ExtensionList&& in);
+grease(ExtensionList&& extensions);
 
 } // namespace mls

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1379,7 +1379,6 @@ State::valid(const LeafNode& leaf_node,
 
   // Verify the leaf_node_source field:
   const auto correct_source = (leaf_node.source() == required_source);
-  const auto source_is_update = leaf_node.source() == LeafNodeSource::update;
 
   // Verify that the signature on the LeafNode is valid using signature_key.
   auto binding = std::optional<LeafNode::MemberBinding>{};
@@ -1428,8 +1427,8 @@ State::valid(const LeafNode& leaf_node,
 
     // Signature keys are allowed to repeat within a leaf
     unique_signature_key =
-      unique_signature_key && ((source_is_update && (i == index)) ||
-                               (signature_key != leaf.signature_key));
+      unique_signature_key &&
+      ((i == index) || (signature_key != leaf.signature_key));
     unique_encryption_key =
       unique_encryption_key && (encryption_key != leaf.encryption_key);
     mutual_credential_support =

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1379,6 +1379,7 @@ State::valid(const LeafNode& leaf_node,
 
   // Verify the leaf_node_source field:
   const auto correct_source = (leaf_node.source() == required_source);
+  const auto source_is_update = leaf_node.source() == LeafNodeSource::update;
 
   // Verify that the signature on the LeafNode is valid using signature_key.
   auto binding = std::optional<LeafNode::MemberBinding>{};
@@ -1427,8 +1428,8 @@ State::valid(const LeafNode& leaf_node,
 
     // Signature keys are allowed to repeat within a leaf
     unique_signature_key =
-      unique_signature_key &&
-      ((i == index) || (signature_key != leaf.signature_key));
+      unique_signature_key && ((source_is_update && (i == index)) ||
+                               (signature_key != leaf.signature_key));
     unique_encryption_key =
       unique_encryption_key && (encryption_key != leaf.encryption_key);
     mutual_credential_support =
@@ -1437,9 +1438,17 @@ State::valid(const LeafNode& leaf_node,
       leaf_node.capabilities.credential_supported(leaf.credential);
   }
 
+  // Verify that the extensions in the LeafNode are supported by checking that
+  // the ID for each extension in the extensions field is listed in the
+  // capabilities.extensions field of the LeafNode.
+  auto all_extensions_supported =
+    stdx::all_of(leaf_node.extensions.extensions, [&](const auto& ext) {
+      return stdx::contains(leaf_node.capabilities.extensions, ext.type);
+    });
+
   return (signature_valid && supports_group_extensions && correct_source &&
           mutual_credential_support && unique_signature_key &&
-          unique_encryption_key);
+          unique_encryption_key && all_extensions_supported);
 }
 
 bool

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -571,12 +571,12 @@ TEST_CASE_FIXTURE(StateTest, "Enforce Required Capabilities")
   auto kp_no = kp_no_;
 
   auto [init_yes, leaf_yes, id_yes, kp_yes] = make_client();
-  kp_yes.leaf_node.capabilities = extended_capabilities;
+  kp_yes.leaf_node.set_capabilities(extended_capabilities);
   kp_yes.leaf_node.sign(suite, id_yes, std::nullopt);
   kp_yes.sign(id_yes);
 
   auto [init_yes_2, leaf_yes_2, id_yes_2, kp_yes_2] = make_client();
-  kp_yes_2.leaf_node.capabilities = extended_capabilities;
+  kp_yes_2.leaf_node.set_capabilities(extended_capabilities);
   kp_yes_2.leaf_node.sign(suite, id_yes_2, std::nullopt);
   kp_yes_2.sign(id_yes_2);
 


### PR DESCRIPTION
The GREASE provisions in the spec address `LeafNode.capabilities` and `LeafNode.extensions` separately, even though the spec requires that `capabilities.extensions` reflect all the values in `extensions`.  This PR extends the GREASE logic to make sure that the extension types of any GREASE extensions are reflected in `capabilities.extensions`.