### PR TITLE
adding vcpkg as a submodule to speed up CI

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -153,12 +153,12 @@ jobs:
         git -C ${{ env.VCPKG_REPO }} rev-parse HEAD > vcpkg_commit.txt
 
     - name: Set Deployment Target
-      if: ${{ matrix.os == 'macos-latest' && matrix.deployment_target > 0 }}
+      if: ${{ startsWith(matrix.os, 'macos') && matrix.deployment_target > 0 }}
       run: |
         echo "MACOSX_DEPLOYMENT_TARGET=${{ matrix.deployment_target }}" >> $GITHUB_ENV
 
     - name: Dependencies (macOs)
-      if: ${{ matrix.os == 'macos-latest' }}
+      if: ${{ startsWith(matrix.os, 'macos') }}
       run: |
         brew install llvm pkg-config
         ln -s "/usr/local/opt/llvm/bin/clang-format" "/usr/local/bin/clang-format"

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -29,7 +29,7 @@ jobs:
           - 'cmd'
           - 'lib'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Run clang-format style check for C/C++ programs
       uses: jidicula/clang-format-action@v4.11.0
@@ -43,22 +43,42 @@ jobs:
     name: Quick Linux Check and Interop
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+
+    # check out the repository with recursively pulling the submodules
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    # write the commit hash of vcpkg to a text file so we can use it in the
+    # hashFiles for cache
+    - run: |
+        git -C vcpkg rev-parse HEAD > vcpkg-commit.txt
 
     - name: Dependencies (Ubuntu)
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         sudo apt-get install -y linux-headers-$(uname -r)
 
-    - name: Restore cache
+    # First, attempt to pull key key, if that is not present, pull one of the
+    # restore-keys so we do not need to build from scratch.
+    # VCPKG-BinaryCache - description of cache
+    # v1 - provide a way to reset cache
+    # matrix.os - cache per OS and version
+    # hashFiles - Recache if the vcpkg files change
+    - name: Restore Cache
       uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/build/cache
-        key: VCPKG-BinaryCache-${{ runner.os }}
+        key: VCPKG-BinaryCache-ubuntu-latest-v1-${{ hashFiles('vcpkg-commit.txt', 'vcpkg.json', 'alternatives/openssl_3/vcpkg.json') }}
+        restore-keys: |
+          VCPKG-BinaryCache-ubuntu-latest-v1
+          VCPKG-BinaryCache-ubuntu-latest
 
     - name: Build (OpenSSL 1.1)
       run: |
-        cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DTESTING=ON -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+        cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DTESTING=ON -DCMAKE_TOOLCHAIN_FILE="vcpkg/scripts/buildsystems/vcpkg.cmake"
         cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target all --parallel 2
 
     - name: Unit Test (OpenSSL 1.1)
@@ -68,7 +88,7 @@ jobs:
     - name: Build (Interop Harness)
       run: |
         cd cmd/interop
-        cmake -B build -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+        cmake -B build -DCMAKE_TOOLCHAIN_FILE="../../vcpkg/scripts/buildsystems/vcpkg.cmake"
         cmake --build build
 
     - name: Test self-interop
@@ -86,13 +106,17 @@ jobs:
         
     - name: Build (OpenSSL 3)
       run: |
-        cmake -B "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" -DTESTING=ON -DVCPKG_MANIFEST_DIR="alternatives/openssl_3" -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+        cmake -B "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" -DTESTING=ON -DVCPKG_MANIFEST_DIR="alternatives/openssl_3" -DCMAKE_TOOLCHAIN_FILE="vcpkg/scripts/buildsystems/vcpkg.cmake"
         cmake --build "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}"
 
     - name: Unit Test (OpenSSL 3)
       run: |
         cmake --build "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" --target test
 
+  # recently, the oldest supported macos image was added to this matrix. This is
+  # to ensure backward compatibility on existing integrations.  The goal is to
+  # have the newest and oldest OS's represented for macOs. Only using latest
+  # windows and linux images because they have not been an challenge.
   platform-sanitizer-tests:
     if: github.event.pull_request.draft == false
     needs: quick-linux-interop-check
@@ -101,23 +125,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest, macos-11]
         include:
