### PR TITLE
Simplify clang-format CI job

### DIFF
--- a/.github/workflows/boring.yml
+++ b/.github/workflows/boring.yml
@@ -17,27 +17,6 @@ env:
   VCPKG_TOOLCHAIN_FILE: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
 
 jobs:
-  formatting-check:
-    name: Formatting Check
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        path:
-          - 'include'
-          - 'src'
-          - 'test'
-          - 'cmd'
-          - 'lib'
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Run clang-format style check for C/C++ programs
-      uses: jidicula/clang-format-action@v4.11.0
-      with:
-        clang-format-version: '16'
-        check-path: ${{ matrix.path }}
-        fallback-style: 'Mozilla'
-
   platform-sanitizer-tests:
     name: Build and test platforms using sanitizers and clang-tidy
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -25,22 +25,13 @@ jobs:
   formatting-check:
     name: Formatting Check
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        path:
-          - 'include'
-          - 'src'
-          - 'test'
-          - 'cmd'
-          - 'lib'
     steps:
     - uses: actions/checkout@v4
 
     - name: Run clang-format style check for C/C++ programs
       uses: jidicula/clang-format-action@v4.11.0
       with:
-        clang-format-version: '16'
-        check-path: ${{ matrix.path }}
+        include-regex: '^\./(src|include|test|cmd)/.*\.(cpp|h)$'
         fallback-style: 'Mozilla'
 
   quick-linux-interop-check:

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Run clang-format style check for C/C++ programs
       uses: jidicula/clang-format-action@v4.11.0
       with:
+        clang-format-version: 16
         include-regex: '^\./(src|include|test|cmd)/.*\.(cpp|h)$'
         fallback-style: 'Mozilla'
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -3,8 +3,7 @@
 
 namespace MLS_NAMESPACE {
 
-uint64_t
-seconds_since_epoch()
+uint64_t seconds_since_epoch()
 {
   // TODO(RLB) This should use std::chrono, but that seems not to be available
   // on some platforms.

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -3,7 +3,8 @@
 
 namespace MLS_NAMESPACE {
 
-uint64_t seconds_since_epoch()
+uint64_t
+seconds_since_epoch()
 {
   // TODO(RLB) This should use std::chrono, but that seems not to be available
   // on some platforms.


### PR DESCRIPTION
For quite some time, the clang-format CI job has run as a matrix across several individual directories.  This clutters up the GitHub interface, since GitHub considers each entry in the matrix a different job.  This PR removes the matrix run and instead uses the `include-regex` feature of the clang-format job to select which files to look at.  In case the CI output doesn't show it, I verified locally that the regex here hits the right files.