### PR TITLE
Disable unit tests on Windows

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -55,9 +55,7 @@ jobs:
 
     - name: Build
       run: |
-        # XXX(RLB): If we do not have SANITIZERS=ON here, the Windows CI builds
-        # hang in the middle of unit testing.
-        cmake -B "${{ env.BUILD_DIR }}" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}" -DTESTING=ON -DSANITIZERS=ON
+        cmake -B "${{ env.BUILD_DIR }}" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}" -DTESTING=ON
         cmake --build "${{ env.BUILD_DIR }}"
 
     - name: Unit Test (non-Windows)
@@ -65,10 +63,16 @@ jobs:
       run: |
         cmake --build "${{ env.BUILD_DIR }}" --target test
 
-    - name: Unit Test (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        cmake --build "${{ env.BUILD_DIR }}" --target RUN_TESTS
+# XXX(RLB): Unit tests are currently disabled on Windows because of two
+# conflicting bugs.  On the one hand, doctest has a bug that causes
+# doctest_discover_tests to fail when tests are built with sanitizers.  On the
+# other hand, if tests are not built with sanitizers, then the unit tests hang
+# in the middle of the test run.
+#
+#    - name: Unit Test (Windows)
+#      if: matrix.os == 'windows-latest'
+#      run: |
+#        cmake --build "${{ env.BUILD_DIR }}" --target RUN_TESTS
   
   interop-test:
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
This PR disables unit testing in Windows CI runs.  As the comment in the workflow file notes for posterity, we have two conflicting bugs.  A [doctest bug](https://github.com/doctest/doctest/issues/836) discovered through #413 which causes doctest to fail when built with ASAN, and a GitHub Actions bug that causes the tests to hang when _not_ built with ASAN.

Disabling unit tests on Windows is unfortunate, but I don't think it's a huge loss in terms of test fidelity.  The behaviors we're testing are higher-level things that I would expect to be pretty portable, not dependent on anything platform-specific.

The long-term fix here probably entails moving to a new test framework, since it looks like [doctest is essentially unmaintained](https://github.com/doctest/doctest/issues/554).  My understanding is that [Catch2](https://github.com/catchorg/Catch2) is a pretty standard alternative, and appears to be better maintained than doctest.  The syntax seems similar (I think by design), so it may be pretty straightforward to change over.