### PR TITLE
Fix build error in Visual Studio 17.7

### DIFF
--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -160,7 +160,7 @@ Welcome::encrypt(const KeyPackage& kp, const std::optional<bytes>& path_secret)
 {
   auto gs = GroupSecrets{ _joiner_secret, std::nullopt, _psks };
   if (path_secret) {
-    gs.path_secret = { opt::get(path_secret) };
+    gs.path_secret = GroupSecrets::PathSecret{ opt::get(path_secret) };
   }
 
   auto gs_data = tls::marshal(gs);

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -492,8 +492,8 @@ TreeKEMPublicKey::merge(LeafIndex from, const UpdatePath& path)
       parent_hash = ph[i + 1];
     }
 
-    node_at(n).node = Node{ ParentNode{
-      path.nodes[i].public_key, parent_hash, {} } };
+    node_at(n).node =
+      Node{ ParentNode{ path.nodes[i].public_key, parent_hash, {} } };
   }
 
   set_hash_all();

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -492,7 +492,7 @@ TreeKEMPublicKey::merge(LeafIndex from, const UpdatePath& path)
       parent_hash = ph[i + 1];
     }
 
-    node_at(n).node = { ParentNode{
+    node_at(n).node = Node{ ParentNode{
       path.nodes[i].public_key, parent_hash, {} } };
   }
 


### PR DESCRIPTION
Fix build error on Windows:

```
Severity	Code	Description	Project	File	Line	Suppression State
Error	C2664	'std::optional<mls_v4::Node> &std::optional<mls_v4::Node>::operator =(std::optional<mls_v4::Node> &&)': cannot convert argument 1 from 'initializer list' to 'std::optional<mls_v4::Node> &&'	mlspp_v4	J:\dev\webex\spark-client-framework\thirdparty\mlspp_v4\src\treekem.cpp	495	
Error	C2664	'std::optional<mls_v4::GroupSecrets::PathSecret> &std::optional<mls_v4::GroupSecrets::PathSecret>::operator =(std::optional<mls_v4::GroupSecrets::PathSecret> &&)': cannot convert argument 1 from 'initializer list' to 'std::optional<mls_v4::GroupSecrets::PathSecret> &&'	mlspp_v4	J:\dev\webex\spark-client-framework\thirdparty\mlspp_v4\src\messages.cpp	163
```

How to reproduce the build error?

1. Use Visual Studio 2022 v17.7 (I reproduced with vs2022 v17.7.4)
2. Use c++20
