### PR TITLE
allow CMake/compile option to DISABLE_GREASE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ option(TESTING    "Build tests" OFF)
 option(CLANG_TIDY "Perform linting with clang-tidy" OFF)
 option(SANITIZERS "Enable sanitizers" OFF)
 option(MLS_NAMESPACE_SUFFIX "Namespace Suffix for CXX and CMake Export")
+option(DISABLE_GREASE "Disables the inclusion of MLS protocol recommended GREASE values")
 
 if(MLS_NAMESPACE_SUFFIX)
     set(MLS_CXX_NAMESPACE "mls_${MLS_NAMESPACE_SUFFIX}" CACHE STRING "Top-level Namespace for CXX")
@@ -78,6 +79,10 @@ endif()
 if("$ENV{MACOSX_DEPLOYMENT_TARGET}" STREQUAL "10.11")
   add_compile_options(-DVARIANT_COMPAT)
 endif()
+
+if (DISABLE_GREASE)
+  add_compile_options(-DDISABLE_GREASE)
+endif ()
 
 ###
 ### Enable testing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(TESTING    "Build tests" OFF)
 option(CLANG_TIDY "Perform linting with clang-tidy" OFF)
 option(SANITIZERS "Enable sanitizers" OFF)
 option(MLS_NAMESPACE_SUFFIX "Namespace Suffix for CXX and CMake Export")
-option(DISABLE_GREASE "Disables the inclusion of MLS protocol recommended GREASE values")
+option(DISABLE_GREASE "Disables the inclusion of MLS protocol recommended GREASE values" OFF)
 
 if(MLS_NAMESPACE_SUFFIX)
     set(MLS_CXX_NAMESPACE "mls_${MLS_NAMESPACE_SUFFIX}" CACHE STRING "Top-level Namespace for CXX")

--- a/src/grease.cpp
+++ b/src/grease.cpp
@@ -6,6 +6,21 @@
 
 namespace MLS_NAMESPACE {
 
+#ifdef DISABLE_GREASE
+
+Capabilities
+grease(Capabilities&& capabilities, [[maybe_unused]] const ExtensionList& extensions)
+{
+  return capabilities;
+}
+
+ExtensionList
+grease(ExtensionList&& extensions) {
+  return extensions;
+}
+
+#else
+
 // Randomness parmeters:
 // * Given a list of N items, insert max(1, rand(p_grease * N)) GREASE values
 // * Each GREASE value added is distinct, unless more than 15 values are needed
@@ -117,5 +132,7 @@ grease(ExtensionList&& extensions)
 
   return { ext };
 }
+
+#endif // DISABLE_GREASE
 
 } // namespace MLS_NAMESPACE

--- a/src/grease.cpp
+++ b/src/grease.cpp
@@ -9,13 +9,15 @@ namespace MLS_NAMESPACE {
 #ifdef DISABLE_GREASE
 
 Capabilities
-grease(Capabilities&& capabilities, [[maybe_unused]] const ExtensionList& extensions)
+grease(Capabilities&& capabilities,
+       [[maybe_unused]] const ExtensionList& extensions)
 {
   return capabilities;
 }
 
 ExtensionList
-grease(ExtensionList&& extensions) {
+grease(ExtensionList&& extensions)
+{
   return extensions;
 }
 


### PR DESCRIPTION
Adds a non-default behaviour to disable greasing of extensions/capabilities. This behaviour is recommended as something you should do by the MLS protocol, but it would be nice for a library consumer to be able to disable it as it can reduce the size of messages that need to be passed around.

I went back and forth on making the definition `ADD_GREASE` or `DISABLE_GREASE`, open to changing it to the "positive" direction so we can avoid the `#ifndef DISABLE_` pattern if it is bothersome.