### PR TITLE
More integration fixes

### DIFF
--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -419,8 +419,8 @@ struct GroupContext;
 enum struct WireFormat : uint16_t
 {
   reserved = 0,
-  mls_plaintext = 1,
-  mls_ciphertext = 2,
+  mls_public_message = 1,
+  mls_private_message = 2,
   mls_welcome = 3,
   mls_group_info = 4,
   mls_key_package = 5,
@@ -653,8 +653,8 @@ struct MLSMessage
   WireFormat wire_format() const;
 
   MLSMessage() = default;
-  MLSMessage(PublicMessage mls_plaintext);
-  MLSMessage(PrivateMessage mls_ciphertext);
+  MLSMessage(PublicMessage public_message);
+  MLSMessage(PrivateMessage private_message);
   MLSMessage(Welcome welcome);
   MLSMessage(GroupInfo group_info);
   MLSMessage(KeyPackage key_package);
@@ -718,10 +718,10 @@ TLS_VARIANT_MAP(MLS_NAMESPACE::SenderType,
 
 TLS_VARIANT_MAP(MLS_NAMESPACE::WireFormat,
                 MLS_NAMESPACE::PublicMessage,
-                mls_plaintext)
+                mls_public_message)
 TLS_VARIANT_MAP(MLS_NAMESPACE::WireFormat,
                 MLS_NAMESPACE::PrivateMessage,
-                mls_ciphertext)
+                mls_private_message)
 TLS_VARIANT_MAP(MLS_NAMESPACE::WireFormat, MLS_NAMESPACE::Welcome, mls_welcome)
 TLS_VARIANT_MAP(MLS_NAMESPACE::WireFormat,
                 MLS_NAMESPACE::GroupInfo,

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -1812,11 +1812,15 @@ MessagesTestVector::MessagesTestVector()
 
   auto version = ProtocolVersion::mls10;
   auto hpke_priv = prg.hpke_key("hpke_priv");
+  auto hpke_priv_2 = prg.hpke_key("hpke_priv_2");
   auto hpke_pub = hpke_priv.public_key;
+  auto hpke_pub_2 = hpke_priv_2.public_key;
   auto hpke_ct =
     HPKECiphertext{ prg.secret("kem_output"), prg.secret("ciphertext") };
   auto sig_priv = prg.signature_key("signature_priv");
+  auto sig_priv_2 = prg.signature_key("signature_priv_2");
   auto sig_pub = sig_priv.public_key;
+  auto sig_pub_2 = sig_priv_2.public_key;
 
   // KeyPackage and extensions
   auto cred = Credential::basic(user_id);
@@ -1828,6 +1832,14 @@ MessagesTestVector::MessagesTestVector()
                              Lifetime::create_default(),
                              ext_list,
                              sig_priv };
+  auto leaf_node_2 = LeafNode{ suite,
+                             hpke_pub_2,
+                             sig_pub_2,
+                             cred,
+                             Capabilities::create_default(),
+                             Lifetime::create_default(),
+                             ext_list,
+                             sig_priv_2 };
   auto key_package_obj = KeyPackage{ suite, hpke_pub, leaf_node, {}, sig_priv };
 
   auto leaf_node_update =
@@ -1839,7 +1851,7 @@ MessagesTestVector::MessagesTestVector()
 
   auto tree = TreeKEMPublicKey{ suite };
   tree.add_leaf(leaf_node);
