### PR TITLE
Build with vcpkg and OpenSSL 1.1 by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ all: ${BUILD_DIR}
 	cmake --build ${BUILD_DIR} --target mlspp
 
 ${BUILD_DIR}: CMakeLists.txt test/CMakeLists.txt
-	cmake -B${BUILD_DIR} .
+	cmake -B${BUILD_DIR}  \
+		-DVCPKG_MANIFEST_DIR=${OPENSSL11_MANIFEST} \
+		-DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE}
 
 ${TOOLCHAIN_FILE}:
 	git submodule update --init --recursive

--- a/cmd/interop/src/mls_client_impl.cpp
+++ b/cmd/interop/src/mls_client_impl.cpp
@@ -749,7 +749,7 @@ Status
 MLSClientImpl::join_group(const JoinGroupRequest* request,
                           JoinGroupResponse* response)
 {
-  auto join = load_join(request->transaction_id());
+  auto join = load_join(request->transaction_id() + 1);
   if (!join) {
     return Status(StatusCode::INVALID_ARGUMENT, "Unknown transaction ID");
   }

--- a/cmd/interop/src/mls_client_impl.cpp
+++ b/cmd/interop/src/mls_client_impl.cpp
@@ -749,7 +749,7 @@ Status
 MLSClientImpl::join_group(const JoinGroupRequest* request,
                           JoinGroupResponse* response)
 {
-  auto join = load_join(request->transaction_id() + 1);
+  auto join = load_join(request->transaction_id());
   if (!join) {
     return Status(StatusCode::INVALID_ARGUMENT, "Unknown transaction ID");
   }


### PR DESCRIPTION
Right now, an unadorned `make` grabs whatever OpenSSL the system happens to provide via FindPackage.  This PR changes the behavior of `make` so that it uses vcpkg with OpenSSL 1.1.