### PR TITLE
Fix cache key to avoid crypto library duplication

### DIFF
--- a/.github/actions/prepare-build/action.yml
+++ b/.github/actions/prepare-build/action.yml
@@ -26,7 +26,6 @@ runs:
         key: v02-vcpkg-${{ inputs.os }}-${{ inputs.crypto }}-${{ hashFiles('vcpkg_commit.txt', 'alternatives/*/vcpkg.json') }}
         restore-keys: |
           v02-vcpkg-${{ inputs.os }}-${{ inputs.crypto }}
-          v02-vcpkg-${{ inputs.os }}
 
     - name: Install dependencies (macOS)
       if: ${{ runner.os == 'macOS' }}

--- a/.github/actions/prepare-build/action.yml
+++ b/.github/actions/prepare-build/action.yml
@@ -23,9 +23,10 @@ runs:
       uses: actions/cache@v3
       with:
         path: ${{ inputs.cache-dir }}
-        key: v01-vcpkg-${{ inputs.os }}-${{ inputs.crypto }}-${{ hashFiles('vcpkg_commit.txt', 'alternatives/*/vcpkg.json') }}
+        key: v02-vcpkg-${{ inputs.os }}-${{ inputs.crypto }}-${{ hashFiles('vcpkg_commit.txt', 'alternatives/*/vcpkg.json') }}
         restore-keys: |
-          v01-vcpkg-${{ inputs.os }}
+          v02-vcpkg-${{ inputs.os }}-${{ inputs.crypto }}
+          v02-vcpkg-${{ inputs.os }}
 
     - name: Install dependencies (macOS)
       if: ${{ runner.os == 'macOS' }}


### PR DESCRIPTION
In the current cache key strategy, it will be able to "snowball" crypto libraries as vcpkg dependencies change.  This will eliminate that edge case.

It also seems like and invalid cache has been created, we need to rebuild the cache for the main branch.  Changing the cache version will do that.