-            - os: windows-latest
-              vcpkg-cmake-file: "$env:VCPKG_INSTALLATION_ROOT\\scripts\\buildsystems\\vcpkg.cmake"
-              ossl3-vcpkg-dir: "alternatives\\openssl_3"
-              ctest-target: RUN_TESTS
-            - os: ubuntu-latest
-              vcpkg-cmake-file: "$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
-              ossl3-vcpkg-dir: "alternatives/openssl_3"
-              ctest-target: test
-            - os: macos-latest
-              vcpkg-cmake-file: "$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
-              ossl3-vcpkg-dir: "alternatives/openssl_3"
-              ctest-target: test
+          - os: windows-latest
+            vcpkg-cmake-file: "vcpkg\\scripts\\buildsystems\\vcpkg.cmake"
+            ossl3-vcpkg-dir: "alternatives\\openssl_3"
+            ctest-target: RUN_TESTS
+          - os: ubuntu-latest
+            vcpkg-cmake-file: "vcpkg/scripts/buildsystems/vcpkg.cmake"
+            ossl3-vcpkg-dir: "alternatives/openssl_3"
+            ctest-target: test
+          - os: macos-latest
+            vcpkg-cmake-file: "vcpkg/scripts/buildsystems/vcpkg.cmake"
+            ossl3-vcpkg-dir: "alternatives/openssl_3"
+            ctest-target: test
+          - os: macos-11
+            vcpkg-cmake-file: "vcpkg/scripts/buildsystems/vcpkg.cmake"
+            ossl3-vcpkg-dir: "alternatives/openssl_3"
+            ctest-target: test
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    # write the commit hash of vcpkg to a text file so we can use it in the
+    # hashFiles for cache
+    - run: |
+        git -C vcpkg rev-parse HEAD > vcpkg-commit.txt
 
     - name: Dependencies (macOs)
       if: ${{ matrix.os == 'macos-latest' }}
@@ -131,11 +168,14 @@ jobs:
       run: |
         sudo apt-get install -y linux-headers-$(uname -r)
 
-    - name: Restore cache
+    - name: Restore Cache
       uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/build/cache
-        key: VCPKG-BinaryCache-${{ runner.os }}
+        key: VCPKG-BinaryCache-${{ matrix.os }}-v1-${{ hashFiles('vcpkg-commit.txt', 'vcpkg.json', 'alternatives/openssl_3/vcpkg.json') }}
+        restore-keys: |
+          VCPKG-BinaryCache-${{ matrix.os }}-v1
+          VCPKG-BinaryCache-${{ matrix.os }}
 
     - name: Build (OpenSSL1.1)
       run: |
@@ -154,36 +194,3 @@ jobs:
     - name: Unit Test (OpenSSL3)
       run: |
         cmake --build "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" --target "${{ matrix.ctest-target}}"
-
-  old-macos-compatibility:
-    if: github.event.pull_request.draft == false
-    needs: quick-linux-interop-check
-    name: Build for older MacOS
-    runs-on: macos-latest
-
-    env:
-        CMAKE_BUILD_DIR: ${{ github.workspace }}/build
-        TOOLCHAIN_FILE: $VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake
-        VCPKG_BINARY_SOURCES: files,${{ github.workspace }}/build/cache,readwrite
-        MACOSX_DEPLOYMENT_TARGET: 10.11
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: dependencies
-      run: |
-        brew install llvm pkg-config
-        ln -s "/usr/local/opt/llvm/bin/clang-format" "/usr/local/bin/clang-format"
-        ln -s "/usr/local/opt/llvm/bin/clang-tidy" "/usr/local/bin/clang-tidy"
-
-    - name: Restore cache
-      uses: actions/cache@v3
-      with:
-        path: ${{ github.workspace }}/build/cache
-        key: VCPKG-BinaryCache-${{ runner.os }}
-
-    - name: Build
-      run: |
-        cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}"
-        cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target mlspp --parallel 2
-

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -162,8 +162,8 @@ jobs:
       if: ${{ startsWith(matrix.os, 'macos') }}
       run: |
         brew install llvm@14 pkg-config
-        ln -s "/usr/local/opt/llvm/bin/clang-format" "/usr/local/bin/clang-format"
-        ln -s "/usr/local/opt/llvm/bin/clang-tidy" "/usr/local/bin/clang-tidy"
+        ln -s "/usr/local/opt/llvm@14/bin/clang-format" "/usr/local/bin/clang-format"
+        ln -s "/usr/local/opt/llvm@14/bin/clang-tidy" "/usr/local/bin/clang-tidy"
 
     - name: Dependencies (Ubuntu)
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -184,12 +184,12 @@ jobs:
         cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DTESTING=ON -DCLANG_TIDY=ON -DSANITIZERS=ON -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}"
         cmake --build "${{ env.CMAKE_BUILD_DIR }}" --parallel 2
 
