### PR TITLE
update signatures for DISABLE_GREASE

### DIFF
--- a/src/grease.cpp
+++ b/src/grease.cpp
@@ -8,17 +8,15 @@ namespace MLS_NAMESPACE {
 
 #ifdef DISABLE_GREASE
 
-Capabilities
-grease(Capabilities&& capabilities,
+void
+grease([[maybe_unused]] Capabilities& capabilities,
        [[maybe_unused]] const ExtensionList& extensions)
 {
-  return capabilities;
 }
 
-ExtensionList
-grease(ExtensionList&& extensions)
+void
+grease([[maybe_unused]] ExtensionList& extensions)
 {
-  return extensions;
 }
 
 #else


### PR DESCRIPTION
#385 changed the grease signatures, so using DISABLE_GREASE currently has missing symbols. This updates the grease calls that do nothing when DISABLE_GREASE is defined to have the new signatures.