### PR TITLE
Fix 'json::parse' build error in Xcode 15

### DIFF
--- a/lib/hpke/src/userinfo_vc.cpp
+++ b/lib/hpke/src/userinfo_vc.cpp
@@ -212,8 +212,8 @@ struct UserInfoVC::ParsedCredential
     const auto signature_b64 = jwt.substr(last_dot + 1);
 
     // Parse the components
-    const auto header = json::parse(from_base64url(header_b64));
-    const auto payload = json::parse(from_base64url(payload_b64));
+    const auto header = json::parse(to_ascii(from_base64url(header_b64)));
+    const auto payload = json::parse(to_ascii(from_base64url(payload_b64)));
 
     // Prepare the validation inputs
     const auto& sig = signature_from_alg(header.at("alg"));


### PR DESCRIPTION
Fix build error in Xcode 15:
```
'char_traits<unsigned char>' is deprecated: char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. It will be removed in LLVM 18, so please migrate off of it.
```