### PR TITLE
Make zeroization test tighter and more reliable

### DIFF
--- a/lib/bytes/test/bytes.cpp
+++ b/lib/bytes/test/bytes.cpp
@@ -12,7 +12,7 @@ using namespace std::literals::string_literals;
 #ifndef SANITIZERS
 TEST_CASE("Zeroization")
 {
-  const auto size = size_t(32);
+  const auto size = size_t(1024);
   const auto canary = uint8_t(0xff);
 
   auto vec = std::make_unique<bytes>(size, canary);
@@ -26,9 +26,9 @@ TEST_CASE("Zeroization")
   // allocator can do with it what it wants, and may have written something to
   // it when deallocating.  For example, on macOS, the allocator appears to
   // write a single pointer at the beginning.  Assuming other platforms are not
-  // too different, we verify that no more than a pointer's worth of bytes are
-  // non-zero.
-  const auto non_zero_threshold = sizeof(void*);
+  // too different, we verify that no more than a few pointer's worth of bytes
+  // are non-zero.
+  const auto non_zero_threshold = 4 * sizeof(void*);
   REQUIRE(std::count(begin, end, 0) >= size - non_zero_threshold);
 }
 #endif

--- a/lib/bytes/test/bytes.cpp
+++ b/lib/bytes/test/bytes.cpp
@@ -12,19 +12,24 @@ using namespace std::literals::string_literals;
 #ifndef SANITIZERS
 TEST_CASE("Zeroization")
 {
+  const auto size = size_t(32);
   const auto canary = uint8_t(0xff);
-  auto vec = std::make_unique<bytes>(32, canary);
-  const auto size = vec->size();
-  const auto* ptr = vec->data();
+
+  auto vec = std::make_unique<bytes>(size, canary);
+  const auto* begin = vec->data();
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+  const auto* end = begin + size;
   vec.reset();
 
-  for (size_t i = 0; i < size; i++) {
-    // We test for inequality instead of zero because the vector might already
-    // be partially overwritten at this point.
-    //
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-    REQUIRE(*(ptr + i) != canary);
-  }
+  // In principle, the memory previously owned by the vector should be all zero
+  // at this point.  However, since this is now unallocated memory, the
+  // allocator can do with it what it wants, and may have written something to
+  // it when deallocating.  For example, on macOS, the allocator appears to
+  // write a single pointer at the beginning.  Assuming other platforms are not
+  // too different, we verify that no more than a pointer's worth of bytes are
+  // non-zero.
+  const auto non_zero_threshold = sizeof(void*);
+  REQUIRE(std::count(begin, end, 0) >= size - non_zero_threshold);
 }
 #endif
 


### PR DESCRIPTION
Currently, the zeroization test fails if it finds any bytes that matches the canary.  This is both incorrect, since we should be checking that the vector is all-zero, and failure prone, since it will match against random data with some probability.  This PR changes the test to verify that basically all of the vector is zero, with some allowance for the allocator to re-use a few bytes.

Fully solving this problem would require defining a new allocator (so that we could control what happens on deallocation, and avoid UAF) and updating `bytes` so that it could be provided a non-default allocator.  However, this is a pretty non-trivial change, and not really worth it to fix this one test.