### PR TITLE
Add an equality operator for PublicMessage

### DIFF
--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -592,6 +592,7 @@ struct PublicMessage
 
   friend tls::ostream& operator<<(tls::ostream& str, const PublicMessage& obj);
   friend tls::istream& operator>>(tls::istream& str, PublicMessage& obj);
+  friend bool operator==(const PublicMessage& lhs, const PublicMessage& rhs);
 
 private:
   GroupContent content;

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -630,6 +630,14 @@ operator>>(tls::istream& str, PublicMessage& obj)
   return str;
 }
 
+bool
+operator==(const PublicMessage& lhs, const PublicMessage& rhs)
+{
+  return lhs.content == rhs.content &&
+    lhs.auth == rhs.auth &&
+    lhs.membership_tag == rhs.membership_tag;
+}
+
 static bytes
 marshal_ciphertext_content(const GroupContent& content,
                            const GroupContentAuthData& auth,


### PR DESCRIPTION
Since PublicMessage uses its own TLS serialization operators instead of `TLS_SERIALIZABLE`, it also needs to define its own equality operator.  This PR adds one, in the obvious way.