-    - name: Unit Test (OpenSSL1.1)
+    - name: Unit Test (OpenSSL1.1) (Windows)
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
         cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target "${{ env.WINDOWS_CTEST_TARGET }}"
 
-    - name: Unit Test (OpenSSL1.1)
+    - name: Unit Test (OpenSSL1.1) (Non-Windows)
       if: ${{ matrix.os != 'windows-latest' }}
       run: |
         cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target "${{ env.DEFAULT_CTEST_TARGET }}"
@@ -199,12 +199,12 @@ jobs:
         cmake -B "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" -DTESTING=ON -DCLANG_TIDY=ON -DSANITIZERS=ON -DVCPKG_MANIFEST_DIR="${{ env.OPENSSL3_MANIFEST_DIR }}" -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}"
         cmake --build "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}"
 
-    - name: Unit Test (OpenSSL3)
+    - name: Unit Test (OpenSSL3) (Windows)
       if: ${{ matrix.os == 'windows-latest' }}
       run: |
         cmake --build "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" --target "${{ env.WINDOWS_CTEST_TARGET }}"
 
-    - name: Unit Test (OpenSSL3)
+    - name: Unit Test (OpenSSL3) (Non-Windows)
       if: ${{ matrix.os != 'windows-latest' }}
       run: |
         cmake --build "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" --target "${{ env.DEFAULT_CTEST_TARGET }}"

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -134,10 +134,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-13]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         deployment_target: [0]
         include:
-          - os: macos-13
+          - os: macos-latest
             deployment_target: 10.11
 
     steps:

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -157,10 +157,11 @@ jobs:
       run: |
         echo "MACOSX_DEPLOYMENT_TARGET=${{ matrix.deployment_target }}" >> $GITHUB_ENV
 
+    # Because Homebrew promotes versions regularly this will locking llvm at 14
     - name: Dependencies (macOs)
       if: ${{ startsWith(matrix.os, 'macos') }}
       run: |
-        brew install llvm pkg-config
+        brew install llvm@14 pkg-config
         ln -s "/usr/local/opt/llvm/bin/clang-format" "/usr/local/bin/clang-format"
         ln -s "/usr/local/opt/llvm/bin/clang-tidy" "/usr/local/bin/clang-tidy"
 

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -11,10 +11,17 @@ on:
 env:
   CTEST_OUTPUT_ON_FAILURE: 1
   CMAKE_BUILD_DIR: ${{ github.workspace }}/build
+  CMAKE_TEST_DIR: ${{ github.workspace }}/build/test
   CMAKE_BUILD_OPENSSL3_DIR: ${{ github.workspace }}/build_openssl3
   CMAKE_TEST_OPENSSL3_DIR: ${{ github.workspace }}/build_openssl3/test
-  CMAKE_TEST_DIR: ${{ github.workspace }}/build/test
   VCPKG_BINARY_SOURCES: files,${{ github.workspace }}/build/cache,readwrite
+  TOOLCHAIN_FILE: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+  OPENSSL3_MANIFEST_DIR: ${{ github.workspace }}/alternatives/openssl_3
+  DEFAULT_VCPKG_CONFIG: ${{ github.workspace }}/vcpkg.json
+  OPENSSL3_VCPKG_CONFIG: ${{ github.workspace }}/alternatives/openssl_3/vcpkg.json
+  VCPKG_REPO: ${{ github.workspace }}/vcpkg
+  DEFAULT_CTEST_TARGET: test
+  WINDOWS_CTEST_TARGET: RUN_TESTS
 
 jobs:
   formatting-check:
@@ -42,9 +49,10 @@ jobs:
     needs: formatting-check
     name: Quick Linux Check and Interop
     runs-on: ubuntu-latest
+
     steps:
 
-    # check out the repository with recursively pulling the submodules
+    # check out the repository recursively pulling the submodules
     - name: Checkout repository and submodules
       uses: actions/checkout@v4
       with:
@@ -54,7 +62,7 @@ jobs:
     # write the commit hash of vcpkg to a text file so we can use it in the
     # hashFiles for cache
     - run: |
