### PR TITLE
Implement the Free() RPC

### DIFF
--- a/cmd/interop/src/mls_client_impl.cpp
+++ b/cmd/interop/src/mls_client_impl.cpp
@@ -427,6 +427,20 @@ MLSClientImpl::HandleBranch(ServerContext* /* context */,
   });
 }
 
+Status
+MLSClientImpl::Free(ServerContext* /* context */,
+                    const FreeRequest* request,
+                    FreeResponse* /* response */)
+{
+  const auto state_id = request->state_id();
+  if (state_cache.count(state_id) == 0) {
+    return Status(StatusCode::NOT_FOUND, "Unknown state");
+  }
+
+  remove_state(state_id);
+  return Status::OK;
+}
+
 // Cached join transactions
 uint32_t
 MLSClientImpl::store_join(KeyPackageWithSecrets&& kp_priv)

--- a/cmd/interop/src/mls_client_impl.h
+++ b/cmd/interop/src/mls_client_impl.h
@@ -129,6 +129,11 @@ class MLSClientImpl final : public MLSClient::Service
                       const HandleBranchRequest* request,
                       HandleBranchResponse* response) override;
 
+  // Cleanup
+  Status Free(ServerContext* context,
+              const FreeRequest* request,
+              FreeResponse* response) override;
+
 private:
   // Wrapper for methods that rely on state
   template<typename Req, typename F>


### PR DESCRIPTION
Corresponds to https://github.com/mlswg/mls-implementations/pull/163

Interop CI will fail until that PR is merged, but I have verified locally that this builds with `CMakeLists.txt` updated to use the PR branch.