### PR TITLE
Convert tests to Catch2

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -15,114 +15,114 @@ env:
   CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
 
 jobs:
-  formatting-check:
-    name: Formatting Check
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Run clang-format style check for C/C++ programs
-      uses: jidicula/clang-format-action@v4.11.0
-      with:
-        clang-format-version: 16
-        include-regex: '^\./(src|include|test|cmd)/.*\.(cpp|h)$'
-        fallback-style: 'Mozilla'
-
-  build-and-unit-test:
-    needs: formatting-check
-    name: Build and test
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
-        crypto: [openssl_1.1, openssl_3, boringssl]
-
-    env:
-      BUILD_DIR: "${RUNNER_TEMP}/build_${{ matrix.crypto }}"
-      CRYPTO_DIR: "./alternatives/${{ matrix.crypto }}"
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        fetch-depth: 0
-
-    - uses: ./.github/actions/prepare-build
-      with:
-        os: ${{ matrix.os }}
-        crypto: ${{ matrix.crypto }}
-        cache-dir: ${{ github.workspace }}/vcpkg_cache
-
-    - name: Build
-      run: |
-        cmake -B "${{ env.BUILD_DIR }}" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}" -DTESTING=ON
-        cmake --build "${{ env.BUILD_DIR }}"
-
-    - name: Unit Test (non-Windows)
-      if: matrix.os != 'windows-latest'
-      run: |
-        cmake --build "${{ env.BUILD_DIR }}" --target test
-
-# XXX(RLB): Unit tests are currently disabled on Windows because of two
-# conflicting bugs.  On the one hand, doctest has a bug that causes
-# doctest_discover_tests to fail when tests are built with sanitizers.  On the
-# other hand, if tests are not built with sanitizers, then the unit tests hang
-# in the middle of the test run.
+#  formatting-check:
+#    name: Formatting Check
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@v4
 #
-#    - name: Unit Test (Windows)
-#      if: matrix.os == 'windows-latest'
+#    - name: Run clang-format style check for C/C++ programs
+#      uses: jidicula/clang-format-action@v4.11.0
+#      with:
+#        clang-format-version: 16
+#        include-regex: '^\./(src|include|test|cmd)/.*\.(cpp|h)$'
+#        fallback-style: 'Mozilla'
+#
+#  build-and-unit-test:
+#    needs: formatting-check
+#    name: Build and test
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      matrix:
+#        os: [windows-latest, ubuntu-latest, macos-latest]
+#        crypto: [openssl_1.1, openssl_3, boringssl]
+#
+#    env:
+#      BUILD_DIR: "${RUNNER_TEMP}/build_${{ matrix.crypto }}"
+#      CRYPTO_DIR: "./alternatives/${{ matrix.crypto }}"
+#
+#    steps:
+#    - uses: actions/checkout@v4
+#      with:
+#        submodules: recursive
+#        fetch-depth: 0
+#
+#    - uses: ./.github/actions/prepare-build
+#      with:
+#        os: ${{ matrix.os }}
+#        crypto: ${{ matrix.crypto }}
+#        cache-dir: ${{ github.workspace }}/vcpkg_cache
+#
+#    - name: Build
 #      run: |
-#        cmake --build "${{ env.BUILD_DIR }}" --target RUN_TESTS
-  
-  interop-test:
-    if: github.event.pull_request.draft == false
-    needs: build-and-unit-test
-    name: Interop test
-    runs-on: ubuntu-latest
-
-    env:
-      BUILD_DIR: "${RUNNER_TEMP}/build_openssl_1.1"
-      CRYPTO_DIR: "./alternatives/openssl_1.1"
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        fetch-depth: 0
-
-    - uses: ./.github/actions/prepare-build
-      with:
-        os: ubuntu-latest
-        crypto-dir: openssl_1.1
-        cache-dir: ${{ github.workspace }}/vcpkg_cache
-
-    - name: Build
-      run: |
-        cmake -B "${{ env.BUILD_DIR }}" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}"
-        cmake --build "${{ env.BUILD_DIR }}"
-
-    - name: Build (Interop Harness)
-      run: |
-        cd cmd/interop
-        cmake -B build
-        cmake --build build
-
-    - name: Test self-interop
-      run: |
-        make -C cmd/interop self-test
-
-    - name: Test interop on test vectors
-      run: |
-        make -C cmd/interop interop-test
-
-    - name: Test gRPC live interop with self
-      run: |
-        cd cmd/interop
-        ./grpc-self-test.sh
-
+#        cmake -B "${{ env.BUILD_DIR }}" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}" -DTESTING=ON
+#        cmake --build "${{ env.BUILD_DIR }}"
+#
+#    - name: Unit Test (non-Windows)
+#      if: matrix.os != 'windows-latest'
+#      run: |
+#        cmake --build "${{ env.BUILD_DIR }}" --target test
+#
+## XXX(RLB): Unit tests are currently disabled on Windows because of two
+## conflicting bugs.  On the one hand, doctest has a bug that causes
+## doctest_discover_tests to fail when tests are built with sanitizers.  On the
+## other hand, if tests are not built with sanitizers, then the unit tests hang
+## in the middle of the test run.
+##
+##    - name: Unit Test (Windows)
+##      if: matrix.os == 'windows-latest'
+##      run: |
+##        cmake --build "${{ env.BUILD_DIR }}" --target RUN_TESTS
+#  
+#  interop-test:
+#    if: github.event.pull_request.draft == false
+#    needs: build-and-unit-test
+#    name: Interop test
+#    runs-on: ubuntu-latest
+#
+#    env:
+#      BUILD_DIR: "${RUNNER_TEMP}/build_openssl_1.1"
+#      CRYPTO_DIR: "./alternatives/openssl_1.1"
+#
+#    steps:
+#    - uses: actions/checkout@v4
+#      with:
+#        submodules: recursive
+#        fetch-depth: 0
+#
+#    - uses: ./.github/actions/prepare-build
+#      with:
+#        os: ubuntu-latest
+#        crypto-dir: openssl_1.1
+#        cache-dir: ${{ github.workspace }}/vcpkg_cache
+#
+#    - name: Build
+#      run: |
+#        cmake -B "${{ env.BUILD_DIR }}" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}"
+#        cmake --build "${{ env.BUILD_DIR }}"
+#
+#    - name: Build (Interop Harness)
+#      run: |
+#        cd cmd/interop
+#        cmake -B build
+#        cmake --build build
+#
+#    - name: Test self-interop
+#      run: |
+#        make -C cmd/interop self-test
+#
+#    - name: Test interop on test vectors
+#      run: |
+#        make -C cmd/interop interop-test
+#
+#    - name: Test gRPC live interop with self
+#      run: |
+#        cd cmd/interop
+#        ./grpc-self-test.sh
+#
   clang-tidy:
     if: github.event.pull_request.draft == false