-        git -C vcpkg rev-parse HEAD > vcpkg-commit.txt
+        git -C ${{ env.VCPKG_REPO }} rev-parse HEAD > vcpkg_commit.txt
 
     - name: Dependencies (Ubuntu)
       if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -71,14 +79,15 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/build/cache
-        key: VCPKG-BinaryCache-ubuntu-latest-v1-${{ hashFiles('vcpkg-commit.txt', 'vcpkg.json', 'alternatives/openssl_3/vcpkg.json') }}
+        key: VCPKG-BinaryCache-ubuntu-latest-0-v1-${{ hashFiles('vcpkg_commit.txt', 'vcpkg.json', 'alternatives/openssl_3/vcpkg.json') }}
         restore-keys: |
-          VCPKG-BinaryCache-ubuntu-latest-v1
+          VCPKG-BinaryCache-ubuntu-latest-0-v1
+          VCPKG-BinaryCache-ubuntu-latest-0
           VCPKG-BinaryCache-ubuntu-latest
 
     - name: Build (OpenSSL 1.1)
       run: |
-        cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DTESTING=ON -DCMAKE_TOOLCHAIN_FILE="vcpkg/scripts/buildsystems/vcpkg.cmake"
+        cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DTESTING=ON -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}"
         cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target all --parallel 2
 
     - name: Unit Test (OpenSSL 1.1)
@@ -88,7 +97,7 @@ jobs:
     - name: Build (Interop Harness)
       run: |
         cd cmd/interop
-        cmake -B build -DCMAKE_TOOLCHAIN_FILE="../../vcpkg/scripts/buildsystems/vcpkg.cmake"
+        cmake -B build -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}"
         cmake --build build
 
     - name: Test self-interop
@@ -106,7 +115,7 @@ jobs:
         
     - name: Build (OpenSSL 3)
       run: |
-        cmake -B "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" -DTESTING=ON -DVCPKG_MANIFEST_DIR="alternatives/openssl_3" -DCMAKE_TOOLCHAIN_FILE="vcpkg/scripts/buildsystems/vcpkg.cmake"
+        cmake -B "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" -DTESTING=ON -DVCPKG_MANIFEST_DIR="${{ env.OPENSSL3_MANIFEST_DIR }}" -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}"
         cmake --build "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}"
 
     - name: Unit Test (OpenSSL 3)
@@ -125,24 +134,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest, macos-11]
+        os: [windows-latest, ubuntu-latest, macos-13]
+        deployment_target: [0]
         include:
-          - os: windows-latest
-            vcpkg-cmake-file: "vcpkg\\scripts\\buildsystems\\vcpkg.cmake"
-            ossl3-vcpkg-dir: "alternatives\\openssl_3"
-            ctest-target: RUN_TESTS
-          - os: ubuntu-latest
-            vcpkg-cmake-file: "vcpkg/scripts/buildsystems/vcpkg.cmake"
-            ossl3-vcpkg-dir: "alternatives/openssl_3"
-            ctest-target: test
-          - os: macos-latest
-            vcpkg-cmake-file: "vcpkg/scripts/buildsystems/vcpkg.cmake"
-            ossl3-vcpkg-dir: "alternatives/openssl_3"
-            ctest-target: test
-          - os: macos-11
-            vcpkg-cmake-file: "vcpkg/scripts/buildsystems/vcpkg.cmake"
-            ossl3-vcpkg-dir: "alternatives/openssl_3"
-            ctest-target: test
+          - os: macos-13
+            deployment_target: 10.11
 
     steps:
     - name: Checkout repository and submodules
@@ -154,7 +150,12 @@ jobs:
     # write the commit hash of vcpkg to a text file so we can use it in the
     # hashFiles for cache
     - run: |
-        git -C vcpkg rev-parse HEAD > vcpkg-commit.txt
+        git -C ${{ env.VCPKG_REPO }} rev-parse HEAD > vcpkg_commit.txt
+
+    - name: Set Deployment Target
+      if: ${{ matrix.os == 'macos-latest' && matrix.deployment_target > 0 }}
+      run: |
+        echo "MACOSX_DEPLOYMENT_TARGET=${{ matrix.deployment_target }}" >> $GITHUB_ENV
 
     - name: Dependencies (macOs)
       if: ${{ matrix.os == 'macos-latest' }}
