### PR TITLE
configure install target for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ target_link_libraries(${LIB_NAME} bytes tls_syntax hpke)
 target_include_directories(${LIB_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
   PRIVATE
     ${OPENSSL_INCLUDE_DIR}
 )
@@ -150,7 +150,7 @@ install(
   DIRECTORY
     include/
   DESTINATION
-    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}-${PROJECT_VERSION})
+    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
 
 install(
   FILES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ option(SANITIZERS "Enable sanitizers" OFF)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 include(CheckCXXCompilerFlag)
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -123,5 +125,38 @@ endif()
 ### Exports
 ###
 set(CMAKE_EXPORT_PACKAGE_REGISTRY ON)
-export(TARGETS mlspp tls_syntax hpke bytes mls_vectors third_party NAMESPACE MLSPP:: FILE MLSPPConfig.cmake)
+export(EXPORT mlspp-targets 
+       NAMESPACE MLSPP::
+       FILE ${CMAKE_CURRENT_BINARY_DIR}/mlspp-targets.cmake)
 export(PACKAGE MLSPP)
+
+configure_package_config_file(cmake/config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/mlspp-config.cmake
+  INSTALL_DESTINATION ${CMAKE_INSTALL_DATADIR}/mlspp
+  NO_SET_AND_CHECK_MACRO)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/mlspp-config-version.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion)
+
+###
+### Install
+###
+
+install(TARGETS ${LIB_NAME} EXPORT mlspp-targets)
+
+install(
+  DIRECTORY
+    include/
+  DESTINATION
+    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}-${PROJECT_VERSION})
+
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/mlspp-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/mlspp-config-version.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/mlspp-targets.cmake
+  DESTINATION
+    ${CMAKE_INSTALL_DATADIR}/mlspp)
+

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/mlspp-targets.cmake)
+check_required_components(mlspp)

--- a/lib/bytes/CMakeLists.txt
+++ b/lib/bytes/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(${CURRENT_LIB_NAME} tls_syntax)
 target_include_directories(${CURRENT_LIB_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
 
 ###
@@ -25,7 +25,7 @@ install(
   DIRECTORY
     include/
   DESTINATION
-    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}-${PROJECT_VERSION}
+    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
 )
 
 ###

--- a/lib/bytes/CMakeLists.txt
+++ b/lib/bytes/CMakeLists.txt
@@ -11,7 +11,21 @@ add_library(${CURRENT_LIB_NAME} ${LIB_HEADERS} ${LIB_SOURCES})
 add_dependencies(${CURRENT_LIB_NAME} tls_syntax)
 target_link_libraries(${CURRENT_LIB_NAME} tls_syntax)
 target_include_directories(${CURRENT_LIB_NAME}
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
+)
+
+###
+### Install
+###
+
+install(TARGETS ${CURRENT_LIB_NAME} EXPORT mlspp-targets)
+install(
+  DIRECTORY
+    include/
+  DESTINATION
+    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}-${PROJECT_VERSION}
 )
 
 ###

--- a/lib/hpke/CMakeLists.txt
+++ b/lib/hpke/CMakeLists.txt
@@ -18,7 +18,7 @@ target_link_libraries(${CURRENT_LIB_NAME} PRIVATE bytes tls_syntax OpenSSL::Cryp
 target_include_directories(${CURRENT_LIB_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
 
 ###
@@ -30,7 +30,7 @@ install(
   DIRECTORY
     include/
   DESTINATION
-    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}-${PROJECT_VERSION}
+    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
 )
 
 ###

--- a/lib/hpke/CMakeLists.txt
+++ b/lib/hpke/CMakeLists.txt
@@ -16,7 +16,21 @@ add_library(${CURRENT_LIB_NAME} ${LIB_HEADERS} ${LIB_SOURCES})
 add_dependencies(${CURRENT_LIB_NAME} bytes tls_syntax)
 target_link_libraries(${CURRENT_LIB_NAME} PRIVATE bytes tls_syntax OpenSSL::Crypto)
 target_include_directories(${CURRENT_LIB_NAME}
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
+)
+
+###
+### Install
+###
+
+install(TARGETS ${CURRENT_LIB_NAME} EXPORT mlspp-targets)
+install(
+  DIRECTORY
+    include/
+  DESTINATION
+    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}-${PROJECT_VERSION}
 )
 
 ###

--- a/lib/mls_vectors/CMakeLists.txt
+++ b/lib/mls_vectors/CMakeLists.txt
@@ -11,7 +11,21 @@ add_library(${CURRENT_LIB_NAME} ${LIB_HEADERS} ${LIB_SOURCES})
 add_dependencies(${CURRENT_LIB_NAME} mlspp)
 target_link_libraries(${CURRENT_LIB_NAME} mlspp bytes tls_syntax)
 target_include_directories(${CURRENT_LIB_NAME}
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
+)
+
+###
+### Install
+###
+
+install(TARGETS ${CURRENT_LIB_NAME} EXPORT mlspp-targets)
+install(
+  DIRECTORY
+    include/
+  DESTINATION
+    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}-${PROJECT_VERSION}
 )
 
 ###

--- a/lib/mls_vectors/CMakeLists.txt
+++ b/lib/mls_vectors/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(${CURRENT_LIB_NAME} mlspp bytes tls_syntax)
 target_include_directories(${CURRENT_LIB_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
 
 ###
@@ -25,7 +25,7 @@ install(
   DIRECTORY
     include/
   DESTINATION
-    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}-${PROJECT_VERSION}
+    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
 )
 
 ###

--- a/lib/tls_syntax/CMakeLists.txt
+++ b/lib/tls_syntax/CMakeLists.txt
@@ -13,7 +13,7 @@ target_link_libraries(${CURRENT_LIB_NAME} third_party)
 target_include_directories(${CURRENT_LIB_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
 
 ###
@@ -25,7 +25,7 @@ install(
   DIRECTORY
     include/
   DESTINATION
-    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}-${PROJECT_VERSION}
+    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}
 )
 
 ###

--- a/lib/tls_syntax/CMakeLists.txt
+++ b/lib/tls_syntax/CMakeLists.txt
@@ -11,7 +11,21 @@ add_library(${CURRENT_LIB_NAME} ${LIB_HEADERS} ${LIB_SOURCES})
 add_dependencies(${CURRENT_LIB_NAME} third_party)
 target_link_libraries(${CURRENT_LIB_NAME} third_party)
 target_include_directories(${CURRENT_LIB_NAME}
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
+)
+
+###
+### Install
+###
+
+install(TARGETS ${CURRENT_LIB_NAME} EXPORT mlspp-targets)
+install(
+  DIRECTORY
+    include/
+  DESTINATION
+    ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}-${PROJECT_VERSION}
 )
 
 ###

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(${CURRENT_LIB_NAME} INTERFACE)
 target_include_directories(${CURRENT_LIB_NAME}
   INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
 
 ###
@@ -14,4 +14,4 @@ target_include_directories(${CURRENT_LIB_NAME}
 install(TARGETS ${CURRENT_LIB_NAME} EXPORT mlspp-targets)
 install(FILES variant.hpp 
         DESTINATION
-            ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}-${PROJECT_VERSION})
+            ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -2,5 +2,16 @@ set(CURRENT_LIB_NAME third_party)
 
 add_library(${CURRENT_LIB_NAME} INTERFACE)
 target_include_directories(${CURRENT_LIB_NAME}
-  INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
 )
+
+###
+### Install
+###
+
+install(TARGETS ${CURRENT_LIB_NAME} EXPORT mlspp-targets)
+install(FILES variant.hpp 
+        DESTINATION
+            ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}-${PROJECT_VERSION})


### PR DESCRIPTION
I have been integrating mlspp into vcpkg, and one of the first steps in doing the integration is the install target.

The install will install includes to a directory `${CMAKE_INSTALL_PREFIX}/mlspp-${MLSPP_VERSION}`

The libraries will be installed into `${CMAKE_INSTALL_PREFIX}/lib`

The cmake configuration files will be installed into `${CMAKE_INSTALL_PREFIX}/share/cmake/mlspp`