-    needs: build-and-unit-test
+#    needs: build-and-unit-test
     name: Build with clang-tidy
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -63,16 +63,10 @@ jobs:
       run: |
         cmake --build "${{ env.BUILD_DIR }}" --target test
 
-# XXX(RLB): Unit tests are currently disabled on Windows because of two
-# conflicting bugs.  On the one hand, doctest has a bug that causes
-# doctest_discover_tests to fail when tests are built with sanitizers.  On the
-# other hand, if tests are not built with sanitizers, then the unit tests hang
-# in the middle of the test run.
-#
-#    - name: Unit Test (Windows)
-#      if: matrix.os == 'windows-latest'
-#      run: |
-#        cmake --build "${{ env.BUILD_DIR }}" --target RUN_TESTS
+    - name: Unit Test (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        cmake --build "${{ env.BUILD_DIR }}" --target RUN_TESTS
   
   interop-test:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -34,8 +34,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest] # XXX, ubuntu-latest, macos-latest]
-        crypto: [openssl_1.1] # XXX, openssl_3, boringssl]
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        crypto: [openssl_1.1, openssl_3, boringssl]
 
     env:
       BUILD_DIR: "${RUNNER_TEMP}/build_${{ matrix.crypto }}"
@@ -55,7 +55,7 @@ jobs:
 
     - name: Build
       run: |
-        cmake -B "${{ env.BUILD_DIR }}" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}" -DTESTING=ON -DSANITIZERS=ON
+        cmake -B "${{ env.BUILD_DIR }}" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}" -DTESTING=ON
         cmake --build "${{ env.BUILD_DIR }}"
 
     - name: Unit Test (non-Windows)
@@ -63,10 +63,16 @@ jobs:
       run: |
         cmake --build "${{ env.BUILD_DIR }}" --target test
 
-    - name: Unit Test (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        cmake --build "${{ env.BUILD_DIR }}" --target RUN_TESTS
+# XXX(RLB): Unit tests are currently disabled on Windows because of two
+# conflicting bugs.  On the one hand, doctest has a bug that causes
+# doctest_discover_tests to fail when tests are built with sanitizers.  On the
+# other hand, if tests are not built with sanitizers, then the unit tests hang
+# in the middle of the test run.
+#
+#    - name: Unit Test (Windows)
+#      if: matrix.os == 'windows-latest'
+#      run: |
+#        cmake --build "${{ env.BUILD_DIR }}" --target RUN_TESTS
   
   interop-test:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -34,8 +34,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
-        crypto: [openssl_1.1, openssl_3, boringssl]
+        os: [windows-latest] # XXX, ubuntu-latest, macos-latest]
+        crypto: [openssl_1.1] # XXX, openssl_3, boringssl]
 
     env:
       BUILD_DIR: "${RUNNER_TEMP}/build_${{ matrix.crypto }}"
@@ -55,7 +55,7 @@ jobs:
 
     - name: Build
       run: |
-        cmake -B "${{ env.BUILD_DIR }}" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}" -DTESTING=ON
+        cmake -B "${{ env.BUILD_DIR }}" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}" -DTESTING=ON -DSANITIZERS=ON
         cmake --build "${{ env.BUILD_DIR }}"
 
     - name: Unit Test (non-Windows)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,11 @@ endif ()
 ###
 if(TESTING)
   enable_testing()
+  
+  find_package(Catch2 REQUIRED)
+  
+  include(CTest)
+  include(Catch)
 endif()
 
 ###

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ endif ()
 if(TESTING)
   enable_testing()
   
-  find_package(Catch2 REQUIRED)
+  find_package(Catch2 3 REQUIRED)
   
   include(CTest)
   include(Catch)

--- a/alternatives/boringssl/vcpkg.json
+++ b/alternatives/boringssl/vcpkg.json
@@ -10,5 +10,11 @@
     "catch2",
     "nlohmann-json"
   ],
-  "builtin-baseline": "3b3bd424827a1f7f4813216f6b32b6c61e386b2e"
+  "builtin-baseline": "eb33d2f7583405fca184bcdf7fdd5828ec88ac05",
+  "overrides": [
+    {
+      "name": "catch2",
+      "version": "3.5.0"
+    }
+  ]
 }

--- a/alternatives/boringssl/vcpkg.json
+++ b/alternatives/boringssl/vcpkg.json
@@ -10,5 +10,5 @@
     "catch2",
     "nlohmann-json"
   ],
-  "builtin-baseline": "5908d702d61cea1429b223a0b7a10ab86bad4c78"
+  "builtin-baseline": "3b3bd424827a1f7f4813216f6b32b6c61e386b2e"
 }

--- a/alternatives/boringssl/vcpkg.json
+++ b/alternatives/boringssl/vcpkg.json
@@ -7,7 +7,7 @@
       "name": "boringssl",
       "version>=": "2023-10-13"
     },
-    "doctest",
+    "catch2",
     "nlohmann-json"
   ],
   "builtin-baseline": "5908d702d61cea1429b223a0b7a10ab86bad4c78"

--- a/alternatives/openssl_1.1/vcpkg.json
+++ b/alternatives/openssl_1.1/vcpkg.json
@@ -7,6 +7,7 @@
       "name": "openssl",
       "version>=": "1.1.1n"
     },
+    "catch2",
     "doctest",
     "nlohmann-json"
   ],

--- a/alternatives/openssl_1.1/vcpkg.json
+++ b/alternatives/openssl_1.1/vcpkg.json
@@ -8,7 +8,6 @@
       "version>=": "1.1.1n"
     },
     "catch2",
-    "doctest",
     "nlohmann-json"
   ],
   "builtin-baseline": "3b3bd424827a1f7f4813216f6b32b6c61e386b2e",

--- a/alternatives/openssl_1.1/vcpkg.json
+++ b/alternatives/openssl_1.1/vcpkg.json
@@ -10,7 +10,7 @@
     "catch2",
     "nlohmann-json"
   ],