@@ -172,25 +173,38 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ github.workspace }}/build/cache
-        key: VCPKG-BinaryCache-${{ matrix.os }}-v1-${{ hashFiles('vcpkg-commit.txt', 'vcpkg.json', 'alternatives/openssl_3/vcpkg.json') }}
+        key: VCPKG-BinaryCache-${{ matrix.os }}-${{ matrix.deployment_target }}-v1-${{ hashFiles('vcpkg_commit.txt', 'vcpkg.json', 'alternatives/openssl_3/vcpkg.json') }}
         restore-keys: |
-          VCPKG-BinaryCache-${{ matrix.os }}-v1
+          VCPKG-BinaryCache-${{ matrix.os }}-${{ matrix.deployment_target }}-v1
+          VCPKG-BinaryCache-${{ matrix.os }}-${{ matrix.deployment_target }}
           VCPKG-BinaryCache-${{ matrix.os }}
 
     - name: Build (OpenSSL1.1)
       run: |
-        cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DTESTING=ON -DCLANG_TIDY=ON -DSANITIZERS=ON -DCMAKE_TOOLCHAIN_FILE="${{ matrix.vcpkg-cmake-file}}"
+        cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DTESTING=ON -DCLANG_TIDY=ON -DSANITIZERS=ON -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}"
         cmake --build "${{ env.CMAKE_BUILD_DIR }}" --parallel 2
 
     - name: Unit Test (OpenSSL1.1)
+      if: ${{ matrix.os == 'windows-latest' }}
       run: |
-        cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target "${{ matrix.ctest-target}}"
+        cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target "${{ env.WINDOWS_CTEST_TARGET }}"
+
+    - name: Unit Test (OpenSSL1.1)
+      if: ${{ matrix.os != 'windows-latest' }}
+      run: |
+        cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target "${{ env.DEFAULT_CTEST_TARGET }}"
 
     - name: Build (OpenSSL3)
       run: |
-        cmake -B "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" -DTESTING=ON -DCLANG_TIDY=ON -DSANITIZERS=ON -DVCPKG_MANIFEST_DIR="${{ matrix.ossl3-vcpkg-dir }}" -DCMAKE_TOOLCHAIN_FILE="${{ matrix.vcpkg-cmake-file}}"
+        cmake -B "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" -DTESTING=ON -DCLANG_TIDY=ON -DSANITIZERS=ON -DVCPKG_MANIFEST_DIR="${{ env.OPENSSL3_MANIFEST_DIR }}" -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}"
         cmake --build "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}"
 
     - name: Unit Test (OpenSSL3)
+      if: ${{ matrix.os == 'windows-latest' }}
       run: |
-        cmake --build "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" --target "${{ matrix.ctest-target}}"
+        cmake --build "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" --target "${{ env.WINDOWS_CTEST_TARGET }}"
+
+    - name: Unit Test (OpenSSL3)
+      if: ${{ matrix.os != 'windows-latest' }}
+      run: |
+        cmake --build "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" --target "${{ env.DEFAULT_CTEST_TARGET }}"

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Build (OpenSSL 1.1)
       run: |
         cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DTESTING=ON -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}"
-        cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target all --parallel 2
+        cmake --build "${{ env.CMAKE_BUILD_DIR }}" --target all --parallel 3
 
     - name: Unit Test (OpenSSL 1.1)
       run: |
@@ -98,7 +98,7 @@ jobs:
       run: |
         cd cmd/interop
         cmake -B build -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}"
-        cmake --build build
+        cmake --build build --parallel 3
 
     - name: Test self-interop
       run: |
@@ -116,7 +116,7 @@ jobs:
     - name: Build (OpenSSL 3)
       run: |
         cmake -B "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" -DTESTING=ON -DVCPKG_MANIFEST_DIR="${{ env.OPENSSL3_MANIFEST_DIR }}" -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}"
-        cmake --build "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}"
+        cmake --build "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" --parallel 3
 
     - name: Unit Test (OpenSSL 3)
       run: |
@@ -182,7 +182,7 @@ jobs:
     - name: Build (OpenSSL1.1)
       run: |
         cmake -B "${{ env.CMAKE_BUILD_DIR }}" -DTESTING=ON -DCLANG_TIDY=ON -DSANITIZERS=ON -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}"
