### PR TITLE
Expose group ID and allow inspection

### DIFF
--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -570,6 +570,23 @@ private:
   friend struct PrivateMessage;
 };
 
+struct ValidatedContent
+{
+  public:
+  const AuthenticatedContent& authenticated_content() const;
+
+  friend bool operator==(const ValidatedContent& lhs, const ValidatedContent& rhs);
+
+  private:
+  AuthenticatedContent content_auth;
+
+  ValidatedContent(AuthenticatedContent content_auth_in);
+
+  friend struct PublicMessage;
+  friend struct PrivateMessage;
+  friend class State;
+};
+
 struct PublicMessage
 {
   PublicMessage() = default;
@@ -581,7 +598,7 @@ struct PublicMessage
                                CipherSuite suite,
                                const std::optional<bytes>& membership_key,
                                const std::optional<GroupContext>& context);
-  std::optional<AuthenticatedContent> unprotect(
+  std::optional<ValidatedContent> unprotect(
     CipherSuite suite,
     const std::optional<bytes>& membership_key,
     const std::optional<GroupContext>& context) const;
@@ -620,7 +637,7 @@ struct PrivateMessage
                                 GroupKeySource& keys,
                                 const bytes& sender_data_secret,
                                 size_t padding_size);
-  std::optional<AuthenticatedContent> unprotect(
+  std::optional<ValidatedContent> unprotect(
     CipherSuite suite,
     GroupKeySource& keys,
     const bytes& sender_data_secret) const;

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -574,6 +574,7 @@ struct PublicMessage
 {
   PublicMessage() = default;
 
+  bytes get_group_id() const { return content.group_id; }
   epoch_t get_epoch() const { return content.epoch; }
 
   static PublicMessage protect(AuthenticatedContent content_auth,
@@ -611,6 +612,7 @@ struct PrivateMessage
 {
   PrivateMessage() = default;
 
+  bytes get_group_id() const { return group_id; }
   epoch_t get_epoch() const { return epoch; }
 
   static PrivateMessage protect(AuthenticatedContent content_auth,
@@ -649,6 +651,7 @@ struct MLSMessage
   var::variant<PublicMessage, PrivateMessage, Welcome, GroupInfo, KeyPackage>
     message;
 
+  bytes group_id() const;
   epoch_t epoch() const;
   WireFormat wire_format() const;
 

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -572,12 +572,12 @@ private:
 
 struct ValidatedContent
 {
-  public:
   const AuthenticatedContent& authenticated_content() const;
 
-  friend bool operator==(const ValidatedContent& lhs, const ValidatedContent& rhs);
+  friend bool operator==(const ValidatedContent& lhs,
+                         const ValidatedContent& rhs);
 
-  private:
+private:
   AuthenticatedContent content_auth;
 
   ValidatedContent(AuthenticatedContent content_auth_in);

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -117,17 +117,14 @@ public:
     const MessageOpts& msg_opts);
 
   ///
-  /// Generic handshake message handler
+  /// Generic handshake message handlers
   ///
   std::optional<State> handle(const MLSMessage& msg);
   std::optional<State> handle(const MLSMessage& msg,
                               std::optional<State> cached_state);
 
-  // In general, you should avoid these methods and prefer the MLSMessage
-  // variants. They are provided for cases where a message recipient wishes to
-  // unwrap and inspect a message before handling it.
-  std::optional<State> handle(const AuthenticatedContent& content_auth);
-  std::optional<State> handle(const AuthenticatedContent& content_auth,
+  std::optional<State> handle(const ValidatedContent& content_auth);
+  std::optional<State> handle(const ValidatedContent& content_auth,
                               std::optional<State> cached_state);
 
   ///
@@ -162,7 +159,7 @@ public:
   ///
   /// Unwrap messages so that applications can inspect them
   ///
-  AuthenticatedContent unwrap(const MLSMessage& msg);
+  ValidatedContent unwrap(const MLSMessage& msg);
 
   ///
   /// Application encryption and decryption
@@ -331,7 +328,7 @@ protected:
     std::optional<State> cached_state,
     const std::optional<CommitParams>& expected_params);
   std::optional<State> handle(
-    const AuthenticatedContent& content_auth,
+    const ValidatedContent& val_content,
     std::optional<State> cached_state,
     const std::optional<CommitParams>& expected_params);
 

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -152,6 +152,11 @@ public:
   bytes epoch_authenticator() const;
 
   ///
+  /// Unwrap messages so that applications can inspect them
+  ///
+  AuthenticatedContent unwrap(const MLSMessage& msg);
+
+  ///
   /// Application encryption and decryption
   ///
   MLSMessage protect(const bytes& authenticated_data,
@@ -333,8 +338,6 @@ protected:
 
   template<typename Inner>
   MLSMessage protect_full(Inner&& content, const MessageOpts& msg_opts);
-
-  AuthenticatedContent unprotect_to_content_auth(const MLSMessage& msg);
 
   // Apply the changes requested by various messages
   LeafIndex apply(const Add& add);

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -122,6 +122,14 @@ public:
   std::optional<State> handle(const MLSMessage& msg);
   std::optional<State> handle(const MLSMessage& msg,
                               std::optional<State> cached_state);
+
+  // In general, you should avoid these methods and prefer the MLSMessage
+  // variants. They are provided for cases where a message recipient wishes to
+  // unwrap and inspect a message before handling it.
+  std::optional<State> handle(const AuthenticatedContent& content_auth);
+  std::optional<State> handle(const AuthenticatedContent& content_auth,
+                              std::optional<State> cached_state);
+
   ///
   /// PSK management
   ///

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -872,18 +872,18 @@ MessageProtectionTestVector::protect_priv(
 std::optional<GroupContent>
 MessageProtectionTestVector::unprotect(const MLSMessage& message)
 {
-  auto do_unprotect = overloaded{
-    [&](const PublicMessage& pt) {
-      return pt.unprotect(cipher_suite, membership_key, group_context());
-    },
-    [&](const PrivateMessage& ct) {
-      auto keys = group_keys();
-      return ct.unprotect(cipher_suite, keys, sender_data_secret);
-    },
-    [](const auto& /* other */) -> std::optional<ValidatedContent> {
-      return std::nullopt;
-    }
-  };
+  auto do_unprotect =
+    overloaded{ [&](const PublicMessage& pt) {
+                 return pt.unprotect(
+                   cipher_suite, membership_key, group_context());
+               },
+                [&](const PrivateMessage& ct) {
+                  auto keys = group_keys();
+                  return ct.unprotect(cipher_suite, keys, sender_data_secret);
+                },
+                [](const auto& /* other */) -> std::optional<ValidatedContent> {
+                  return std::nullopt;
+                } };
 
   auto maybe_auth_content = var::visit(do_unprotect, message.message);
   if (!maybe_auth_content) {

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -880,7 +880,7 @@ MessageProtectionTestVector::unprotect(const MLSMessage& message)
       auto keys = group_keys();
       return ct.unprotect(cipher_suite, keys, sender_data_secret);
     },
-    [](const auto& /* other */) -> std::optional<AuthenticatedContent> {
+    [](const auto& /* other */) -> std::optional<ValidatedContent> {
       return std::nullopt;
     }
   };
@@ -890,7 +890,8 @@ MessageProtectionTestVector::unprotect(const MLSMessage& message)
     return std::nullopt;
   }
 
-  auto auth_content = opt::get(maybe_auth_content);
+  auto val_content = opt::get(maybe_auth_content);
+  const auto& auth_content = val_content.authenticated_content();
   if (!auth_content.verify(cipher_suite, signature_pub, group_context())) {
     return std::nullopt;
   }

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -832,6 +832,20 @@ PrivateMessage::PrivateMessage(GroupContent content,
 {
 }
 
+bytes
+MLSMessage::group_id() const
+{
+  return var::visit(
+    overloaded{
+      [](const PublicMessage& pt) -> bytes { return pt.get_group_id(); },
+      [](const PrivateMessage& pt) -> bytes { return pt.get_group_id(); },
+      [](const auto& /* unused */) -> bytes {
+        throw InvalidParameterError("MLSMessage has no group_id");
+      },
+    },
+    message);
+}
+
 epoch_t
 MLSMessage::epoch() const
 {

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -472,7 +472,8 @@ ValidatedContent::authenticated_content() const
 
 ValidatedContent::ValidatedContent(AuthenticatedContent content_auth_in)
   : content_auth(content_auth_in)
-{}
+{
+}
 
 bool
 operator==(const ValidatedContent& lhs, const ValidatedContent& rhs)

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -838,7 +838,8 @@ MLSMessage::group_id() const
   return var::visit(
     overloaded{
       [](const PublicMessage& pt) -> bytes { return pt.get_group_id(); },
-      [](const PrivateMessage& pt) -> bytes { return pt.get_group_id(); },
+      [](const PrivateMessage& ct) -> bytes { return ct.get_group_id(); },
+      [](const GroupInfo& gi) -> bytes { return gi.group_context.group_id; },
       [](const auto& /* unused */) -> bytes {
         throw InvalidParameterError("MLSMessage has no group_id");
       },

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -471,7 +471,7 @@ ValidatedContent::authenticated_content() const
 }
 
 ValidatedContent::ValidatedContent(AuthenticatedContent content_auth_in)
-  : content_auth(content_auth_in)
+  : content_auth(std::move(content_auth_in))
 {
 }
 

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -820,7 +820,8 @@ State::handle(const AuthenticatedContent& content_auth)
 }
 
 std::optional<State>
-State::handle(const AuthenticatedContent& content_auth, std::optional<State> cached_state)
+State::handle(const AuthenticatedContent& content_auth,
+              std::optional<State> cached_state)
 {
   return handle(content_auth, std::move(cached_state), std::nullopt);
 }

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -408,7 +408,7 @@ State::protect(AuthenticatedContent&& content_auth, size_t padding_size)
 }
 
 AuthenticatedContent
-State::unprotect_to_content_auth(const MLSMessage& msg)
+State::unwrap(const MLSMessage& msg)
 {
   if (msg.version != ProtocolVersion::mls10) {
     throw InvalidParameterError("Unsupported version");
@@ -416,6 +416,14 @@ State::unprotect_to_content_auth(const MLSMessage& msg)
 
   const auto unprotect = overloaded{
     [&](const PublicMessage& pt) -> AuthenticatedContent {
+      if (pt.get_group_id() != _group_id) {
+        throw ProtocolError("PublicMessage not for this group");
+      }
+
+      if (pt.get_epoch() != _epoch) {
+        throw ProtocolError("PublicMessage not for this epoch");
+      }
+
       auto maybe_content_auth =
         pt.unprotect(_suite, _key_schedule.membership_key, group_context());
       if (!maybe_content_auth) {
@@ -425,6 +433,14 @@ State::unprotect_to_content_auth(const MLSMessage& msg)
     },
 
     [&](const PrivateMessage& ct) -> AuthenticatedContent {
+      if (ct.get_group_id() != _group_id) {
+        throw ProtocolError("PrivateMessage not for this group");
+      }
+
+      if (ct.get_epoch() != _epoch) {
+        throw ProtocolError("PrivateMessage not for this epoch");
+      }
+
       auto maybe_content_auth =
         ct.unprotect(_suite, _keys, _key_schedule.sender_data_secret);
       if (!maybe_content_auth) {
@@ -797,7 +813,7 @@ State::handle(const MLSMessage& msg,
               std::optional<State> cached_state,
               const std::optional<CommitParams>& expected_params)
 {
-  auto content_auth = unprotect_to_content_auth(msg);
+  auto content_auth = unwrap(msg);
   if (!verify(content_auth)) {
     throw InvalidParameterError("Message signature failed to verify");
   }
@@ -1136,7 +1152,7 @@ State::Tombstone
 State::handle_reinit_commit(const MLSMessage& commit_msg)
 {
   // Verify the signature and process the commit
-  auto content_auth = unprotect_to_content_auth(commit_msg);
+  auto content_auth = unwrap(commit_msg);
   if (!verify(content_auth)) {
     throw InvalidParameterError("Message signature failed to verify");
   }
@@ -1417,7 +1433,7 @@ State::protect(const bytes& authenticated_data,
 std::tuple<bytes, bytes>
 State::unprotect(const MLSMessage& ct)
 {
-  auto content_auth = unprotect_to_content_auth(ct);
+  auto content_auth = unwrap(ct);
 
   if (!verify(content_auth)) {
     throw InvalidParameterError("Message signature failed to verify");

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -454,7 +454,7 @@ State::unwrap(const MLSMessage& msg)
     },
   };
 
-  const auto val_content = var::visit(unprotect, msg.message);
+  auto val_content = var::visit(unprotect, msg.message);
   if (!verify(val_content.content_auth)) {
     throw InvalidParameterError("Message signature failed to verify");
   }
@@ -1455,8 +1455,8 @@ State::unprotect(const MLSMessage& ct)
   }
 
   return {
-    std::move(content_auth.content.authenticated_data),
-    std::move(var::get<ApplicationData>(content_auth.content.content).data),
+    content_auth.content.authenticated_data,
+    var::get<ApplicationData>(content_auth.content.content).data,
   };
 }
 

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -129,7 +129,8 @@ TEST_CASE_FIXTURE(MLSMessageTest, "PublicMessage Protect/Unprotect")
 
   auto pt = PublicMessage::protect(
     content_auth_original, suite, membership_key, context);
-  auto content_auth_unprotected = pt.unprotect(suite, membership_key, context);
+  auto val_auth_unprotected = pt.unprotect(suite, membership_key, context);
+  const auto& content_auth_unprotected = opt::get(val_auth_unprotected).authenticated_content();
   REQUIRE(content_auth_unprotected == content_auth_original);
 }
 
@@ -145,7 +146,8 @@ TEST_CASE_FIXTURE(MLSMessageTest, "PrivateMessage Protect/Unprotect")
 
   auto ct = PrivateMessage::protect(
     content_auth_original, suite, keys, sender_data_secret, padding_size);
-  auto content_auth_unprotected = ct.unprotect(suite, keys, sender_data_secret);
+  auto val_auth_unprotected = ct.unprotect(suite, keys, sender_data_secret);
+  const auto& content_auth_unprotected = opt::get(val_auth_unprotected).authenticated_content();
   REQUIRE(content_auth_unprotected == content_auth_original);
 }
 

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -130,7 +130,8 @@ TEST_CASE_METHOD(MLSMessageTest, "PublicMessage Protect/Unprotect")
   auto pt = PublicMessage::protect(
     content_auth_original, suite, membership_key, context);
   auto val_auth_unprotected = pt.unprotect(suite, membership_key, context);
-  const auto& content_auth_unprotected = opt::get(val_auth_unprotected).authenticated_content();
+  const auto& content_auth_unprotected =
+    opt::get(val_auth_unprotected).authenticated_content();
   REQUIRE(content_auth_unprotected == content_auth_original);
 }
 
@@ -147,7 +148,8 @@ TEST_CASE_METHOD(MLSMessageTest, "PrivateMessage Protect/Unprotect")
   auto ct = PrivateMessage::protect(
     content_auth_original, suite, keys, sender_data_secret, padding_size);
   auto val_auth_unprotected = ct.unprotect(suite, keys, sender_data_secret);
-  const auto& content_auth_unprotected = opt::get(val_auth_unprotected).authenticated_content();
+  const auto& content_auth_unprotected =
+    opt::get(val_auth_unprotected).authenticated_content();
   REQUIRE(content_auth_unprotected == content_auth_original);
 }
 


### PR DESCRIPTION
Right now, there is no way for application code to inspect an MLS message prior to handling it.  PrivateMessages are of course encrypted until they are handled, but even PublicMessages hide the API to access the message contents.  This PR makes such inspection possible, via an `unwrap()` method that produces `AuthenticatedContent` and a `handle()` variant that accepts `AuthenticatedContent`:

```
const auto content_auth = state.unwrap(message);
// Verify that content_auth has the right contents for the application context
const auto maybe_next = state.handle(content_auth);
```

As a convenience, we also expose `group_id()` on MLSMessage.