-  "builtin-baseline": "3b3bd424827a1f7f4813216f6b32b6c61e386b2e",
+  "builtin-baseline": "eb33d2f7583405fca184bcdf7fdd5828ec88ac05",
   "overrides": [
     {
       "name": "openssl",

--- a/alternatives/openssl_3/vcpkg.json
+++ b/alternatives/openssl_3/vcpkg.json
@@ -10,7 +10,7 @@
     "catch2",
     "nlohmann-json"
   ],
-  "builtin-baseline": "5908d702d61cea1429b223a0b7a10ab86bad4c78",
+  "builtin-baseline": "3b3bd424827a1f7f4813216f6b32b6c61e386b2e",
   "overrides": [
     {
       "name": "openssl",

--- a/alternatives/openssl_3/vcpkg.json
+++ b/alternatives/openssl_3/vcpkg.json
@@ -7,7 +7,7 @@
       "name": "openssl",
       "version>=": "3.0.7"
     },
-    "doctest",
+    "catch2",
     "nlohmann-json"
   ],
   "builtin-baseline": "5908d702d61cea1429b223a0b7a10ab86bad4c78",

--- a/alternatives/openssl_3/vcpkg.json
+++ b/alternatives/openssl_3/vcpkg.json
@@ -10,11 +10,15 @@
     "catch2",
     "nlohmann-json"
   ],
-  "builtin-baseline": "3b3bd424827a1f7f4813216f6b32b6c61e386b2e",
+  "builtin-baseline": "eb33d2f7583405fca184bcdf7fdd5828ec88ac05",
   "overrides": [
     {
       "name": "openssl",
       "version": "3.0.7"
+    },
+    {
+      "name": "catch2",
+      "version": "3.5.0"
     }
   ]
 }

--- a/lib/bytes/test/CMakeLists.txt
+++ b/lib/bytes/test/CMakeLists.txt
@@ -1,16 +1,17 @@
 set(TEST_APP_NAME "${CURRENT_LIB_NAME}_test")
 
 # Dependencies
-find_package(doctest REQUIRED)
+find_package(Catch2 REQUIRED)
 
 # Test Binary
 file(GLOB TEST_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
 add_executable(${TEST_APP_NAME} ${TEST_SOURCES})
 add_dependencies(${TEST_APP_NAME} ${CURRENT_LIB_NAME})
-target_link_libraries(${TEST_APP_NAME} ${CURRENT_LIB_NAME} doctest::doctest)
+target_link_libraries(${TEST_APP_NAME} PRIVATE ${CURRENT_LIB_NAME} Catch2::Catch2WithMain)
 
 # Enable CTest
-include(doctest)
 enable_testing()
-doctest_discover_tests(${TEST_APP_NAME} ADD_LABELS 0)
+include(CTest)
+include(Catch)
+catch_discover_tests(${TEST_APP_NAME})

--- a/lib/bytes/test/CMakeLists.txt
+++ b/lib/bytes/test/CMakeLists.txt
@@ -1,8 +1,5 @@
 set(TEST_APP_NAME "${CURRENT_LIB_NAME}_test")
 
-# Dependencies
-find_package(Catch2 REQUIRED)
-
 # Test Binary
 file(GLOB TEST_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
@@ -11,7 +8,4 @@ add_dependencies(${TEST_APP_NAME} ${CURRENT_LIB_NAME})
 target_link_libraries(${TEST_APP_NAME} PRIVATE ${CURRENT_LIB_NAME} Catch2::Catch2WithMain)
 
 # Enable CTest
-enable_testing()
-include(CTest)
-include(Catch)
 catch_discover_tests(${TEST_APP_NAME})

--- a/lib/bytes/test/bytes.cpp
+++ b/lib/bytes/test/bytes.cpp
@@ -1,5 +1,5 @@
 #include <bytes/bytes.h>
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <memory>
 #include <sstream>
 
@@ -31,7 +31,8 @@ TEST_CASE("Zeroization")
   // to be basically all zero.
   const auto snapshot = std::vector<uint8_t>(begin, end);
   const auto threshold = size - 4 * sizeof(void*);
-  REQUIRE(std::count(snapshot.begin(), snapshot.end(), 0) >= threshold);
+  const auto count = std::count(snapshot.begin(), snapshot.end(), 0);
+  REQUIRE(static_cast<size_t>(count) >= threshold);
 }
 #endif
 

--- a/lib/bytes/test/bytes.cpp
+++ b/lib/bytes/test/bytes.cpp
@@ -1,5 +1,5 @@
 #include <bytes/bytes.h>
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <memory>
 #include <sstream>
 

--- a/lib/bytes/test/main.cpp
+++ b/lib/bytes/test/main.cpp
@@ -1,2 +1,0 @@
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include <doctest/doctest.h>

--- a/lib/hpke/test/CMakeLists.txt
+++ b/lib/hpke/test/CMakeLists.txt
@@ -1,15 +1,13 @@
 set(TEST_APP_NAME "${CURRENT_LIB_NAME}_test")
 
-# Dependencies
-find_package(doctest REQUIRED)
-
 # Test Binary
 file(GLOB TEST_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
 add_executable(${TEST_APP_NAME} ${TEST_SOURCES})
 add_dependencies(${TEST_APP_NAME} ${CURRENT_LIB_NAME} bytes tls_syntax)
-target_link_libraries(${TEST_APP_NAME} ${CURRENT_LIB_NAME} bytes tls_syntax doctest::doctest OpenSSL::Crypto)
+target_link_libraries(${TEST_APP_NAME} PRIVATE ${CURRENT_LIB_NAME}
+  bytes tls_syntax
+  Catch2::Catch2WithMain OpenSSL::Crypto)
 
 # Enable CTest
-include(doctest)
-doctest_discover_tests(${TEST_APP_NAME} ADD_LABELS 0)
+catch_discover_tests(${TEST_APP_NAME})

--- a/lib/hpke/test/aead.cpp
+++ b/lib/hpke/test/aead.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <hpke/hpke.h>
 
 #include "common.h"

--- a/lib/hpke/test/aead.cpp
+++ b/lib/hpke/test/aead.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <hpke/hpke.h>
 
 #include "common.h"

--- a/lib/hpke/test/base64.cpp
+++ b/lib/hpke/test/base64.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <hpke/base64.h>
 
 using namespace MLS_NAMESPACE::hpke;

--- a/lib/hpke/test/base64.cpp
+++ b/lib/hpke/test/base64.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <hpke/base64.h>
 
 using namespace MLS_NAMESPACE::hpke;

--- a/lib/hpke/test/certificate.cpp
+++ b/lib/hpke/test/certificate.cpp
@@ -7,9 +7,6 @@
 #include <iostream>
 #include <vector>
 
-#include <tls/compat.h>
-namespace opt = MLS_NAMESPACE::tls::opt;
-
 TEST_CASE("Certificate Known-Answer depth 2")
 {
   // TODO(suhas) Do this for each supported signature algorithm

--- a/lib/hpke/test/certificate.cpp
+++ b/lib/hpke/test/certificate.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <hpke/certificate.h>
 
 #include "common.h"

--- a/lib/hpke/test/certificate.cpp
+++ b/lib/hpke/test/certificate.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <hpke/certificate.h>
 
 #include "common.h"
@@ -106,9 +106,9 @@ TEST_CASE("Certificate Known-Answer depth 2 with SKID/ADID")
     "4100314a485d01df4c7852ec5720b2af34f5620b2a32a50c4ee0481d013ebbfd8e243784"
     "123a0cfe4d59b1fb09a1738ee9bc2aab59a2b4af2c3ee60ce19afbe1eb03");
 
-  const auto root_skid = std::string("b9e672b8");
-  const auto issuing_skid = std::string("75ecb844");
-  const auto leaf_skid = std::string("dd3b0790");
+  const auto root_skid = from_hex("b9e672b8");
+  const auto issuing_skid = from_hex("75ecb844");
+  const auto leaf_skid = from_hex("dd3b0790");
 
   auto root = Certificate{ root_der };
   auto issuing = Certificate{ issuing_der };
@@ -130,13 +130,11 @@ TEST_CASE("Certificate Known-Answer depth 2 with SKID/ADID")
 
   REQUIRE(root.subject_key_id().has_value());
 
-  CHECK_EQ(to_hex(opt::get(leaf.subject_key_id())), leaf_skid);
-  CHECK_EQ(to_hex(opt::get(leaf.authority_key_id())),
-           to_hex(opt::get(issuing.subject_key_id())));
-  CHECK_EQ(to_hex(opt::get(issuing.subject_key_id())), issuing_skid);
-  CHECK_EQ(to_hex(opt::get(issuing.authority_key_id())),
-           to_hex(opt::get(root.subject_key_id())));
-  CHECK_EQ(to_hex(opt::get(root.subject_key_id())), root_skid);
+  CHECK(leaf.subject_key_id() == leaf_skid);
+  CHECK(leaf.authority_key_id() == issuing.subject_key_id());
+  CHECK(issuing.subject_key_id() == issuing_skid);
+  CHECK(issuing.authority_key_id() == root.subject_key_id());
+  CHECK(root.subject_key_id() == root_skid);
 }
 
 TEST_CASE("Certificate Known-Answer depth 2 with SAN RFC822Name")
@@ -174,7 +172,7 @@ TEST_CASE("Certificate Known-Answer depth 2 with SAN RFC822Name")
   CHECK(issuing.valid_from(root));
   CHECK(root.valid_from(root));
 
-  CHECK_EQ(leaf.email_addresses().at(0), "user@domain.com");
+  CHECK(leaf.email_addresses().at(0) == "user@domain.com");
 }
 
 TEST_CASE("RSA-SHA256 Certificate Known-Answer depth 2")