-        cmake --build "${{ env.CMAKE_BUILD_DIR }}" --parallel 2
+        cmake --build "${{ env.CMAKE_BUILD_DIR }}" --parallel 3
 
     - name: Unit Test (OpenSSL1.1) (Windows)
       if: ${{ matrix.os == 'windows-latest' }}
@@ -197,7 +197,7 @@ jobs:
     - name: Build (OpenSSL3)
       run: |
         cmake -B "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" -DTESTING=ON -DCLANG_TIDY=ON -DSANITIZERS=ON -DVCPKG_MANIFEST_DIR="${{ env.OPENSSL3_MANIFEST_DIR }}" -DCMAKE_TOOLCHAIN_FILE="${{ env.TOOLCHAIN_FILE }}"
-        cmake --build "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}"
+        cmake --build "${{ env.CMAKE_BUILD_OPENSSL3_DIR }}" --parallel 3
 
     - name: Unit Test (OpenSSL3) (Windows)
       if: ${{ matrix.os == 'windows-latest' }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vcpkg"]
+  path = vcpkg
+  url = https://github.com/microsoft/vcpkg.git

--- a/Makefile
+++ b/Makefile
@@ -19,21 +19,20 @@ all: ${BUILD_DIR}
 ${BUILD_DIR}: CMakeLists.txt test/CMakeLists.txt
 	cmake -B${BUILD_DIR} .
 
-vcpkg:
+${TOOLCHAIN_FILE}:
 	git submodule update --init --recursive
 
-dev:
+dev: ${TOOLCHAIN_FILE}
 	# Only enable testing, not clang-tidy/sanitizers; the latter make the build
 	# too slow, and we can run them in CI
-	cmake -B${BUILD_DIR} -DTESTING=ON -DCMAKE_BUILD_TYPE=Debug .
+	cmake -B${BUILD_DIR} -DTESTING=ON -DCMAKE_BUILD_TYPE=Debug \
+		-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}
 
-vcpkg-dev: vcpkg
-	# Like `dev`, but retrieve dependencies using vcpkg
-	cmake -B${BUILD_DIR} -DTESTING=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}
-
-dev3: vcpkg
+dev3: ${TOOLCHAIN_FILE}
 	# Like `dev`, but using OpenSSL 3
-	cmake -B${BUILD_DIR} -DTESTING=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} -DVCPKG_MANIFEST_DIR=${OPENSSL3_MANIFEST} .
+	cmake -B${BUILD_DIR} -DTESTING=ON -DCMAKE_BUILD_TYPE=Debug \
+		-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} \
+		-DVCPKG_MANIFEST_DIR=${OPENSSL3_MANIFEST}
 
 test: ${BUILD_DIR} test/*
 	cmake --build ${BUILD_DIR} --target mlspp_test
@@ -64,14 +63,16 @@ test-all: test-libs ctest
 everything: ${BUILD_DIR}
 	cmake --build ${BUILD_DIR}
 
-ci:
+ci: ${TOOLCHAIN_FILE}
 	cmake -B ${BUILD_DIR} -DTESTING=ON -DCLANG_TIDY=ON -DSANITIZERS=ON \
-		-DCMAKE_BUILD_TYPE=Debug .
+		-DCMAKE_BUILD_TYPE=Debug \
+		-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}
 
-ci3:
+ci3: ${TOOLCHAIN_FILE}
 	# Like `ci`, but using OpenSSL 3
 	cmake -B ${BUILD_DIR} -DTESTING=ON -DCLANG_TIDY=ON -DSANITIZERS=ON \
-		-DCMAKE_BUILD_TYPE=Debug -DVCPKG_MANIFEST_DIR=${OPENSSL3_MANIFEST} .
+		-DCMAKE_BUILD_TYPE=Debug  \
+		-DVCPKG_MANIFEST_DIR=${OPENSSL3_MANIFEST}
 
 clean:
 	cmake --build ${BUILD_DIR} --target clean


### PR DESCRIPTION
This PR will do two things:

1. Adds vcpkg as a submodule will help us to lock in the version of our dependencies requiring us to never build new dependencies. This is a step in minimizing the changes that require to recapture cache.
2. Reworked the cache key to minimize dependencies rebuilds by using an older cache to prime the new cache.  i.e.  if the vcpkg.json changes, it will use recent relevant cache to start rebuilding a new cache.  (Changes to one of the two vcpkg.json will cause a new cache to be created)