### PR TITLE
Add missing tests for GREASE

### DIFF
--- a/test/grease.cpp
+++ b/test/grease.cpp
@@ -1,0 +1,38 @@
+#include "grease.h"
+#include <doctest/doctest.h>
+#include <mls/core_types.h>
+#include <mls/messages.h>
+
+using namespace mls;
+
+TEST_CASE("GREASE capabilities")
+{
+  const auto capas_before = Capabilities::create_default();
+  auto capas_after = capas_before;
+  grease(capas_after, {});
+  REQUIRE(capas_after != capas_before);
+}
+
+TEST_CASE("GREASE extensions")
+{
+  auto exts_before = ExtensionList{};
+  exts_before.add(ApplicationIDExtension{ { 0, 1, 2, 3 } });
+  exts_before.add(RatchetTreeExtension{});
+
+  auto exts_after = exts_before;
+  grease(exts_after);
+  REQUIRE(exts_after != exts_before);
+}
+
+TEST_CASE("GREASE consistently")
+{
+  auto exts = ExtensionList{};
+  const auto ext = Extension{ 0x1A1A, { 0, 1, 2, 3 } };
+  exts.extensions.insert(std::end(exts.extensions), ext);
+
+  const auto capas_before = Capabilities::create_default();
+  auto capas_after = capas_before;
+  grease(capas_after, exts);
+  REQUIRE(capas_after != capas_before);
+  REQUIRE(stdx::contains(capas_after.extensions, ext.type));
+}


### PR DESCRIPTION
I noticed that when I added GREASE, I neglected to `git add` the corresponding test file.  This PR just adds that file.