### PR TITLE
Removes the `from_json()` call for `UserInfoVCAddress`

### DIFF
--- a/lib/hpke/include/hpke/userinfo_vc.h
+++ b/lib/hpke/include/hpke/userinfo_vc.h
@@ -19,8 +19,6 @@ struct UserInfoClaimsAddress
   std::optional<std::string> region;
   std::optional<std::string> postal_code;
   std::optional<std::string> country;
-
-  static UserInfoClaimsAddress from_json(const std::string& address);
 };
 
 struct UserInfoClaims

--- a/lib/hpke/src/userinfo_vc.cpp
+++ b/lib/hpke/src/userinfo_vc.cpp
@@ -282,24 +282,6 @@ struct UserInfoVC::ParsedCredential
 };
 
 ///
-/// UserInfoClaimsAddress
-///
-UserInfoClaimsAddress
-UserInfoClaimsAddress::from_json(const std::string& address)
-{
-  const auto& address_json = nlohmann::json::parse(address);
-
-  return {
-    get_optional<std::string>(address_json, address_formatted_attr),
-    get_optional<std::string>(address_json, address_street_address_attr),
-    get_optional<std::string>(address_json, address_locality_attr),
-    get_optional<std::string>(address_json, address_region_attr),
-    get_optional<std::string>(address_json, address_postal_code_attr),
-    get_optional<std::string>(address_json, address_country_attr),
-  };
-}
-
-///
 /// UserInfoClaims
 ///
 UserInfoClaims
@@ -310,8 +292,15 @@ UserInfoClaims::from_json(const std::string& cred_subject)
   std::optional<UserInfoClaimsAddress> address_opt = {};
 
   if (cred_subject_json.contains(address_attr)) {
-    address_opt = UserInfoClaimsAddress::from_json(
-      cred_subject_json.at(address_attr).dump());
+    auto address_json = cred_subject_json.at(address_attr);
+    address_opt = UserInfoClaimsAddress{
+      get_optional<std::string>(address_json, address_formatted_attr),
+      get_optional<std::string>(address_json, address_street_address_attr),
+      get_optional<std::string>(address_json, address_locality_attr),
+      get_optional<std::string>(address_json, address_region_attr),
+      get_optional<std::string>(address_json, address_postal_code_attr),
+      get_optional<std::string>(address_json, address_country_attr)
+    };
   }
 
   return {


### PR DESCRIPTION
In it's first implementation, it was dumping and parsing the UserInfoVCAddress json structure twice.

This PR will remove the ability to import an UserInfoVCAddress directly. Importing of UserInfoVC will also import the UserInfoVCAddress.

As far as I know, there is not a use case to import the Address directory.  Nor were then any tests.

fixes #393