### PR TITLE
provide the user access to the credentialSubject via UserInfoClaims structure

### DIFF
--- a/lib/hpke/include/hpke/userinfo_vc.h
+++ b/lib/hpke/include/hpke/userinfo_vc.h
@@ -11,6 +11,71 @@ using namespace MLS_NAMESPACE::bytes_ns;
 
 namespace MLS_NAMESPACE::hpke {
 
+struct UserInfoClaims
+{
+  static inline const std::string name_attr = "name";
+  static inline const std::string sub_attr = "sub";
+  static inline const std::string given_name_attr = "given_name";
+  static inline const std::string family_name_attr = "family_name";
+  static inline const std::string middle_name_attr = "middle_name";
+  static inline const std::string nickname_attr = "nickname";
+  static inline const std::string preferred_username_attr =
+    "preferred_username";
+  static inline const std::string profile_attr = "profile";
+  static inline const std::string picture_attr = "picture";
+  static inline const std::string website_attr = "website";
+  static inline const std::string email_attr = "email";
+  static inline const std::string email_verified_attr = "email_verified";
+  static inline const std::string gender_attr = "gender";
+  static inline const std::string birthdate_attr = "birthdate";
+  static inline const std::string zoneinfo_attr = "zoneinfo";
+  static inline const std::string locale_attr = "locale";
+  static inline const std::string phone_number_attr = "phone_number";
+  static inline const std::string phone_number_verified_attr =
+    "phone_number_verified";
+  static inline const std::string address_attr = "address";
+  static inline const std::string address_formatted_attr = "formatted";
+  static inline const std::string address_street_address_attr =
+    "street_address";
+  static inline const std::string address_locality_attr = "locality";
+  static inline const std::string address_region_attr = "region";
+  static inline const std::string address_postal_code_attr = "postal_code";
+  static inline const std::string address_country_attr = "country";
+  static inline const std::string updated_at_attr = "updated_at";
+
+  std::string sub;
+  std::string name;
+  std::string given_name;
+  std::string family_name;
+  std::string middle_name;
+  std::string nickname;
+  std::string preferred_username;
+  std::string profile;
+  std::string picture;
+  std::string website;
+  std::string email;
+  bool email_verified;
+  std::string gender;
+  std::string birthdate;
+  std::string zoneinfo;
+  std::string locale;
+  std::string phone_number;
+  bool phone_number_verified;
+  std::string address_formatted;
+  std::string address_street_address;
+  std::string address_locality;
+  std::string address_region;
+  std::string address_postal_code;
+  std::string address_country;
+  uint64_t updated_at;
+
+  // UserInfoClaims() = default;
+  // ~UserInfoClaims() = default;
+
+  static std::shared_ptr<UserInfoClaims> from_json(
+    const std::string& cred_subject);
+};
+
 struct UserInfoVC
 {
 private:
@@ -29,7 +94,7 @@ public:
   std::string key_id() const;
   std::chrono::system_clock::time_point not_before() const;
   std::chrono::system_clock::time_point not_after() const;
-  std::map<std::string, std::string> subject() const;
+  std::shared_ptr<UserInfoClaims> subject() const;
   const Signature::PublicJWK& public_key() const;
 
   bool valid_from(const Signature::PublicKey& issuer_key) const;

--- a/lib/hpke/include/hpke/userinfo_vc.h
+++ b/lib/hpke/include/hpke/userinfo_vc.h
@@ -6,74 +6,49 @@
 #include <chrono>
 #include <hpke/signature.h>
 #include <map>
+#include <nlohmann/json.hpp>
 
 using namespace MLS_NAMESPACE::bytes_ns;
 
 namespace MLS_NAMESPACE::hpke {
 
+struct UserInfoClaimsAddress
+{
+  std::optional<std::string> formatted;
+  std::optional<std::string> street_address;
+  std::optional<std::string> locality;
+  std::optional<std::string> region;
+  std::optional<std::string> postal_code;
+  std::optional<std::string> country;
+
+  static UserInfoClaimsAddress from_json(const nlohmann::json& address_json);
+};
+
 struct UserInfoClaims
 {
-  static inline const std::string name_attr = "name";
-  static inline const std::string sub_attr = "sub";
-  static inline const std::string given_name_attr = "given_name";
-  static inline const std::string family_name_attr = "family_name";
-  static inline const std::string middle_name_attr = "middle_name";
-  static inline const std::string nickname_attr = "nickname";
-  static inline const std::string preferred_username_attr =
-    "preferred_username";
-  static inline const std::string profile_attr = "profile";
-  static inline const std::string picture_attr = "picture";
-  static inline const std::string website_attr = "website";
-  static inline const std::string email_attr = "email";
-  static inline const std::string email_verified_attr = "email_verified";
-  static inline const std::string gender_attr = "gender";
-  static inline const std::string birthdate_attr = "birthdate";
-  static inline const std::string zoneinfo_attr = "zoneinfo";
-  static inline const std::string locale_attr = "locale";
-  static inline const std::string phone_number_attr = "phone_number";
-  static inline const std::string phone_number_verified_attr =
-    "phone_number_verified";
-  static inline const std::string address_attr = "address";
-  static inline const std::string address_formatted_attr = "formatted";
-  static inline const std::string address_street_address_attr =
-    "street_address";
-  static inline const std::string address_locality_attr = "locality";
-  static inline const std::string address_region_attr = "region";
-  static inline const std::string address_postal_code_attr = "postal_code";
-  static inline const std::string address_country_attr = "country";
-  static inline const std::string updated_at_attr = "updated_at";
 
-  std::string sub;
-  std::string name;
-  std::string given_name;
-  std::string family_name;
-  std::string middle_name;
-  std::string nickname;
-  std::string preferred_username;
-  std::string profile;
-  std::string picture;
-  std::string website;
-  std::string email;
-  bool email_verified;
-  std::string gender;
-  std::string birthdate;
-  std::string zoneinfo;
-  std::string locale;
-  std::string phone_number;
-  bool phone_number_verified;
-  std::string address_formatted;
-  std::string address_street_address;
-  std::string address_locality;
-  std::string address_region;
-  std::string address_postal_code;
-  std::string address_country;
-  uint64_t updated_at;
+  std::optional<std::string> sub;
+  std::optional<std::string> name;
+  std::optional<std::string> given_name;
+  std::optional<std::string> family_name;
+  std::optional<std::string> middle_name;
+  std::optional<std::string> nickname;
+  std::optional<std::string> preferred_username;
+  std::optional<std::string> profile;
+  std::optional<std::string> picture;
+  std::optional<std::string> website;
+  std::optional<std::string> email;
+  std::optional<bool> email_verified;
+  std::optional<std::string> gender;
+  std::optional<std::string> birthdate;
+  std::optional<std::string> zoneinfo;
+  std::optional<std::string> locale;
+  std::optional<std::string> phone_number;
+  std::optional<bool> phone_number_verified;
+  std::optional<UserInfoClaimsAddress> address;
+  std::optional<uint64_t> updated_at;
 
-  // UserInfoClaims() = default;
-  // ~UserInfoClaims() = default;
-
-  static std::shared_ptr<UserInfoClaims> from_json(
-    const std::string& cred_subject);
+  static UserInfoClaims from_json(const nlohmann::json& cred_subject_json);
 };
 
 struct UserInfoVC
@@ -94,7 +69,8 @@ public:
   std::string key_id() const;
   std::chrono::system_clock::time_point not_before() const;
   std::chrono::system_clock::time_point not_after() const;
-  std::shared_ptr<UserInfoClaims> subject() const;
+  const std::string& raw_credential() const;
+  const UserInfoClaims& subject() const;
   const Signature::PublicJWK& public_key() const;
 
   bool valid_from(const Signature::PublicKey& issuer_key) const;

--- a/lib/hpke/src/userinfo_vc.cpp
+++ b/lib/hpke/src/userinfo_vc.cpp
@@ -253,54 +253,39 @@ UserInfoClaims::from_json(const std::string& cred_subject)
 
   // create the UserInfoClaims object
   return std::make_shared<UserInfoClaims>(UserInfoClaims({
-    .sub = cred_subject_json.value<std::string>(UserInfoClaims::sub_attr, ""),
-    .name = cred_subject_json.value<std::string>(UserInfoClaims::name_attr, ""),
-    .given_name =
-      cred_subject_json.value<std::string>(UserInfoClaims::given_name_attr, ""),
-    .family_name = cred_subject_json.value<std::string>(
-      UserInfoClaims::family_name_attr, ""),
-    .middle_name = cred_subject_json.value<std::string>(
-      UserInfoClaims::middle_name_attr, ""),
-    .nickname =
-      cred_subject_json.value<std::string>(UserInfoClaims::nickname_attr, ""),
-    .preferred_username = cred_subject_json.value<std::string>(
+    cred_subject_json.value<std::string>(UserInfoClaims::sub_attr, ""),
+    cred_subject_json.value<std::string>(UserInfoClaims::name_attr, ""),
+    cred_subject_json.value<std::string>(UserInfoClaims::given_name_attr, ""),
+    cred_subject_json.value<std::string>(UserInfoClaims::family_name_attr, ""),
+    cred_subject_json.value<std::string>(UserInfoClaims::middle_name_attr, ""),
+    cred_subject_json.value<std::string>(UserInfoClaims::nickname_attr, ""),
+    cred_subject_json.value<std::string>(
       UserInfoClaims::preferred_username_attr, ""),
-    .profile =
-      cred_subject_json.value<std::string>(UserInfoClaims::profile_attr, ""),
-    .picture =
-      cred_subject_json.value<std::string>(UserInfoClaims::picture_attr, ""),
-    .website =
-      cred_subject_json.value<std::string>(UserInfoClaims::website_attr, ""),
-    .email =
-      cred_subject_json.value<std::string>(UserInfoClaims::email_attr, ""),
-    .email_verified =
-      cred_subject_json.value<bool>(UserInfoClaims::email_verified_attr, false),
-    .gender =
-      cred_subject_json.value<std::string>(UserInfoClaims::gender_attr, ""),
-    .birthdate =
-      cred_subject_json.value<std::string>(UserInfoClaims::birthdate_attr, ""),
-    .zoneinfo =
-      cred_subject_json.value<std::string>(UserInfoClaims::zoneinfo_attr, ""),
-    .locale =
-      cred_subject_json.value<std::string>(UserInfoClaims::locale_attr, ""),
-    .phone_number = cred_subject_json.value<std::string>(
-      UserInfoClaims::phone_number_attr, ""),
-    .phone_number_verified = cred_subject_json.value<bool>(
-      UserInfoClaims::phone_number_verified_attr, false),
-    .address_formatted = cred_subject_address_json.value<std::string>(
+    cred_subject_json.value<std::string>(UserInfoClaims::profile_attr, ""),
+    cred_subject_json.value<std::string>(UserInfoClaims::picture_attr, ""),
+    cred_subject_json.value<std::string>(UserInfoClaims::website_attr, ""),
+    cred_subject_json.value<std::string>(UserInfoClaims::email_attr, ""),
+    cred_subject_json.value<bool>(UserInfoClaims::email_verified_attr, false),
+    cred_subject_json.value<std::string>(UserInfoClaims::gender_attr, ""),
+    cred_subject_json.value<std::string>(UserInfoClaims::birthdate_attr, ""),
+    cred_subject_json.value<std::string>(UserInfoClaims::zoneinfo_attr, ""),
+    cred_subject_json.value<std::string>(UserInfoClaims::locale_attr, ""),
+    cred_subject_json.value<std::string>(UserInfoClaims::phone_number_attr, ""),
+    cred_subject_json.value<bool>(UserInfoClaims::phone_number_verified_attr,
+                                  false),
+    cred_subject_address_json.value<std::string>(
       UserInfoClaims::address_formatted_attr, ""),
-    .address_street_address = cred_subject_address_json.value<std::string>(
+    cred_subject_address_json.value<std::string>(
       UserInfoClaims::address_street_address_attr, ""),
-    .address_locality = cred_subject_address_json.value<std::string>(
+    cred_subject_address_json.value<std::string>(
       UserInfoClaims::address_locality_attr, ""),
-    .address_region = cred_subject_address_json.value<std::string>(
+    cred_subject_address_json.value<std::string>(
       UserInfoClaims::address_region_attr, ""),
-    .address_postal_code = cred_subject_address_json.value<std::string>(
+    cred_subject_address_json.value<std::string>(
       UserInfoClaims::address_postal_code_attr, ""),
-    .address_country = cred_subject_address_json.value<std::string>(
+    cred_subject_address_json.value<std::string>(
       UserInfoClaims::address_country_attr, ""),
-    .updated_at =
-      cred_subject_json.value<uint64_t>(UserInfoClaims::updated_at_attr, 0),
+    cred_subject_json.value<uint64_t>(UserInfoClaims::updated_at_attr, 0),
   }));
 }
 

--- a/lib/hpke/test/userinfo_vc.cpp
+++ b/lib/hpke/test/userinfo_vc.cpp
@@ -130,7 +130,7 @@ TEST_CASE("UserInfoVC Parsing and Validation")
   CHECK(vc.not_after().time_since_epoch() == known_not_after);
   CHECK(vc.public_key() == known_subject_jwk);
 
-  const auto subject = vc.subject();
+  const auto& subject = vc.subject();
   CHECK(subject.sub.value_or("") == known_subject.at("sub"));
 
   CHECK(vc.subject().name.value_or("") == known_subject.at("name"));


### PR DESCRIPTION
This PR will change the format of the credentialSubject from a map of string to a struct that contains the claims and defined in the specification.

https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims