### PR TITLE
Provide more flexible JWK parsing

### DIFF
--- a/include/mls/credential.h
+++ b/include/mls/credential.h
@@ -6,6 +6,10 @@
 
 namespace MLS_NAMESPACE {
 
+namespace hpke {
+  struct UserInfoVC;
+}
+
 // struct {
 //     opaque identity<0..2^16-1>;
 //     SignaturePublicKey public_key;
@@ -57,17 +61,20 @@ operator>>(tls::istream& str, X509Credential& obj);
 struct UserInfoVCCredential
 {
   UserInfoVCCredential() = default;
-  explicit UserInfoVCCredential(bytes userinfo_vc_jwt_in);
+  explicit UserInfoVCCredential(std::string userinfo_vc_jwt_in);
 
-  bytes userinfo_vc_jwt;
+  std::string userinfo_vc_jwt;
 
   bool valid_for(const SignaturePublicKey& pub) const;
+  bool valid_from(const PublicJWK& pub) const;
 
-  TLS_SERIALIZABLE(userinfo_vc_jwt)
+  friend tls::ostream operator<<(tls::ostream& str, const UserInfoVCCredential& obj);
+  friend tls::istream operator>>(tls::istream& str, UserInfoVCCredential& obj);
+  friend bool operator==(const UserInfoVCCredential& str, const UserInfoVCCredential& obj);
+  friend bool operator!=(const UserInfoVCCredential& str, const UserInfoVCCredential& obj);
 
 private:
-  SignaturePublicKey _public_key;
-  SignatureScheme _signature_scheme;
+  std::shared_ptr<hpke::UserInfoVC> _vc;
 };
 
 bool
@@ -149,7 +156,7 @@ struct Credential
 
   static Credential basic(const bytes& identity);
   static Credential x509(const std::vector<bytes>& der_chain);
-  static Credential userinfo_vc(const bytes& userinfo_vc_jwt);
+  static Credential userinfo_vc(const std::string& userinfo_vc_jwt);
   static Credential multi(
     const std::vector<CredentialBindingInput>& binding_inputs,
     const SignaturePublicKey& signature_key);

--- a/include/mls/credential.h
+++ b/include/mls/credential.h
@@ -7,7 +7,7 @@
 namespace MLS_NAMESPACE {
 
 namespace hpke {
-  struct UserInfoVC;
+struct UserInfoVC;
 }
 
 // struct {
@@ -68,10 +68,13 @@ struct UserInfoVCCredential
   bool valid_for(const SignaturePublicKey& pub) const;
   bool valid_from(const PublicJWK& pub) const;
 
-  friend tls::ostream operator<<(tls::ostream& str, const UserInfoVCCredential& obj);
+  friend tls::ostream operator<<(tls::ostream& str,
+                                 const UserInfoVCCredential& obj);
   friend tls::istream operator>>(tls::istream& str, UserInfoVCCredential& obj);
-  friend bool operator==(const UserInfoVCCredential& lhs, const UserInfoVCCredential& rhs);
-  friend bool operator!=(const UserInfoVCCredential& lhs, const UserInfoVCCredential& rhs);
+  friend bool operator==(const UserInfoVCCredential& lhs,
+                         const UserInfoVCCredential& rhs);
+  friend bool operator!=(const UserInfoVCCredential& lhs,
+                         const UserInfoVCCredential& rhs);
 
 private:
   std::shared_ptr<hpke::UserInfoVC> _vc;

--- a/include/mls/credential.h
+++ b/include/mls/credential.h
@@ -70,8 +70,8 @@ struct UserInfoVCCredential
 
   friend tls::ostream operator<<(tls::ostream& str, const UserInfoVCCredential& obj);
   friend tls::istream operator>>(tls::istream& str, UserInfoVCCredential& obj);
-  friend bool operator==(const UserInfoVCCredential& str, const UserInfoVCCredential& obj);
-  friend bool operator!=(const UserInfoVCCredential& str, const UserInfoVCCredential& obj);
+  friend bool operator==(const UserInfoVCCredential& lhs, const UserInfoVCCredential& rhs);
+  friend bool operator!=(const UserInfoVCCredential& lhs, const UserInfoVCCredential& rhs);
 
 private:
   std::shared_ptr<hpke::UserInfoVC> _vc;

--- a/include/mls/crypto.h
+++ b/include/mls/crypto.h
@@ -227,7 +227,8 @@ struct SignaturePublicKey
   TLS_SERIALIZABLE(data)
 };
 
-struct PublicJWK {
+struct PublicJWK
+{
   SignatureScheme signature_scheme;
   std::optional<std::string> key_id;
   SignaturePublicKey public_key;

--- a/include/mls/crypto.h
+++ b/include/mls/crypto.h
@@ -208,8 +208,14 @@ extern const std::string group_info;
 extern const std::string multi_credential;
 } // namespace sign_label
 
+struct PublicJWK;
+
 struct SignaturePublicKey
 {
+  // XXX(RLB) It would be nice to wrap this return value as a struct, but that
+  // results in a compiler error "field has incomplete type".
+  static PublicJWK parse_jwk(const std::string& jwk_json);
+
   static SignaturePublicKey from_jwk(CipherSuite suite,
                                      const std::string& json_str);
 
@@ -223,6 +229,12 @@ struct SignaturePublicKey
   std::string to_jwk(CipherSuite suite) const;
 
   TLS_SERIALIZABLE(data)
+};
+
+struct PublicJWK {
+  SignatureScheme signature_scheme;
+  std::optional<std::string> key_id;
+  SignaturePublicKey public_key;
 };
 
 struct SignaturePrivateKey

--- a/include/mls/crypto.h
+++ b/include/mls/crypto.h
@@ -212,10 +212,6 @@ struct PublicJWK;
 
 struct SignaturePublicKey
 {
-  // XXX(RLB) It would be nice to wrap this return value as a struct, but that
-  // results in a compiler error "field has incomplete type".
-  static PublicJWK parse_jwk(const std::string& jwk_json);
-
   static SignaturePublicKey from_jwk(CipherSuite suite,
                                      const std::string& json_str);
 
@@ -235,6 +231,8 @@ struct PublicJWK {
   SignatureScheme signature_scheme;
   std::optional<std::string> key_id;
   SignaturePublicKey public_key;
+
+  static PublicJWK parse(const std::string& jwk_json);
 };
 
 struct SignaturePrivateKey

--- a/include/mls/crypto.h
+++ b/include/mls/crypto.h
@@ -208,8 +208,6 @@ extern const std::string group_info;
 extern const std::string multi_credential;
 } // namespace sign_label
 
-struct PublicJWK;
-
 struct SignaturePublicKey
 {
   static SignaturePublicKey from_jwk(CipherSuite suite,

--- a/lib/hpke/include/hpke/userinfo_vc.h
+++ b/lib/hpke/include/hpke/userinfo_vc.h
@@ -65,8 +65,9 @@ public:
   UserInfoVC& operator=(const UserInfoVC& other) = default;
   UserInfoVC& operator=(UserInfoVC&& other) = default;
 
+  const Signature& signature_algorithm() const;
   std::string issuer() const;
-  std::string key_id() const;
+  std::optional<std::string> key_id() const;
   std::chrono::system_clock::time_point not_before() const;
   std::chrono::system_clock::time_point not_after() const;
   const std::string& raw_credential() const;

--- a/src/credential.cpp
+++ b/src/credential.cpp
@@ -118,7 +118,8 @@ operator==(const X509Credential& lhs, const X509Credential& rhs)
 UserInfoVCCredential::UserInfoVCCredential(std::string userinfo_vc_jwt_in)
   : userinfo_vc_jwt(std::move(userinfo_vc_jwt_in))
   , _vc(std::make_shared<hpke::UserInfoVC>(userinfo_vc_jwt))
-{}
+{
+}
 
 bool
 // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
@@ -140,27 +141,32 @@ UserInfoVCCredential::valid_from(const PublicJWK& pub) const
   return _vc->valid_from(*sig_pub);
 }
 
-tls::ostream operator<<(tls::ostream& str, const UserInfoVCCredential& obj) {
+tls::ostream
+operator<<(tls::ostream& str, const UserInfoVCCredential& obj)
+{
   return str << from_ascii(obj.userinfo_vc_jwt);
 }
 
-tls::istream operator>>(tls::istream& str, UserInfoVCCredential& obj) {
+tls::istream
+operator>>(tls::istream& str, UserInfoVCCredential& obj)
+{
   auto jwt = bytes{};
   str >> jwt;
   obj = UserInfoVCCredential(to_ascii(jwt));
   return str;
 }
 
-bool operator==(const UserInfoVCCredential& lhs, const UserInfoVCCredential& rhs) {
+bool
+operator==(const UserInfoVCCredential& lhs, const UserInfoVCCredential& rhs)
+{
   return lhs.userinfo_vc_jwt == rhs.userinfo_vc_jwt;
 }
 
-bool operator!=(const UserInfoVCCredential& lhs, const UserInfoVCCredential& rhs) {
+bool
+operator!=(const UserInfoVCCredential& lhs, const UserInfoVCCredential& rhs)
+{
   return !(lhs == rhs);
 }
-
-
-
 
 ///
 /// CredentialBinding and MultiCredential

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -385,15 +385,6 @@ SignaturePublicKey::verify(const CipherSuite& suite,
   return suite.sig().verify(content, signature, *pub);
 }
 
-PublicJWK
-SignaturePublicKey::parse_jwk(const std::string& jwk_json)
-{
-  const auto parsed = Signature::parse_jwk(jwk_json);
-  const auto scheme = tls_signature_scheme(parsed.sig.id);
-  const auto pub_data = parsed.sig.serialize(*parsed.key);
-  return { scheme, parsed.key_id, { pub_data } };
-}
-
 SignaturePublicKey
 SignaturePublicKey::from_jwk(CipherSuite suite, const std::string& json_str)
 {
@@ -407,6 +398,15 @@ SignaturePublicKey::to_jwk(CipherSuite suite) const
 {
   auto pub = suite.sig().deserialize(data);
   return suite.sig().export_jwk(*pub);
+}
+
+PublicJWK
+PublicJWK::parse(const std::string& jwk_json)
+{
+  const auto parsed = Signature::parse_jwk(jwk_json);
+  const auto scheme = tls_signature_scheme(parsed.sig.id);
+  const auto pub_data = parsed.sig.serialize(*parsed.key);
+  return { scheme, parsed.key_id, { pub_data } };
 }
 
 SignaturePrivateKey

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -385,6 +385,15 @@ SignaturePublicKey::verify(const CipherSuite& suite,
   return suite.sig().verify(content, signature, *pub);
 }
 
+PublicJWK
+SignaturePublicKey::parse_jwk(const std::string& jwk_json)
+{
+  const auto parsed = Signature::parse_jwk(jwk_json);
+  const auto scheme = tls_signature_scheme(parsed.sig.id);
+  const auto pub_data = parsed.sig.serialize(*parsed.key);
+  return { scheme, parsed.key_id, { pub_data } };
+}
+
 SignaturePublicKey
 SignaturePublicKey::from_jwk(CipherSuite suite, const std::string& json_str)
 {

--- a/test/crypto.cpp
+++ b/test/crypto.cpp
@@ -106,6 +106,23 @@ TEST_CASE("Signature Key JWK Import/Export")
     const auto decoded_pub = SignaturePublicKey::from_jwk(suite, encoded_pub);
     REQUIRE(decoded_pub == pub);
   }
+
+  // Test PublicJWK parsing
+  const auto full_jwk = R"({
+    "kty": "OKP",
+    "crv": "Ed25519",
+    "kid": "059fc2ee-5ef6-456a-91d8-49c422c772b2",
+    "x": "miljqilAZV2yFkqIBhrxhvt2wIMvPtkNEFzuziEGOtI"
+  })";
+
+  const auto known_scheme = SignatureScheme::ed25519;
+  const auto known_key_id = std::string("059fc2ee-5ef6-456a-91d8-49c422c772b2");
+  const auto knwon_pub_data = from_hex("9a2963aa2940655db2164a88061af186fb76c0832f3ed90d105ceece21063ad2");
+
+  const auto jwk = PublicJWK::parse(full_jwk);
+  REQUIRE(jwk.signature_scheme == known_scheme);
+  REQUIRE(jwk.key_id == known_key_id);
+  REQUIRE(jwk.public_key == SignaturePublicKey{ knwon_pub_data });
 }
 
 TEST_CASE("Crypto Interop")

--- a/test/crypto.cpp
+++ b/test/crypto.cpp
@@ -117,7 +117,8 @@ TEST_CASE("Signature Key JWK Import/Export")
 
   const auto known_scheme = SignatureScheme::ed25519;
   const auto known_key_id = std::string("059fc2ee-5ef6-456a-91d8-49c422c772b2");
-  const auto knwon_pub_data = from_hex("9a2963aa2940655db2164a88061af186fb76c0832f3ed90d105ceece21063ad2");
+  const auto knwon_pub_data = from_hex(
+    "9a2963aa2940655db2164a88061af186fb76c0832f3ed90d105ceece21063ad2");
 
   const auto jwk = PublicJWK::parse(full_jwk);
   REQUIRE(jwk.signature_scheme == known_scheme);

--- a/test/crypto.cpp
+++ b/test/crypto.cpp
@@ -113,7 +113,7 @@ TEST_CASE("Signature Key JWK Import/Export")
     "crv": "Ed25519",
     "kid": "059fc2ee-5ef6-456a-91d8-49c422c772b2",
     "x": "miljqilAZV2yFkqIBhrxhvt2wIMvPtkNEFzuziEGOtI"
-  })";
+  })"s;
 
   const auto known_scheme = SignatureScheme::ed25519;
   const auto known_key_id = std::string("059fc2ee-5ef6-456a-91d8-49c422c772b2");


### PR DESCRIPTION
Currently, JWK import requires the caller to specify the cipher suite for the key.  This is not always known.  This PR introduces a `PublicJWK` class that provides more fulsome JWK parsing, including capturing the `alg` and `kid` parameters.