-  tree.add_leaf(leaf_node);
+  tree.add_leaf(leaf_node_2);
   auto ratchet_tree_obj = RatchetTreeExtension{ tree };
 
   // Welcome and its substituents

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -828,7 +828,7 @@ MessageProtectionTestVector::protect_pub(
   auto content =
     GroupContent{ group_id, epoch, sender, authenticated_data, raw_content };
 
-  auto auth_content = AuthenticatedContent::sign(WireFormat::mls_plaintext,
+  auto auth_content = AuthenticatedContent::sign(WireFormat::mls_public_message,
                                                  content,
                                                  cipher_suite,
                                                  signature_priv,
@@ -853,7 +853,7 @@ MessageProtectionTestVector::protect_priv(
   auto content =
     GroupContent{ group_id, epoch, sender, authenticated_data, raw_content };
 
-  auto auth_content = AuthenticatedContent::sign(WireFormat::mls_ciphertext,
+  auto auth_content = AuthenticatedContent::sign(WireFormat::mls_private_message,
                                                  content,
                                                  cipher_suite,
                                                  signature_priv,
@@ -973,7 +973,7 @@ TranscriptTestVector::TranscriptTestVector(CipherSuite suite)
   auto leaf_index = LeafIndex{ 0 };
 
   authenticated_content = AuthenticatedContent::sign(
-    WireFormat::mls_plaintext,
+    WireFormat::mls_public_message,
     GroupContent{
       group_id, epoch, { MemberSender{ leaf_index } }, {}, Commit{} },
     suite,
@@ -1898,7 +1898,7 @@ MessagesTestVector::MessagesTestVector()
   auto membership_key = prg.secret("membership_key");
 
   auto content_auth_proposal = AuthenticatedContent::sign(
-    WireFormat::mls_plaintext,
+    WireFormat::mls_public_message,
     { group_id, epoch, sender, {}, Proposal{ remove } },
     suite,
     sig_priv,
@@ -1907,7 +1907,7 @@ MessagesTestVector::MessagesTestVector()
     content_auth_proposal, suite, membership_key, group_context);
 
   auto content_auth_commit =
-    AuthenticatedContent::sign(WireFormat::mls_plaintext,
+    AuthenticatedContent::sign(WireFormat::mls_public_message,
                                { group_id, epoch, sender, {}, commit_obj },
                                suite,
                                sig_priv,
@@ -1918,7 +1918,7 @@ MessagesTestVector::MessagesTestVector()
 
   // PrivateMessage
   auto content_auth_application_obj = AuthenticatedContent::sign(
-    WireFormat::mls_ciphertext,
+    WireFormat::mls_private_message,
     { group_id, epoch, sender, {}, ApplicationData{} },
     suite,
     sig_priv,
@@ -1994,15 +1994,15 @@ MessagesTestVector::verify() const
   VERIFY_TLS_RTT_VAL("Public(Proposal)",
                      MLSMessage,
                      public_message_proposal,
-                     require_format(WireFormat::mls_plaintext));
+                     require_format(WireFormat::mls_public_message));
   VERIFY_TLS_RTT_VAL("Public(Commit)",
                      MLSMessage,
                      public_message_commit,
-                     require_format(WireFormat::mls_plaintext));
+                     require_format(WireFormat::mls_public_message));
   VERIFY_TLS_RTT_VAL("PrivateMessage",
                      MLSMessage,
                      private_message,
-                     require_format(WireFormat::mls_ciphertext));
+                     require_format(WireFormat::mls_private_message));
 
   return std::nullopt;
 }

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -853,11 +853,12 @@ MessageProtectionTestVector::protect_priv(
   auto content =
     GroupContent{ group_id, epoch, sender, authenticated_data, raw_content };
 
-  auto auth_content = AuthenticatedContent::sign(WireFormat::mls_private_message,
-                                                 content,
-                                                 cipher_suite,
-                                                 signature_priv,
-                                                 group_context());
+  auto auth_content =
+    AuthenticatedContent::sign(WireFormat::mls_private_message,
+                               content,
+                               cipher_suite,
+                               signature_priv,
+                               group_context());
   if (content.content_type() == ContentType::commit) {
     auto confirmation_tag = prg.secret("confirmation_tag");
     auth_content.set_confirmation_tag(confirmation_tag);
@@ -1833,13 +1834,13 @@ MessagesTestVector::MessagesTestVector()
                              ext_list,
                              sig_priv };
   auto leaf_node_2 = LeafNode{ suite,
-                             hpke_pub_2,
-                             sig_pub_2,
-                             cred,
-                             Capabilities::create_default(),
-                             Lifetime::create_default(),
-                             ext_list,
-                             sig_priv_2 };
+                               hpke_pub_2,
+                               sig_pub_2,
+                               cred,
+                               Capabilities::create_default(),
+                               Lifetime::create_default(),
+                               ext_list,
+                               sig_priv_2 };
   auto key_package_obj = KeyPackage{ suite, hpke_pub, leaf_node, {}, sig_priv };
 
   auto leaf_node_update =

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -851,13 +851,13 @@ MLSMessage::wire_format() const
   return tls::variant<WireFormat>::type(message);
 }
 
-MLSMessage::MLSMessage(PublicMessage mls_plaintext)
-  : message(std::move(mls_plaintext))
+MLSMessage::MLSMessage(PublicMessage public_message)
+  : message(std::move(public_message))
 {
 }
 
-MLSMessage::MLSMessage(PrivateMessage mls_ciphertext)
-  : message(std::move(mls_ciphertext))
+MLSMessage::MLSMessage(PrivateMessage private_message)
+  : message(std::move(private_message))
 {
 }
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -351,7 +351,7 @@ AuthenticatedContent::sign(WireFormat wire_format,
                            const SignaturePrivateKey& sig_priv,
                            const std::optional<GroupContext>& context)
 {
-  if (wire_format == WireFormat::mls_plaintext &&
+  if (wire_format == WireFormat::mls_public_message &&
       content.content_type() == ContentType::application) {
     throw InvalidParameterError(
       "Application data cannot be sent as PublicMessage");
@@ -369,7 +369,7 @@ AuthenticatedContent::verify(CipherSuite suite,
                              const SignaturePublicKey& sig_pub,
                              const std::optional<GroupContext>& context) const
 {
-  if (wire_format == WireFormat::mls_plaintext &&
+  if (wire_format == WireFormat::mls_public_message &&
       content.content_type() == ContentType::application) {
     return false;
   }
@@ -545,7 +545,7 @@ PublicMessage::unprotect(CipherSuite suite,
   }
 
   return AuthenticatedContent{
-    WireFormat::mls_plaintext,
+    WireFormat::mls_public_message,
     content,
     auth,
   };
@@ -561,7 +561,7 @@ AuthenticatedContent
 PublicMessage::authenticated_content() const
 {
   auto auth_content = AuthenticatedContent{};
-  auth_content.wire_format = WireFormat::mls_plaintext;
+  auth_content.wire_format = WireFormat::mls_public_message;
   auth_content.content = content;
   auth_content.auth = auth;
   return auth_content;
@@ -571,7 +571,7 @@ PublicMessage::PublicMessage(AuthenticatedContent content_auth)
   : content(std::move(content_auth.content))
   , auth(std::move(content_auth.auth))
 {
-  if (content_auth.wire_format != WireFormat::mls_plaintext) {
+  if (content_auth.wire_format != WireFormat::mls_public_message) {
     throw InvalidParameterError("Wire format mismatch (not mls_plaintext)");
   }
 }
@@ -590,7 +590,7 @@ PublicMessage::membership_mac(CipherSuite suite,
                               const std::optional<GroupContext>& context) const
 {
   auto tbm = tls::marshal(GroupContentTBM{
-    { WireFormat::mls_plaintext, content, context },
+    { WireFormat::mls_public_message, content, context },
     auth,
   });
 
@@ -813,7 +813,7 @@ PrivateMessage::unprotect(CipherSuite suite,
   unmarshal_ciphertext_content(opt::get(content_pt), content, auth);
 
   return AuthenticatedContent{
-    WireFormat::mls_ciphertext,
+    WireFormat::mls_private_message,
     std::move(content),
     std::move(auth),
   };
@@ -906,7 +906,7 @@ external_proposal(CipherSuite suite,
                                { /* no authenticated data */ },
                                { proposal } };
   auto content_auth = AuthenticatedContent::sign(
-    WireFormat::mls_plaintext, std::move(content), suite, sig_priv, {});
+    WireFormat::mls_public_message, std::move(content), suite, sig_priv, {});
 
   return PublicMessage::protect(std::move(content_auth), suite, {}, {});
 }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -200,14 +200,14 @@ Session::Inner::import_handshake(const bytes& encoded) const
   auto msg = tls::get<MLSMessage>(encoded);
 
   switch (msg.wire_format()) {
-    case WireFormat::mls_plaintext:
+    case WireFormat::mls_public_message:
       if (encrypt_handshake) {
         throw ProtocolError("Handshake not encrypted as required");
       }
 
       return msg;
 
-    case WireFormat::mls_ciphertext: {
+    case WireFormat::mls_private_message: {
       if (!encrypt_handshake) {
         throw ProtocolError("Unexpected handshake encryption");
       }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -299,8 +299,8 @@ State::sign(const Sender& sender,
     _group_id, _epoch, sender, authenticated_data, { inner_content }
   };
 
-  auto wire_format =
-    (encrypt) ? WireFormat::mls_private_message : WireFormat::mls_public_message;
+  auto wire_format = (encrypt) ? WireFormat::mls_private_message
+                               : WireFormat::mls_public_message;
 
   auto content_auth = AuthenticatedContent::sign(
     wire_format, std::move(content), _suite, _identity_priv, group_context());
@@ -1421,10 +1421,11 @@ State::valid(const LeafNode& leaf_node,
   //
   // Note: Uniqueness of signature and encryption keys is assured by the
   // tree operations (add/update), so we do not need to verify those here.
-  const auto mutual_credential_support = _tree.all_leaves([&](auto /* i */, const auto& leaf) {
-    return leaf.capabilities.credential_supported(leaf_node.credential) &&
-      leaf_node.capabilities.credential_supported(leaf.credential);
-  });
+  const auto mutual_credential_support =
+    _tree.all_leaves([&](auto /* i */, const auto& leaf) {
+      return leaf.capabilities.credential_supported(leaf_node.credential) &&
+             leaf_node.capabilities.credential_supported(leaf.credential);
+    });
 
   // Verify that the extensions in the LeafNode are supported by checking that
   // the ID for each extension in the extensions field is listed in the

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -869,19 +869,19 @@ TreeKEMPublicKey::parent_hashes(
   const FilteredDirectPath& fdp,
   const std::vector<UpdatePathNode>& path_nodes) const
 {
+  // An empty filtered direct path indicates a one-member tree, since there's
+  // nobody else there to encrypt with.  In this special case, there's no
+  // parent hashing to be done.
+  if (fdp.empty()) {
+    return {};
+  }
+
   // The list of nodes for whom parent hashes are computed, namely: Direct path
   // excluding root, including leaf
   auto from_node = NodeIndex(from);
   auto dp = fdp;
-  if (!dp.empty()) {
-    // pop_back() on an empty list is undefined behavior
-    dp.pop_back();
-  }
-
-  if (from_node != NodeIndex::root(size)) {
-    // Handle the special case of a one-leaf tree
-    dp.insert(dp.begin(), { from_node, {} });
-  }
+  dp.pop_back();
+  dp.insert(dp.begin(), { from_node, {} });
 
   if (dp.size() != path_nodes.size()) {
     throw ProtocolError("Malformed UpdatePath");

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -382,7 +382,7 @@ TreeKEMPublicKey::TreeKEMPublicKey(CipherSuite suite_in)
 }
 
 LeafIndex
-TreeKEMPublicKey::add_leaf(const LeafNode& leaf)
+TreeKEMPublicKey::allocate_leaf()
 {
   // Find the leftmost blank leaf node
   auto index = LeafIndex(0);
@@ -391,7 +391,6 @@ TreeKEMPublicKey::add_leaf(const LeafNode& leaf)
   }
 
   // Extend the tree if necessary
-  auto ni = NodeIndex(index);
   if (index.val >= size.val) {
     if (size.val == 0) {
       size.val = 1;
@@ -402,11 +401,29 @@ TreeKEMPublicKey::add_leaf(const LeafNode& leaf)
     }
   }
 
+  return index;
+}
+
+LeafIndex
+TreeKEMPublicKey::add_leaf(const LeafNode& leaf)
+{
+  // Check that the leaf node's keys are not already present in the tree
+  if (exists_in_tree(leaf.encryption_key, std::nullopt)) {
+    throw InvalidParameterError("Duplicate encryption key");
+  }
+
+  if (exists_in_tree(leaf.signature_key, std::nullopt)) {
+    throw InvalidParameterError("Duplicate signature key");
+  }
+
+  // Allocate a blank leaf for this node
+  const auto index = allocate_leaf();
+
   // Set the leaf
   node_at(index).node = Node{ leaf };
 
   // Update the unmerged list
-  for (auto& n : ni.dirpath(size)) {
+  for (auto& n : NodeIndex(index).dirpath(size)) {
     if (!node_at(n).node) {
       continue;
     }
@@ -425,6 +442,16 @@ TreeKEMPublicKey::add_leaf(const LeafNode& leaf)
 void
 TreeKEMPublicKey::update_leaf(LeafIndex index, const LeafNode& leaf)
 {
+  // Check that the leaf node's keys are not already present in the tree, except
+  // for the signature key, which is allowed to repeat.
+  if (exists_in_tree(leaf.encryption_key, std::nullopt)) {
+    throw InvalidParameterError("Duplicate encryption key");
+  }
+
+  if (exists_in_tree(leaf.signature_key, index)) {
+    throw InvalidParameterError("Duplicate signature key");
+  }
+
   blank_path(index);
   node_at(NodeIndex(index)).node = Node{ leaf };
   clear_hash_path(index);
@@ -449,7 +476,7 @@ TreeKEMPublicKey::blank_path(LeafIndex index)
 void
 TreeKEMPublicKey::merge(LeafIndex from, const UpdatePath& path)
 {
-  node_at(from).node = Node{ path.leaf_node };
+  update_leaf(from, path.leaf_node);
 
   auto dp = filtered_direct_path(NodeIndex(from));
   if (dp.size() != path.nodes.size()) {
@@ -469,7 +496,6 @@ TreeKEMPublicKey::merge(LeafIndex from, const UpdatePath& path)
       path.nodes[i].public_key, parent_hash, {} } };
   }
 
-  clear_hash_path(from);
   set_hash_all();
 }
 
@@ -1009,6 +1035,24 @@ TreeKEMPublicKey::parent_hash_valid(LeafIndex from,
   }
 
   return leaf_ph && opt::get(leaf_ph) == hash_chain[0];
+}
+
+bool
+TreeKEMPublicKey::exists_in_tree(const HPKEPublicKey& key,
+                                 std::optional<LeafIndex> except) const
+{
+  return any_leaf([&](auto i, const auto& node) {
+    return i != except && node.encryption_key == key;
+  });
+}
+
+bool
+TreeKEMPublicKey::exists_in_tree(const SignaturePublicKey& key,
+                                 std::optional<LeafIndex> except) const
+{
+  return any_leaf([&](auto i, const auto& node) {
+    return i != except && node.signature_key == key;
+  });
 }
 
 tls::ostream&

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -98,23 +98,34 @@ protected:
 TEST_CASE_FIXTURE(MLSMessageTest, "AuthenticatedContent Sign/Verify")
 {
   // Verify that a sign / verify round-trip works
-  auto content_auth = AuthenticatedContent::sign(
-    WireFormat::mls_private_message, application_content, suite, sig_priv, context);
+  auto content_auth =
+    AuthenticatedContent::sign(WireFormat::mls_private_message,
+                               application_content,
+                               suite,
+                               sig_priv,
+                               context);
 
   REQUIRE(content_auth.verify(suite, sig_priv.public_key, context));
   REQUIRE(content_auth.content == application_content);
 
   // Verify that `mls_plaintext` is forbidden for ApplicationData
   // NOLINTNEXTLINE(llvm-else-after-return, readability-else-after-return)
-  REQUIRE_THROWS(AuthenticatedContent::sign(
-    WireFormat::mls_public_message, application_content, suite, sig_priv, context));
+  REQUIRE_THROWS(AuthenticatedContent::sign(WireFormat::mls_public_message,
+                                            application_content,
+                                            suite,
+                                            sig_priv,
+                                            context));
 }
 
 TEST_CASE_FIXTURE(MLSMessageTest, "PublicMessage Protect/Unprotect")
 {
   auto content = proposal_content;
-  auto content_auth_original = AuthenticatedContent::sign(
-    WireFormat::mls_public_message, std::move(content), suite, sig_priv, context);
+  auto content_auth_original =
+    AuthenticatedContent::sign(WireFormat::mls_public_message,
+                               std::move(content),
+                               suite,
+                               sig_priv,
+                               context);
 
   auto pt = PublicMessage::protect(
     content_auth_original, suite, membership_key, context);
@@ -125,8 +136,12 @@ TEST_CASE_FIXTURE(MLSMessageTest, "PublicMessage Protect/Unprotect")
 TEST_CASE_FIXTURE(MLSMessageTest, "PrivateMessage Protect/Unprotect")
 {
   auto content = proposal_content;
-  auto content_auth_original = AuthenticatedContent::sign(
-    WireFormat::mls_private_message, std::move(content), suite, sig_priv, context);
+  auto content_auth_original =
+    AuthenticatedContent::sign(WireFormat::mls_private_message,
+                               std::move(content),
+                               suite,
+                               sig_priv,
+                               context);
 
   auto ct = PrivateMessage::protect(
     content_auth_original, suite, keys, sender_data_secret, padding_size);

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -99,7 +99,7 @@ TEST_CASE_FIXTURE(MLSMessageTest, "AuthenticatedContent Sign/Verify")
 {
   // Verify that a sign / verify round-trip works
   auto content_auth = AuthenticatedContent::sign(
-    WireFormat::mls_ciphertext, application_content, suite, sig_priv, context);
+    WireFormat::mls_private_message, application_content, suite, sig_priv, context);
 
   REQUIRE(content_auth.verify(suite, sig_priv.public_key, context));
   REQUIRE(content_auth.content == application_content);
@@ -107,14 +107,14 @@ TEST_CASE_FIXTURE(MLSMessageTest, "AuthenticatedContent Sign/Verify")
   // Verify that `mls_plaintext` is forbidden for ApplicationData
   // NOLINTNEXTLINE(llvm-else-after-return, readability-else-after-return)
   REQUIRE_THROWS(AuthenticatedContent::sign(
-    WireFormat::mls_plaintext, application_content, suite, sig_priv, context));
+    WireFormat::mls_public_message, application_content, suite, sig_priv, context));
 }
 
 TEST_CASE_FIXTURE(MLSMessageTest, "PublicMessage Protect/Unprotect")
 {
   auto content = proposal_content;
   auto content_auth_original = AuthenticatedContent::sign(
-    WireFormat::mls_plaintext, std::move(content), suite, sig_priv, context);
+    WireFormat::mls_public_message, std::move(content), suite, sig_priv, context);
 
   auto pt = PublicMessage::protect(
     content_auth_original, suite, membership_key, context);
@@ -126,7 +126,7 @@ TEST_CASE_FIXTURE(MLSMessageTest, "PrivateMessage Protect/Unprotect")
 {
   auto content = proposal_content;
   auto content_auth_original = AuthenticatedContent::sign(
-    WireFormat::mls_ciphertext, std::move(content), suite, sig_priv, context);
+    WireFormat::mls_private_message, std::move(content), suite, sig_priv, context);
 
   auto ct = PrivateMessage::protect(
     content_auth_original, suite, keys, sender_data_secret, padding_size);

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -365,6 +365,63 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with PSK")
   REQUIRE(first1 == second0);
 }
 
+TEST_CASE_FIXTURE(StateTest, "Two Person with Replacement")
+{
+  // Initialize the creator's state
+  auto first0 = State{ group_id,
+                       suite,
+                       leaf_privs[0],
+                       identity_privs[0],
+                       key_packages[0].leaf_node,
+                       {} };
+
+  // Handle the Add proposal and create a Commit
+  const auto add1 = first0.add_proposal(key_packages[1]);
+  const auto [commit1, welcome1, first1_] =
+    first0.commit(fresh_secret(), CommitOpts{ { add1 }, true, false, {} }, {});
+  silence_unused(commit1);
+  auto first1 = first1_;
+
+  // Initialize the second participant from the Welcome
+  auto second1 = State{ init_privs[1],
+                        leaf_privs[1],
+                        identity_privs[1],
+                        key_packages[1],
+                        welcome1,
+                        std::nullopt,
+                        {} };
+  REQUIRE(first1 == second1);
+
+  // Create a new appearance of the first member
+  const auto [init_priv, leaf_priv, _identity_priv, key_package_] = make_client();
+  const auto identity_priv = identity_privs[0];
+  auto key_package = key_package_;
+  key_package.leaf_node.signature_key = identity_priv.public_key;
+  key_package.leaf_node.sign(suite, identity_priv, std::nullopt);
+  key_package.sign(identity_priv);
+
+  // Create a commit replacing the first member
+  const auto remove2 = second1.remove_proposal(LeafIndex{ 0 });
+  const auto add2 = second1.add_proposal(key_package);
+  const auto [commit2, welcome2, second2_] = second1.commit(fresh_secret(),
+      CommitOpts{ { add2, remove2 }, true, false, {} }, {});
+  auto second2 = second2_;
+  silence_unused(commit2);
+
+  // Initialize the new first member from the Welcome
+  const auto first2 = State{ init_priv,
+                        leaf_priv,
+                        identity_priv,
+                        key_package,
+                        welcome2,
+                        std::nullopt,
+                        {} };
+  REQUIRE(first2 == second2);
+
+  auto group = std::vector<State>{ first2, second2 };
+  verify_group_functionality(group);
+}
+
 TEST_CASE_FIXTURE(StateTest, "External Join")
 {
   // Initialize the creator's state

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -393,7 +393,8 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with Replacement")
   REQUIRE(first1 == second1);
 
   // Create a new appearance of the first member
-  const auto [init_priv, leaf_priv, _identity_priv, key_package_] = make_client();
+  const auto [init_priv, leaf_priv, _identity_priv, key_package_] =
+    make_client();
   const auto identity_priv = identity_privs[0];
   auto key_package = key_package_;
   key_package.leaf_node.signature_key = identity_priv.public_key;
@@ -403,19 +404,15 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with Replacement")
   // Create a commit replacing the first member
   const auto remove2 = second1.remove_proposal(LeafIndex{ 0 });
   const auto add2 = second1.add_proposal(key_package);
-  const auto [commit2, welcome2, second2_] = second1.commit(fresh_secret(),
-      CommitOpts{ { add2, remove2 }, true, false, {} }, {});
+  const auto [commit2, welcome2, second2_] = second1.commit(
+    fresh_secret(), CommitOpts{ { add2, remove2 }, true, false, {} }, {});
   auto second2 = second2_;
   silence_unused(commit2);
 
   // Initialize the new first member from the Welcome
-  const auto first2 = State{ init_priv,
-                        leaf_priv,
-                        identity_priv,
-                        key_package,
-                        welcome2,
-                        std::nullopt,
-                        {} };
+  const auto first2 =
+    State{ init_priv,    leaf_priv, identity_priv, key_package, welcome2,
+           std::nullopt, {} };
   REQUIRE(first2 == second2);
 
   auto group = std::vector<State>{ first2, second2 };

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -163,7 +163,8 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Public Key")
     REQUIRE(found_leaf == leaf_before);
 
     // Manually construct a direct path to populate nodes above the new leaf
-    const auto [_init_priv_after, sig_priv_after, leaf_after_] = new_leaf_node();
+    const auto [_init_priv_after, sig_priv_after, leaf_after_] =
+      new_leaf_node();
     const auto leaf_after = leaf_after_;
     auto path = UpdatePath{ leaf_after, {} };
     auto dp = pub.filtered_direct_path(NodeIndex(index));

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -69,9 +69,9 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Private Key")
   const auto hash_size = suite.digest().hash_size;
 
   // Create a tree with N blank leaves
-  auto [_leaf_priv, _sig_priv, leaf_node] = new_leaf_node();
   auto pub = TreeKEMPublicKey(suite);
   for (auto i = uint32_t(0); i < size.val; i++) {
+    auto [_leaf_priv, _sig_priv, leaf_node] = new_leaf_node();
     pub.add_leaf(leaf_node);
   }
 
@@ -144,9 +144,10 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Public Key")
   auto pub = TreeKEMPublicKey{ suite };
   for (uint32_t i = 0; i < size.val; i++) {
     // Add a leaf
-    auto [init_priv, sig_priv, leaf_before_] = new_leaf_node();
+    auto [_init_priv_before, _sig_priv_before, leaf_before_] = new_leaf_node();
     auto leaf_before = leaf_before_;
-    silence_unused(init_priv);
+    silence_unused(_init_priv_before);
+    silence_unused(_sig_priv_before);
 
     auto index = LeafIndex(i);
 
@@ -162,20 +163,22 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Public Key")
     REQUIRE(found_leaf == leaf_before);
 
     // Manually construct a direct path to populate nodes above the new leaf
-    auto path = UpdatePath{ leaf_before, {} };
+    const auto [_init_priv_after, sig_priv_after, leaf_after_] = new_leaf_node();
+    const auto leaf_after = leaf_after_;
+    auto path = UpdatePath{ leaf_after, {} };
     auto dp = pub.filtered_direct_path(NodeIndex(index));
     while (path.nodes.size() < dp.size()) {
       auto node_pub = HPKEPrivateKey::generate(suite).public_key;
       path.nodes.push_back({ node_pub, {} });
     }
 
-    path.leaf_node.sign(suite, sig_priv, std::nullopt);
+    path.leaf_node.sign(suite, sig_priv_after, std::nullopt);
 
     // Merge the direct path (ignoring parent hash validity)
     pub.merge(index, path);
 
-    auto leaf_after = path.leaf_node;
-    found = pub.find(leaf_after);
+    const auto& re_signed_leaf = path.leaf_node;
+    found = pub.find(re_signed_leaf);
     REQUIRE(found);
     REQUIRE(found == index);
     for (const auto& [n_, _res] : dp) {
@@ -185,7 +188,7 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Public Key")
 
     found_leaf = pub.leaf_node(index);
     REQUIRE(found_leaf);
-    REQUIRE(found_leaf == leaf_after);
+    REQUIRE(found_leaf == re_signed_leaf);
   }
 
   // Remove a node and verify that the resolution comes out right
@@ -237,7 +240,6 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM encap/decap")
     auto ok = ok_;
     REQUIRE(ok);
 
-    pubs[i].merge(adder, path);
     REQUIRE(privs[i].consistent(pubs[i]));
 
     // New joiner initializes their private key


### PR DESCRIPTION
This PR makes a few changes

* Aligns the WireFormat enum value names to the RFC
* Updates parent hash computation to properly handle the case when there is only one member in the tree, but the member is not in leaf 0
* Move key uniqueness checking to TreeKEMPublicKey, and remove those checks from proposal validation.