@@ -593,12 +591,15 @@ TEST_CASE("Test Subject Parsing")
 
   auto leaf = Certificate{ leaf_der };
   CHECK(leaf.raw == leaf_der);
+
   auto parsed_subject = leaf.subject();
-  CHECK_EQ(parsed_subject.size(), 2);
+  CHECK(parsed_subject.size() == 2);
+
   auto it = parsed_subject.find(Certificate::NameType::common_name);
-  CHECK_EQ(it->second, "custom:12345");
+  CHECK(it->second == "custom:12345");
+
   it = parsed_subject.find(Certificate::NameType::serial_number);
-  CHECK_EQ(it->second, "11-22-33");
+  CHECK(it->second == "11-22-33");
 }
 
 TEST_CASE("Test Certificate notBefore status")

--- a/lib/hpke/test/common.cpp
+++ b/lib/hpke/test/common.cpp
@@ -2,7 +2,7 @@
 #include <set>
 #include <stdexcept>
 
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <openssl/crypto.h>
 
 #if defined(WITH_OPENSSL3)

--- a/lib/hpke/test/common.cpp
+++ b/lib/hpke/test/common.cpp
@@ -2,7 +2,7 @@
 #include <set>
 #include <stdexcept>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <openssl/crypto.h>
 
 #if defined(WITH_OPENSSL3)

--- a/lib/hpke/test/hpke.cpp
+++ b/lib/hpke/test/hpke.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <hpke/hpke.h>
 #include <namespace.h>
 

--- a/lib/hpke/test/hpke.cpp
+++ b/lib/hpke/test/hpke.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <hpke/hpke.h>
 #include <namespace.h>
 

--- a/lib/hpke/test/kdf.cpp
+++ b/lib/hpke/test/kdf.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <hpke/hpke.h>
 
 #include "common.h"

--- a/lib/hpke/test/kdf.cpp
+++ b/lib/hpke/test/kdf.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <hpke/hpke.h>
 
 #include "common.h"

--- a/lib/hpke/test/kem.cpp
+++ b/lib/hpke/test/kem.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <hpke/hpke.h>
 
 #include "common.h"
@@ -34,7 +34,7 @@ TEST_CASE("KEM round-trip")
     auto pkSm = kem.serialize(*pkS);
     REQUIRE(pkSm.size() == kem.pk_size);
 
-    SUBCASE("Encap/Decap")
+    SECTION("Encap/Decap")
     {
       auto [secretS_, enc_] = kem.encap(*pkR);
       auto secretS = secretS_;
@@ -47,7 +47,7 @@ TEST_CASE("KEM round-trip")
       REQUIRE(secretR == secretS);
     }
 
-    SUBCASE("AuthEncap/AuthDecap")
+    SECTION("AuthEncap/AuthDecap")
     {
       auto [secretS_, enc_] = kem.auth_encap(*pkR, *skS);
       auto secretS = secretS_;

--- a/lib/hpke/test/kem.cpp
+++ b/lib/hpke/test/kem.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <hpke/hpke.h>
 
 #include "common.h"

--- a/lib/hpke/test/main.cpp
+++ b/lib/hpke/test/main.cpp
@@ -1,2 +1,0 @@
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include <doctest/doctest.h>

--- a/lib/hpke/test/random.cpp
+++ b/lib/hpke/test/random.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <hpke/random.h>
 
 #include "common.h"

--- a/lib/hpke/test/random.cpp
+++ b/lib/hpke/test/random.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <hpke/random.h>
 
 #include "common.h"

--- a/lib/hpke/test/signature.cpp
+++ b/lib/hpke/test/signature.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <hpke/signature.h>
 #include <nlohmann/json.hpp>
 

--- a/lib/hpke/test/signature.cpp
+++ b/lib/hpke/test/signature.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <hpke/signature.h>
 #include <nlohmann/json.hpp>
 

--- a/lib/hpke/test/userinfo_vc.cpp
+++ b/lib/hpke/test/userinfo_vc.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <hpke/userinfo_vc.h>
 #include <nlohmann/json.hpp>
 

--- a/lib/hpke/test/userinfo_vc.cpp
+++ b/lib/hpke/test/userinfo_vc.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <hpke/userinfo_vc.h>
 #include <nlohmann/json.hpp>
 
@@ -7,6 +7,8 @@ namespace opt = MLS_NAMESPACE::tls::opt;
 
 using namespace MLS_NAMESPACE::hpke;
 using namespace std::string_literals;
+
+namespace mls::hpke {
 
 static bool
 operator==(const Signature::PublicJWK& lhs, const Signature::PublicJWK& rhs)
@@ -20,6 +22,8 @@ operator==(const Signature::PublicJWK& lhs, const Signature::PublicJWK& rhs)
 
   return sig && kid && key;
 }
+
+} // namespace mls::hpke
 
 TEST_CASE("UserInfoVC Parsing and Validation")
 {

--- a/lib/mls_vectors/test/CMakeLists.txt
+++ b/lib/mls_vectors/test/CMakeLists.txt
@@ -1,15 +1,11 @@
 set(TEST_APP_NAME "${CURRENT_LIB_NAME}_test")
 
-# Dependencies
-find_package(doctest REQUIRED)
-
 # Test Binary
 file(GLOB TEST_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
 add_executable(${TEST_APP_NAME} ${TEST_SOURCES})
 add_dependencies(${TEST_APP_NAME} ${CURRENT_LIB_NAME} bytes tls_syntax)
-target_link_libraries(${TEST_APP_NAME} ${CURRENT_LIB_NAME} doctest::doctest)
+target_link_libraries(${TEST_APP_NAME} PRIVATE ${CURRENT_LIB_NAME} Catch2::Catch2WithMain)
 
 # Enable CTest
-include(doctest)
-doctest_discover_tests(${TEST_APP_NAME} ADD_LABELS 0)
+catch_discover_tests(${TEST_APP_NAME})

--- a/lib/mls_vectors/test/main.cpp
+++ b/lib/mls_vectors/test/main.cpp
@@ -1,2 +1,0 @@
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include <doctest/doctest.h>

--- a/lib/mls_vectors/test/mls_vectors.cpp
+++ b/lib/mls_vectors/test/mls_vectors.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <mls_vectors/mls_vectors.h>
 #include <tls/tls_syntax.h>
 

--- a/lib/mls_vectors/test/mls_vectors.cpp
+++ b/lib/mls_vectors/test/mls_vectors.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <mls_vectors/mls_vectors.h>
 #include <tls/tls_syntax.h>
 

--- a/lib/tls_syntax/test/CMakeLists.txt
+++ b/lib/tls_syntax/test/CMakeLists.txt
@@ -1,15 +1,11 @@
 set(TEST_APP_NAME "${CURRENT_LIB_NAME}_test")
 
-# Dependencies
-find_package(doctest REQUIRED)
-
 # Test Binary
 file(GLOB TEST_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
 add_executable(${TEST_APP_NAME} ${TEST_SOURCES})
 add_dependencies(${TEST_APP_NAME} ${CURRENT_LIB_NAME} bytes)
-target_link_libraries(${TEST_APP_NAME} ${CURRENT_LIB_NAME} bytes doctest::doctest)
+target_link_libraries(${TEST_APP_NAME} PRIVATE ${CURRENT_LIB_NAME} bytes Catch2::Catch2WithMain)
 
 # Enable CTest
-include(doctest)
-doctest_discover_tests(${TEST_APP_NAME} ADD_LABELS 0)
+catch_discover_tests(${TEST_APP_NAME})

--- a/lib/tls_syntax/test/main.cpp
+++ b/lib/tls_syntax/test/main.cpp
@@ -1,2 +1,0 @@
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include <doctest/doctest.h>

--- a/lib/tls_syntax/test/tls_syntax.cpp
+++ b/lib/tls_syntax/test/tls_syntax.cpp
@@ -1,5 +1,5 @@
 #include <bytes/bytes.h>
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <namespace.h>
 #include <tls/tls_syntax.h>
 

--- a/lib/tls_syntax/test/tls_syntax.cpp
+++ b/lib/tls_syntax/test/tls_syntax.cpp
@@ -1,5 +1,5 @@
 #include <bytes/bytes.h>
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <namespace.h>
 #include <tls/tls_syntax.h>
 
@@ -106,7 +106,7 @@ ostream_test(T val, const std::vector<uint8_t>& enc)
   REQUIRE(w.size() == enc.size());
 }
 
-TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS ostream")
+TEST_CASE_METHOD(TLSSyntaxTest, "TLS ostream")
 {
   bytes answer{ 1, 2, 3, 4 };
   MLS_NAMESPACE::tls::ostream w;
@@ -136,7 +136,7 @@ istream_test(T val, T& data, const std::vector<uint8_t>& enc)
   REQUIRE(r.empty());
 }
 
-TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS istream")
+TEST_CASE_METHOD(TLSSyntaxTest, "TLS istream")
 {
   bool data_bool = false;
   istream_test(val_bool, data_bool, enc_bool);
@@ -172,7 +172,7 @@ TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS istream")
   istream_test(val_enum, data_enum, enc_enum);
 }
 
-TEST_CASE_FIXTURE(TLSSyntaxTest, "TLS abbreviations")
+TEST_CASE_METHOD(TLSSyntaxTest, "TLS abbreviations")
 {
   ExampleStruct val_in = val_struct;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,16 +1,12 @@
 set(TEST_APP_NAME "${LIB_NAME}_test")
 
-# Dependencies
-find_package(doctest REQUIRED)
-
 # Test Binary
 file(GLOB TEST_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
 add_executable(${TEST_APP_NAME} ${TEST_SOURCES})
 add_dependencies(${TEST_APP_NAME} ${LIB_NAME} bytes tls_syntax mls_vectors)
 target_include_directories(${TEST_APP_NAME} PRIVATE ${PROJECT_SOURCE_DIR}/src)
-target_link_libraries(${TEST_APP_NAME} mls_vectors doctest::doctest)
+target_link_libraries(${TEST_APP_NAME} PRIVATE mls_vectors Catch2::Catch2WithMain)
 
 # Enable CTest
-include(doctest)
-doctest_discover_tests(${TEST_APP_NAME} ADD_LABELS 0)
+catch_discover_tests(${TEST_APP_NAME})

--- a/test/credential.cpp
+++ b/test/credential.cpp
@@ -137,7 +137,7 @@ TEST_CASE("X509 Credential Depth 2")
 
   auto cred = Credential::x509(der_in);
   auto x509 = cred.get<X509Credential>();
-  CHECK(x509.public_key().data.size() != 0);
+  CHECK(!x509.public_key().data.size());
 
   const auto& x509_original = cred.get<X509Credential>();
   CHECK(x509.der_chain == x509_original.der_chain);
@@ -167,7 +167,7 @@ TEST_CASE("X509 Credential Depth 2 Marshal/Unmarshal")
 
   auto original = Credential::x509(der_in);
   const auto& x509_original = original.get<X509Credential>();
-  CHECK(x509_original.public_key().data.size() != 0);
+  CHECK(!x509_original.public_key().data.empty());
 
   auto marshalled = tls::marshal(original);
   auto unmarshaled = tls::get<Credential>(marshalled);
@@ -193,7 +193,7 @@ TEST_CASE("X509 Credential Depth 1 Marshal/Unmarshal")
 
   auto original = Credential::x509(der_in);
   auto x509_original = original.get<X509Credential>();
-  CHECK(x509_original.public_key().data.size() != 0);
+  CHECK(!x509_original.public_key().data.empty());
 
   auto marshalled = tls::marshal(original);
   auto unmarshaled = tls::get<Credential>(marshalled);

--- a/test/credential.cpp
+++ b/test/credential.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <mls/credential.h>
 
 using namespace MLS_NAMESPACE;

--- a/test/credential.cpp
+++ b/test/credential.cpp
@@ -137,7 +137,7 @@ TEST_CASE("X509 Credential Depth 2")
 
   auto cred = Credential::x509(der_in);
   auto x509 = cred.get<X509Credential>();
-  CHECK(!x509.public_key().data.size());
+  CHECK(!x509.public_key().data.empty());
 
   const auto& x509_original = cred.get<X509Credential>();
   CHECK(x509.der_chain == x509_original.der_chain);

--- a/test/credential.cpp
+++ b/test/credential.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <mls/credential.h>
 
 using namespace MLS_NAMESPACE;

--- a/test/crypto.cpp
+++ b/test/crypto.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <mls/crypto.h>
 #include <mls_vectors/mls_vectors.h>
 #include <string>

--- a/test/crypto.cpp
+++ b/test/crypto.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <mls/crypto.h>
 #include <mls_vectors/mls_vectors.h>
 #include <string>

--- a/test/grease.cpp
+++ b/test/grease.cpp
@@ -1,5 +1,5 @@
 #include "grease.h"
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <mls/core_types.h>
 #include <mls/messages.h>
 

--- a/test/grease.cpp
+++ b/test/grease.cpp
@@ -1,5 +1,5 @@
 #include "grease.h"
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <mls/core_types.h>
 #include <mls/messages.h>
 

--- a/test/key_schedule.cpp
+++ b/test/key_schedule.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <mls/state.h>
 #include <mls_vectors/mls_vectors.h>
 

--- a/test/key_schedule.cpp
+++ b/test/key_schedule.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <mls/state.h>
 #include <mls_vectors/mls_vectors.h>
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,2 +1,0 @@
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-#include <doctest/doctest.h>

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <mls/messages.h>
 #include <mls/state.h>
 #include <mls_vectors/mls_vectors.h>

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <mls/messages.h>
 #include <mls/state.h>
 #include <mls_vectors/mls_vectors.h>
@@ -95,7 +95,7 @@ protected:
   GroupContent proposal_content;
 };
 
-TEST_CASE_FIXTURE(MLSMessageTest, "AuthenticatedContent Sign/Verify")
+TEST_CASE_METHOD(MLSMessageTest, "AuthenticatedContent Sign/Verify")
 {
   // Verify that a sign / verify round-trip works
   auto content_auth =
@@ -117,7 +117,7 @@ TEST_CASE_FIXTURE(MLSMessageTest, "AuthenticatedContent Sign/Verify")
                                             context));
 }
 
-TEST_CASE_FIXTURE(MLSMessageTest, "PublicMessage Protect/Unprotect")
+TEST_CASE_METHOD(MLSMessageTest, "PublicMessage Protect/Unprotect")
 {
   auto content = proposal_content;
   auto content_auth_original =
@@ -133,7 +133,7 @@ TEST_CASE_FIXTURE(MLSMessageTest, "PublicMessage Protect/Unprotect")
   REQUIRE(content_auth_unprotected == content_auth_original);
 }
 
-TEST_CASE_FIXTURE(MLSMessageTest, "PrivateMessage Protect/Unprotect")
+TEST_CASE_METHOD(MLSMessageTest, "PrivateMessage Protect/Unprotect")
 {
   auto content = proposal_content;
   auto content_auth_original =

--- a/test/session.cpp
+++ b/test/session.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <hpke/random.h>
 #include <mls/session.h>
 
@@ -125,12 +125,12 @@ protected:
   }
 };
 
-TEST_CASE_FIXTURE(SessionTest, "Two-Person Session Creation")
+TEST_CASE_METHOD(SessionTest, "Two-Person Session Creation")
 {
   broadcast_add();
 }
 
-TEST_CASE_FIXTURE(SessionTest, "Full-Size Session Creation")
+TEST_CASE_METHOD(SessionTest, "Full-Size Session Creation")
 {
   for (int i = 0; i < group_size - 1; i += 1) {
     broadcast_add();
@@ -148,7 +148,7 @@ protected:
   }
 };
 
-TEST_CASE_FIXTURE(RunningSessionTest, "Update within Session")
+TEST_CASE_METHOD(RunningSessionTest, "Update within Session")
 {
   for (int i = 0; i < group_size; i += 1) {
     auto initial_epoch = sessions[0].epoch();
@@ -160,7 +160,7 @@ TEST_CASE_FIXTURE(RunningSessionTest, "Update within Session")
   }
 }
 
-TEST_CASE_FIXTURE(RunningSessionTest, "Remove within Session")
+TEST_CASE_METHOD(RunningSessionTest, "Remove within Session")
 {
   for (int i = group_size - 1; i > 0; i -= 1) {
     auto initial_epoch = sessions[0].epoch();
@@ -177,7 +177,7 @@ TEST_CASE_FIXTURE(RunningSessionTest, "Remove within Session")
   }
 }
 
-TEST_CASE_FIXTURE(RunningSessionTest, "Replace within Session")
+TEST_CASE_METHOD(RunningSessionTest, "Replace within Session")
 {
   for (int i = 0; i < group_size; ++i) {
     auto target = (i + 1) % group_size;
@@ -197,7 +197,7 @@ TEST_CASE_FIXTURE(RunningSessionTest, "Replace within Session")
   }
 }
 
-TEST_CASE_FIXTURE(RunningSessionTest, "Full Session Life-Cycle")
+TEST_CASE_METHOD(RunningSessionTest, "Full Session Life-Cycle")
 {
   // 1. Group is created in the ctor
 

--- a/test/session.cpp
+++ b/test/session.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <hpke/random.h>
 #include <mls/session.h>
 

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <hpke/random.h>
 #include <mls/common.h>
 #include <mls/state.h>

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <hpke/random.h>
 #include <mls/common.h>
 #include <mls/state.h>
@@ -119,7 +119,7 @@ protected:
   }
 };
 
-TEST_CASE_FIXTURE(StateTest, "Two Person")
+TEST_CASE_METHOD(StateTest, "Two Person")
 {
   // Initialize the creator's state
   auto first0 = State{ group_id,
@@ -150,7 +150,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person")
   verify_group_functionality(group);
 }
 
-TEST_CASE_FIXTURE(StateTest, "Two Person with New Member Add")
+TEST_CASE_METHOD(StateTest, "Two Person with New Member Add")
 {
   // Initialize the creator's state
   auto first0 = State{ group_id,
@@ -183,7 +183,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with New Member Add")
   verify_group_functionality(group);
 }
 
-TEST_CASE_FIXTURE(StateTest, "Two Person with External Proposal")
+TEST_CASE_METHOD(StateTest, "Two Person with External Proposal")
 {
   // Initialize the creator's state, with two trusted external parties
   auto external_priv_0 = SignaturePrivateKey::generate(suite);
@@ -228,7 +228,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with External Proposal")
   verify_group_functionality(group);
 }
 
-TEST_CASE_FIXTURE(StateTest, "Two Person with custom extensions")
+TEST_CASE_METHOD(StateTest, "Two Person with custom extensions")
 {
   // Initialize the creator's state
   auto first_exts = ExtensionList{};
@@ -276,7 +276,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with custom extensions")
   REQUIRE(first2.extensions() == second_exts);
 }
 
-TEST_CASE_FIXTURE(StateTest, "Two Person with external tree for welcome")
+TEST_CASE_METHOD(StateTest, "Two Person with external tree for welcome")
 {
   // Initialize the creator's state
   auto first0 = State{ group_id,
@@ -332,7 +332,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with external tree for welcome")
   verify_group_functionality(group);
 }
 
-TEST_CASE_FIXTURE(StateTest, "Two Person with PSK")
+TEST_CASE_METHOD(StateTest, "Two Person with PSK")
 {
   const auto psk_id = from_ascii("external psk");
   const auto psk_secret = from_ascii("super secret");
@@ -365,7 +365,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with PSK")
   REQUIRE(first1 == second0);
 }
 
-TEST_CASE_FIXTURE(StateTest, "Two Person with Replacement")
+TEST_CASE_METHOD(StateTest, "Two Person with Replacement")
 {
   // Initialize the creator's state
   auto first0 = State{ group_id,
@@ -419,7 +419,7 @@ TEST_CASE_FIXTURE(StateTest, "Two Person with Replacement")
   verify_group_functionality(group);
 }
 
-TEST_CASE_FIXTURE(StateTest, "External Join")
+TEST_CASE_METHOD(StateTest, "External Join")
 {
   // Initialize the creator's state
   auto first0 = State{ group_id,
@@ -447,7 +447,7 @@ TEST_CASE_FIXTURE(StateTest, "External Join")
   verify_group_functionality(group);
 }
 
-TEST_CASE_FIXTURE(StateTest, "External Join with External Tree")
+TEST_CASE_METHOD(StateTest, "External Join with External Tree")
 {
   // Initialize the creator's state
   auto first0 = State{ group_id,
@@ -476,7 +476,7 @@ TEST_CASE_FIXTURE(StateTest, "External Join with External Tree")
   verify_group_functionality(group);
 }
 
-TEST_CASE_FIXTURE(StateTest, "External Join with PSK")
+TEST_CASE_METHOD(StateTest, "External Join with PSK")
 {
   // Initialize the creator's state
   auto first0 = State{ group_id,
@@ -512,7 +512,7 @@ TEST_CASE_FIXTURE(StateTest, "External Join with PSK")
   verify_group_functionality(group);
 }
 
-TEST_CASE_FIXTURE(StateTest, "External Join with Eviction of Prior Appearance")
+TEST_CASE_METHOD(StateTest, "External Join with Eviction of Prior Appearance")
 {
   // Initialize the creator's state
   auto first0 = State{ group_id,
@@ -559,7 +559,7 @@ TEST_CASE_FIXTURE(StateTest, "External Join with Eviction of Prior Appearance")
   REQUIRE(first2.roster().size() == 2);
 }
 
-TEST_CASE_FIXTURE(StateTest, "SFrame Parameter Negotiation")
+TEST_CASE_METHOD(StateTest, "SFrame Parameter Negotiation")
 {
   // Set the SFrame parameters for the group
   auto specified_params = SFrameParameters{ 1, 8 };
@@ -603,7 +603,7 @@ TEST_CASE_FIXTURE(StateTest, "SFrame Parameter Negotiation")
   REQUIRE(opt::get(first_params) == opt::get(second_params));
 }
 
-TEST_CASE_FIXTURE(StateTest, "Enforce Required Capabilities")
+TEST_CASE_METHOD(StateTest, "Enforce Required Capabilities")
 {
   // Require some capabilities that don't exist
   auto exotic_extension = uint16_t(0xffff);
@@ -660,7 +660,7 @@ TEST_CASE_FIXTURE(StateTest, "Enforce Required Capabilities")
   state.handle(state.add(kp_yes_2, msg_opts));
 }
 
-TEST_CASE_FIXTURE(StateTest, "Add Multiple Members")
+TEST_CASE_METHOD(StateTest, "Add Multiple Members")
 {
   // Initialize the creator's state
   states.emplace_back(group_id,
@@ -696,7 +696,7 @@ TEST_CASE_FIXTURE(StateTest, "Add Multiple Members")
   verify_group_functionality(states);
 }
 
-TEST_CASE_FIXTURE(StateTest, "Full Size Group")
+TEST_CASE_METHOD(StateTest, "Full Size Group")
 {
   // Initialize the creator's state
   states.emplace_back(group_id,
@@ -784,7 +784,7 @@ protected:
   }
 };
 
-TEST_CASE_FIXTURE(RunningGroupTest, "Update Everyone via Empty Commit")
+TEST_CASE_METHOD(RunningGroupTest, "Update Everyone via Empty Commit")
 {
   for (size_t i = 0; i < group_size; i += 1) {
     auto new_leaf = fresh_secret();
@@ -803,7 +803,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Update Everyone via Empty Commit")
   }
 }
 
-TEST_CASE_FIXTURE(RunningGroupTest, "Update Everyone in a Group")
+TEST_CASE_METHOD(RunningGroupTest, "Update Everyone in a Group")
 {
   for (size_t i = 0; i < group_size; i += 1) {
     auto committer_index = (i + 1) % group_size;
@@ -831,7 +831,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Update Everyone in a Group")
   }
 }
 
-TEST_CASE_FIXTURE(RunningGroupTest, "Add a PSK from Everyone in a Group")
+TEST_CASE_METHOD(RunningGroupTest, "Add a PSK from Everyone in a Group")
 {
   for (uint32_t i = 0; i < group_size; i += 1) {
     auto psk_id = tls::marshal(i);
@@ -856,7 +856,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Add a PSK from Everyone in a Group")
   }
 }
 
-TEST_CASE_FIXTURE(RunningGroupTest, "Remove Members from a Group")
+TEST_CASE_METHOD(RunningGroupTest, "Remove Members from a Group")
 {
   for (uint32_t i = uint32_t(group_size) - 2; i > 0; i -= 1) {
     auto remove = states[i].remove_proposal(LeafIndex{ i + 1 });
@@ -877,7 +877,7 @@ TEST_CASE_FIXTURE(RunningGroupTest, "Remove Members from a Group")
   }
 }
 
-TEST_CASE_FIXTURE(RunningGroupTest, "Roster Updates")
+TEST_CASE_METHOD(RunningGroupTest, "Roster Updates")
 {
   static const auto get_creds = [](const auto& kps) {
     return stdx::transform<Credential>(
@@ -948,7 +948,7 @@ protected:
   }
 };
 
-TEST_CASE_FIXTURE(RelatedGroupTest, "Branch the group")
+TEST_CASE_METHOD(RelatedGroupTest, "Branch the group")
 {
   // Note the epoch authenticator before we branch
   auto original_epoch_authenticator = states[0].epoch_authenticator();
@@ -996,7 +996,7 @@ TEST_CASE_FIXTURE(RelatedGroupTest, "Branch the group")
   }
 }
 
-TEST_CASE_FIXTURE(RelatedGroupTest, "Reinitialize the group")
+TEST_CASE_METHOD(RelatedGroupTest, "Reinitialize the group")
 {
   // Member 0 proposes reinitialization with a new group ID
   auto new_group_id = from_ascii("reinitialized group");

--- a/test/tree_math.cpp
+++ b/test/tree_math.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <mls_vectors/mls_vectors.h>
 
 #include <vector>

--- a/test/tree_math.cpp
+++ b/test/tree_math.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <mls_vectors/mls_vectors.h>
 
 #include <vector>

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -1,4 +1,4 @@
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 #include <hpke/random.h>
 #include <mls/common.h>
 #include <mls/treekem.h>

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -1,4 +1,4 @@
-#include <doctest/doctest.h>
+#include <catch2/catch.hpp>
 #include <hpke/random.h>
 #include <mls/common.h>
 #include <mls/treekem.h>
@@ -29,7 +29,7 @@ protected:
   }
 };
 
-TEST_CASE_FIXTURE(TreeKEMTest, "ParentNode Equality")
+TEST_CASE_METHOD(TreeKEMTest, "ParentNode Equality")
 {
   auto initA = HPKEPrivateKey::generate(suite);
   auto initB = HPKEPrivateKey::generate(suite);
@@ -44,7 +44,7 @@ TEST_CASE_FIXTURE(TreeKEMTest, "ParentNode Equality")
   REQUIRE(nodeA != nodeB);
 }
 
-TEST_CASE_FIXTURE(TreeKEMTest, "Node public key")
+TEST_CASE_METHOD(TreeKEMTest, "Node public key")
 {
   auto parent_priv = HPKEPrivateKey::generate(suite);
   auto parent = Node{ ParentNode{ parent_priv.public_key, {}, {} } };
@@ -58,7 +58,7 @@ TEST_CASE_FIXTURE(TreeKEMTest, "Node public key")
   REQUIRE(leaf_node.public_key() == leaf_priv.public_key);
 }
 
-TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Private Key")
+TEST_CASE_METHOD(TreeKEMTest, "TreeKEM Private Key")
 {
   const auto size = LeafCount{ 5 };
   const auto index = LeafIndex{ 2 };
@@ -133,7 +133,7 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Private Key")
 //  X   _   _   _
 // X X _ X X _ _ _
 // 0123456789abcde
-TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Public Key")
+TEST_CASE_METHOD(TreeKEMTest, "TreeKEM Public Key")
 {
   const auto size = LeafCount{ 5 };
   const auto removed = LeafIndex{ 2 };
@@ -200,7 +200,7 @@ TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM Public Key")
   REQUIRE(root_resolution == pub.resolve(NodeIndex::root(size)));
 }
 
-TEST_CASE_FIXTURE(TreeKEMTest, "TreeKEM encap/decap")
+TEST_CASE_METHOD(TreeKEMTest, "TreeKEM encap/decap")
 {
   const auto size = LeafCount{ 10 };
 


### PR DESCRIPTION
As discussed in #415, doctest is broken and abandoned.  Catch2 seems to be a more standard and more supported test framework.  This PR converts MLSpp's tests from doctest to Catch2.

* Adjust all the `vcpkg.json` files so that Catch2 is available in all configurations
* Updates CMakeLists.txt in the test files to build/link against Catch2
* Makes some minor fixes in test files to fix errors building against Catch2

And for good measure, I went ahead and re-enabled tests on Windows.  We'll see what happens in CI!