### PR TITLE
Implement light MLS

### DIFF
--- a/include/mls/core_types.h
+++ b/include/mls/core_types.h
@@ -42,6 +42,7 @@ struct ExtensionType
   static constexpr Extension::Type external_senders = 5;
 
   static constexpr Extension::Type flags = 6;
+  static constexpr Extension::Type membership_proof = 7;
 
   // XXX(RLB) There is no IANA-registered type for this extension yet, so we use
   // a value from the vendor-specific space

--- a/include/mls/core_types.h
+++ b/include/mls/core_types.h
@@ -41,6 +41,8 @@ struct ExtensionType
   static constexpr Extension::Type external_pub = 4;
   static constexpr Extension::Type external_senders = 5;
 
+  static constexpr Extension::Type flags = 6;
+
   // XXX(RLB) There is no IANA-registered type for this extension yet, so we use
   // a value from the vendor-specific space
   static constexpr Extension::Type sframe_parameters = 0xff02;

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -279,6 +279,15 @@ private:
     const std::vector<PSKWithSecret>& psks);
 };
 
+struct LightCommit
+{
+  GroupContext group_context;
+  bytes confirmation_tag;
+  TreeSlice sender_membership_proof;
+  std::optional<HPKECiphertext> encrypted_path_secret;
+  std::optional<NodeIndex> decryption_node_index;
+};
+
 ///
 /// Proposals & Commit
 ///
@@ -645,6 +654,10 @@ private:
   bytes membership_mac(CipherSuite suite,
                        const bytes& membership_key,
                        const std::optional<GroupContext>& context) const;
+
+  // XXX(RLB) This is a hack to avoid unwrapping across epochs.  We should do
+  // something more elegant, like unchecked_content()
+  friend class State;
 };
 
 struct PrivateMessage

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -43,6 +43,20 @@ struct ExternalSendersExtension
   TLS_SERIALIZABLE(senders);
 };
 
+struct FlagsExtension
+{
+  std::vector<uint8_t> flag_data;
+
+  void set(size_t pos);
+  void unset(size_t pos);
+  bool get(size_t pos) const;
+
+  static const uint16_t type;
+
+  // XXX(RLB): This should check for extra zero bytes on deserialize.
+  TLS_SERIALIZABLE(flag_data);
+};
+
 struct SFrameParameters
 {
   uint16_t cipher_suite;

--- a/include/mls/messages.h
+++ b/include/mls/messages.h
@@ -27,6 +27,14 @@ struct RatchetTreeExtension
   TLS_SERIALIZABLE(tree)
 };
 
+struct MembershipProofExtension
+{
+  std::vector<TreeSlice> slices;
+
+  static const uint16_t type;
+  TLS_SERIALIZABLE(slices)
+};
+
 struct ExternalSender
 {
   SignaturePublicKey signature_key;

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -19,9 +19,20 @@ struct RosterIndex : public UInt32
 
 struct CommitOpts
 {
+  // Include these proposals in the commit by value
   std::vector<Proposal> extra_proposals;
-  bool inline_tree;
-  bool force_path;
+
+  // Send a ratchet_tree extension in the Welcome
+  bool inline_tree = false;
+
+  // Send an UpdatePath even if none is required
+  bool force_path = false;
+
+  // Send a membership_proof extension in the Welcome covering the committer and
+  // the new joiners
+  bool membership_proof = false;
+
+  // Update the committer's LeafNode in the following way
   LeafNodeOptions leaf_node_opts;
 };
 
@@ -145,6 +156,7 @@ public:
   const ExtensionList& extensions() const { return _extensions; }
   const TreeKEMPublicKey& tree() const { return _tree; }
   const bytes& resumption_psk() const { return _key_schedule.resumption_psk; }
+  bool is_full_client() const { return _tree.is_complete(); }
 
   bytes do_export(const std::string& label,
                   const bytes& context,

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -139,6 +139,12 @@ public:
                               std::optional<State> cached_state);
 
   ///
+  /// Light MLS
+  ///
+  LightCommit lighten_for(LeafIndex leaf, const MLSMessage& commit) const;
+  State handle(const LightCommit& light_commit) const;
+
+  ///
   /// PSK management
   ///
   void add_resumption_psk(const bytes& group_id, epoch_t epoch, bytes secret);

--- a/include/mls/tree_math.h
+++ b/include/mls/tree_math.h
@@ -99,8 +99,8 @@ struct NodeIndex : public UInt32
   // of `ancestor` that is not in the direct path of this node.
   NodeIndex sibling(NodeIndex ancestor) const;
 
-  std::vector<NodeIndex> dirpath(LeafCount n);
-  std::vector<NodeIndex> copath(LeafCount n);
+  std::vector<NodeIndex> dirpath(LeafCount n) const;
+  std::vector<NodeIndex> copath(LeafCount n) const;
 
   uint32_t level() const;
 };

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -113,7 +113,7 @@ struct TreeKEMPublicKey
 {
   CipherSuite suite;
   LeafCount size{ 0 };
-  std::vector<OptionalNode> nodes;
+  std::map<NodeIndex, OptionalNode> nodes;
 
   explicit TreeKEMPublicKey(CipherSuite suite);
 

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -67,6 +67,7 @@ struct TreeSlice
   std::vector<bytes> copath_hashes;
 
   bytes tree_hash(CipherSuite suite) const;
+  void add(const TreeSlice& other);
 
   TLS_SERIALIZABLE(leaf_index, n_leaves, direct_path_nodes, copath_hashes);
 };
@@ -157,6 +158,7 @@ struct TreeKEMPublicKey
 
   bool parent_hash_valid(LeafIndex from, const UpdatePath& path) const;
   bool parent_hash_valid() const;
+  bool is_complete() const;
 
   bool has_leaf(LeafIndex index) const;
   std::optional<LeafIndex> find(const LeafNode& leaf) const;

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -120,6 +120,9 @@ struct TreeKEMPrivateKey
   void implant(const TreeKEMPublicKey& pub,
                NodeIndex start,
                const bytes& path_secret);
+  void implant_matching(const TreeKEMPublicKey& pub,
+                        NodeIndex start,
+                        const bytes& path_secret);
 };
 
 struct TreeKEMPublicKey
@@ -167,6 +170,9 @@ struct TreeKEMPublicKey
 
   TreeSlice extract_slice(LeafIndex leaf) const;
   void implant_slice(const TreeSlice& slice);
+  std::tuple<HPKECiphertext, NodeIndex> slice_path(UpdatePath path,
+                                                   LeafIndex from,
+                                                   LeafIndex to) const;
 
   template<typename UnaryPredicate>
   bool all_leaves(const UnaryPredicate& pred) const

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -59,6 +59,18 @@ struct OptionalNode
   TLS_SERIALIZABLE(node)
 };
 
+struct TreeSlice
+{
+  LeafIndex leaf_index;
+  LeafCount n_leaves;
+  std::vector<OptionalNode> direct_path_nodes;
+  std::vector<bytes> copath_hashes;
+
+  bytes tree_hash(CipherSuite suite) const;
+
+  TLS_SERIALIZABLE(leaf_index, n_leaves, direct_path_nodes, copath_hashes);
+};
+
 struct TreeKEMPublicKey;
 
 struct TreeKEMPrivateKey
@@ -116,6 +128,7 @@ struct TreeKEMPublicKey
   std::map<NodeIndex, OptionalNode> nodes;
 
   explicit TreeKEMPublicKey(CipherSuite suite);
+  TreeKEMPublicKey(CipherSuite suite, const TreeSlice& slice);
 
   TreeKEMPublicKey() = default;
   TreeKEMPublicKey(const TreeKEMPublicKey& other) = default;
@@ -149,6 +162,9 @@ struct TreeKEMPublicKey
   std::optional<LeafIndex> find(const LeafNode& leaf) const;
   std::optional<LeafNode> leaf_node(LeafIndex index) const;
   std::vector<NodeIndex> resolve(NodeIndex index) const;
+
+  TreeSlice extract_slice(LeafIndex leaf) const;
+  void implant_slice(const TreeSlice& slice);
 
   template<typename UnaryPredicate>
   bool all_leaves(const UnaryPredicate& pred) const
@@ -227,6 +243,8 @@ private:
                       std::optional<LeafIndex> except) const;
   bool exists_in_tree(const SignaturePublicKey& key,
                       std::optional<LeafIndex> except) const;
+
+  void implant_slice_unchecked(const TreeSlice& slice);
 
   OptionalNode blank_node;
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -14,9 +14,66 @@ const Extension::Type ExternalPubExtension::type = ExtensionType::external_pub;
 const Extension::Type RatchetTreeExtension::type = ExtensionType::ratchet_tree;
 const Extension::Type ExternalSendersExtension::type =
   ExtensionType::external_senders;
+const Extension::Type FlagsExtension::type = ExtensionType::flags;
 const Extension::Type SFrameParameters::type = ExtensionType::sframe_parameters;
 const Extension::Type SFrameCapabilities::type =
   ExtensionType::sframe_parameters;
+
+void
+FlagsExtension::set(size_t pos)
+{
+  const auto byte_pos = pos >> 3;
+  const auto bit_pos = pos & 0x07;
+
+  // Ensure space
+  if (byte_pos >= flag_data.size()) {
+    flag_data.resize(byte_pos + 1);
+  }
+
+  // Set the bit
+  flag_data.at(byte_pos) |= uint8_t(1 << bit_pos);
+}
+
+void
+FlagsExtension::unset(size_t pos)
+{
+  const auto byte_pos = pos >> 3;
+  const auto bit_pos = pos & 0x07;
+
+  if (byte_pos >= flag_data.size()) {
+    return;
+  }
+
+  // Unset the bit
+  flag_data.at(byte_pos) &= ~uint8_t(1 << bit_pos);
+
+  // Trim any zero bytes
+  auto cut = flag_data.size() - 1;
+  while (cut > 0 && flag_data.at(cut) == 0) {
+    cut -= 1;
+  }
+
+  if (flag_data.at(cut) == 0) {
+    flag_data.clear();
+    return;
+  }
+
+  flag_data.resize(cut + 1);
+}
+
+bool
+FlagsExtension::get(size_t pos) const
+{
+  const auto byte_pos = pos >> 3;
+  const auto bit_pos = pos & 0x07;
+
+  if (byte_pos >= flag_data.size()) {
+    return false;
+  }
+
+  const auto bit = (flag_data.at(byte_pos) >> bit_pos) & 0x01;
+  return bit == 1;
+}
 
 bool
 SFrameCapabilities::compatible(const SFrameParameters& params) const

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -12,7 +12,8 @@ namespace MLS_NAMESPACE {
 
 const Extension::Type ExternalPubExtension::type = ExtensionType::external_pub;
 const Extension::Type RatchetTreeExtension::type = ExtensionType::ratchet_tree;
-const Extension::Type MembershipProofExtension::type = ExtensionType::membership_proof;
+const Extension::Type MembershipProofExtension::type =
+  ExtensionType::membership_proof;
 const Extension::Type ExternalSendersExtension::type =
   ExtensionType::external_senders;
 const Extension::Type FlagsExtension::type = ExtensionType::flags;

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -12,6 +12,7 @@ namespace MLS_NAMESPACE {
 
 const Extension::Type ExternalPubExtension::type = ExtensionType::external_pub;
 const Extension::Type RatchetTreeExtension::type = ExtensionType::ratchet_tree;
+const Extension::Type MembershipProofExtension::type = ExtensionType::membership_proof;
 const Extension::Type ExternalSendersExtension::type =
   ExtensionType::external_senders;
 const Extension::Type FlagsExtension::type = ExtensionType::flags;

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -306,7 +306,7 @@ Session::commit()
   auto commit_secret = inner->fresh_secret();
   auto encrypt = inner->encrypt_handshake;
   auto [commit, welcome, new_state] = inner->history.front().commit(
-    commit_secret, CommitOpts{ {}, true, encrypt, {} }, { encrypt, {}, 0 });
+    commit_secret, CommitOpts{ {}, true, encrypt, false, {} }, { encrypt, {}, 0 });
 
   auto commit_msg = tls::marshal(commit);
   auto welcome_msg = tls::marshal(welcome);

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -305,8 +305,10 @@ Session::commit()
 {
   auto commit_secret = inner->fresh_secret();
   auto encrypt = inner->encrypt_handshake;
-  auto [commit, welcome, new_state] = inner->history.front().commit(
-    commit_secret, CommitOpts{ {}, true, encrypt, false, {} }, { encrypt, {}, 0 });
+  auto [commit, welcome, new_state] =
+    inner->history.front().commit(commit_secret,
+                                  CommitOpts{ {}, true, encrypt, false, {} },
+                                  { encrypt, {}, 0 });
 
   auto commit_msg = tls::marshal(commit);
   auto welcome_msg = tls::marshal(welcome);

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -29,13 +29,13 @@ State::State(bytes group_id,
   }
 
   _index = _tree.add_leaf(leaf_node);
-  _tree.set_hash_all();
   _tree_priv = TreeKEMPrivateKey::solo(suite, _index, std::move(enc_priv));
   if (!_tree_priv.consistent(_tree)) {
     throw InvalidParameterError("LeafNode inconsistent with private key");
   }
 
   // XXX(RLB): Convert KeyScheduleEpoch to take GroupContext?
+  _tree.set_hash_all();
   auto ctx = tls::marshal(group_context());
   _key_schedule =
     KeyScheduleEpoch(_suite, random_bytes(_suite.secret_size()), ctx);
@@ -53,7 +53,8 @@ State::import_tree(const bytes& tree_hash,
 {
   auto tree = TreeKEMPublicKey(_suite);
   auto maybe_tree_extn = extensions.find<RatchetTreeExtension>();
-  auto maybe_membership_proof_extn = extensions.find<MembershipProofExtension>();
+  auto maybe_membership_proof_extn =
+    extensions.find<MembershipProofExtension>();
 
   if (external) {
     tree = opt::get(external);
@@ -1006,6 +1007,97 @@ State::handle(const ValidatedContent& val_content,
   if (!content_auth.check_confirmation_tag(confirmation_tag)) {
     throw ProtocolError("Confirmation failed to verify");
   }
+
+  return next;
+}
+
+LightCommit
+State::lighten_for(LeafIndex leaf, const MLSMessage& commit_msg) const
+{
+  // Check that the current epoch is one higher than commit.epoch
+  if (_epoch != commit_msg.epoch() + 1) {
+    throw InvalidParameterError("Invalid epoch for lightening operation");
+  }
+
+  // Pull the GroupContext for the current state
+  const auto ctx = group_context();
+
+  // Make a memberhsip proof
+  const auto& public_msg = var::get<PublicMessage>(commit_msg.message);
+  const auto& sender =
+    var::get<MemberSender>(public_msg.content.sender.sender).sender;
+
+  const auto confirmation_tag = opt::get(public_msg.auth.confirmation_tag);
+  const auto sender_membership_proof = _tree.extract_slice(sender);
+
+  // Extract the correct path secret for the recipient
+  const auto& commit = var::get<Commit>(public_msg.content.content);
+  auto encrypted_path_secret = std::optional<HPKECiphertext>{};
+  auto decryption_node_index = std::optional<NodeIndex>{};
+  if (commit.path) {
+    const auto [secret, index] =
+      _tree.slice_path(opt::get(commit.path), sender, leaf);
+    encrypted_path_secret = secret;
+    decryption_node_index = index;
+  }
+
+  return {
+    ctx,
+    confirmation_tag,
+    sender_membership_proof,
+    encrypted_path_secret,
+    decryption_node_index,
+  };
+}
+
+State
+State::handle(const LightCommit& light_commit) const
+{
+  // Verify the membership proof
+  // TODO(RLB) Also verify the signature (?)
+  // XXX(RLB) Should this use the new or old tree hash?
+  if (light_commit.sender_membership_proof.tree_hash(_suite) !=
+      light_commit.group_context.tree_hash) {
+    throw ProtocolError("Invalid sender membership proof");
+  }
+
+  // Import the GroupContext
+  // TODO(RLB) Verify that version, cipher_suite, group_id, epoch are as
+  // expected
+  auto next = successor();
+  next._epoch += 1;
+  next._tree =
+    TreeKEMPublicKey(next._suite, light_commit.sender_membership_proof);
+  next._extensions = light_commit.group_context.extensions;
+
+  // Decrypt the commit secret
+  auto commit_secret = _suite.zero();
+  if (light_commit.encrypted_path_secret) {
+    const auto& encrypted_path_secret =
+      opt::get(light_commit.encrypted_path_secret);
+    const auto& decryption_node_index =
+      opt::get(light_commit.decryption_node_index);
+
+    const auto priv = opt::get(_tree_priv.private_key(decryption_node_index));
+    const auto context = tls::marshal(next.group_context());
+    const auto path_secret = priv.decrypt(next._suite,
+                                          encrypt_label::update_path_node,
+                                          context,
+                                          encrypted_path_secret);
+    const auto ancestor =
+      next._index.ancestor(light_commit.sender_membership_proof.leaf_index);
+    next._tree_priv.implant_matching(next._tree, ancestor, path_secret);
+
+    commit_secret = next._tree_priv.update_secret;
+  }
+
+  // Update the key schedule
+  // TODO(RLB) Need to accommodate PSKs for light clients
+  next._transcript_hash =
+    TranscriptHash(next._suite,
+                   light_commit.group_context.confirmed_transcript_hash,
+                   light_commit.confirmation_tag);
+  next.update_epoch_secrets(commit_secret, {}, std::nullopt);
 
   return next;
 }
@@ -2057,6 +2149,7 @@ State::update_epoch_secrets(const bytes& commit_secret,
     _transcript_hash.confirmed,
     _extensions,
   });
+
   _key_schedule =
     _key_schedule.next(commit_secret, psks, force_init_secret, ctx);
   _keys = _key_schedule.encryption_keys(_tree.size);

--- a/src/tree_math.cpp
+++ b/src/tree_math.cpp
@@ -47,8 +47,13 @@ LeafCount::full(const LeafCount n)
 }
 
 NodeCount::NodeCount(const LeafCount n)
-  : UInt32(2 * (n.val - 1) + 1)
+  : UInt32(0)
 {
+  if (n.val == 0) {
+    val = 0;
+  } else {
+    val = 2 * (n.val - 1) + 1;
+  }
 }
 
 LeafIndex::LeafIndex(NodeIndex x)

--- a/src/tree_math.cpp
+++ b/src/tree_math.cpp
@@ -170,7 +170,7 @@ NodeIndex::sibling(NodeIndex ancestor) const
 }
 
 std::vector<NodeIndex>
-NodeIndex::dirpath(LeafCount n)
+NodeIndex::dirpath(LeafCount n) const
 {
   if (val >= NodeCount(n).val) {
     throw InvalidParameterError("Request for dirpath outside of tree");
@@ -198,7 +198,7 @@ NodeIndex::dirpath(LeafCount n)
 }
 
 std::vector<NodeIndex>
-NodeIndex::copath(LeafCount n)
+NodeIndex::copath(LeafCount n) const
 {
   auto d = dirpath(n);
   if (d.empty()) {

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -586,6 +586,12 @@ TreeKEMPublicKey::parent_hash_valid() const
   return true;
 }
 
+bool
+TreeKEMPublicKey::is_complete() const
+{
+  return nodes.size() == NodeCount{size}.val;
+}
+
 std::vector<NodeIndex>
 TreeKEMPublicKey::resolve(NodeIndex index) const
 {
@@ -705,6 +711,11 @@ std::optional<LeafIndex>
 TreeKEMPublicKey::find(const LeafNode& leaf) const
 {
   for (LeafIndex i{ 0 }; i < size; i.val++) {
+    if (nodes.count(NodeIndex{ i }) == 0) {
+      // Unknown leaf node
+      continue;
+    }
+
     const auto& node = node_at(i);
     if (!node.blank() && node.leaf_node() == leaf) {
       return i;

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -125,6 +125,30 @@ TreeKEMPrivateKey::implant(const TreeKEMPublicKey& pub,
   update_secret = pub.suite.derive_secret(secret, "path");
 }
 
+void
+TreeKEMPrivateKey::implant_matching(const TreeKEMPublicKey& pub,
+                                    NodeIndex start,
+                                    const bytes& path_secret)
+{
+  auto secret = path_secret;
+
+  path_secrets.insert_or_assign(start, secret);
+  private_key_cache.erase(start);
+
+  const auto dp = start.dirpath(pub.size);
+  for (const auto& n : dp) {
+    if (pub.node_at(n).blank()) {
+      continue;
+    }
+
+    secret = pub.suite.derive_secret(secret, "path");
+    path_secrets.insert_or_assign(n, secret);
+    private_key_cache.erase(n);
+  }
+
+  update_secret = pub.suite.derive_secret(secret, "path");
+}
+
 std::optional<HPKEPrivateKey>
 TreeKEMPrivateKey::private_key(NodeIndex n) const
 {
@@ -589,7 +613,7 @@ TreeKEMPublicKey::parent_hash_valid() const
 bool
 TreeKEMPublicKey::is_complete() const
 {
-  return nodes.size() == NodeCount{size}.val;
+  return nodes.size() == NodeCount{ size }.val;
 }
 
 std::vector<NodeIndex>
@@ -653,6 +677,34 @@ TreeKEMPublicKey::implant_slice(const TreeSlice& slice)
   }
 
   implant_slice_unchecked(slice);
+}
+
+std::tuple<HPKECiphertext, NodeIndex>
+TreeKEMPublicKey::slice_path(UpdatePath path,
+                             LeafIndex from,
+                             LeafIndex to) const
+{
+  const auto toi = NodeIndex(to);
+  const auto fdp = filtered_direct_path(NodeIndex(from));
+
+  for (auto i = size_t(0); i < fdp.size(); i++) {
+    const auto& [dpi, res] = fdp.at(i);
+
+    if (!toi.is_below(dpi)) {
+      continue;
+    }
+
+    for (auto j = size_t(0); j < res.size(); j++) {
+      const auto resi = res.at(j);
+      if (!toi.is_below(resi)) {
+        continue;
+      }
+
+      return { path.nodes.at(i).encrypted_path_secret.at(j), resi };
+    }
+  }
+
+  throw ProtocolError("Decryption node not found");
 }
 
 void

--- a/test/messages.cpp
+++ b/test/messages.cpp
@@ -23,6 +23,35 @@ TEST_CASE("Extensions")
   REQUIRE(tree0 == tree1);
 }
 
+TEST_CASE("Flags Extension")
+{
+  auto flags = FlagsExtension{};
+
+  const auto flag_data_3 = from_hex("08");
+  const auto flag_data_3_5 = from_hex("28");
+  const auto flag_data_3_5_23 = from_hex("280080");
+
+  // Following the example from TLS:
+  // https://datatracker.ietf.org/doc/html/draft-ietf-tls-tlsflags-13#section-2
+  flags.set(3);
+  REQUIRE(flags.flag_data == flag_data_3);
+
+  flags.set(5);
+  REQUIRE(flags.flag_data == flag_data_3_5);
+
+  flags.set(23);
+  REQUIRE(flags.flag_data == flag_data_3_5_23);
+
+  flags.unset(23);
+  REQUIRE(flags.flag_data == flag_data_3_5);
+
+  flags.unset(5);
+  REQUIRE(flags.flag_data == flag_data_3);
+
+  flags.unset(3);
+  REQUIRE(flags.flag_data.empty());
+}
+
 // TODO(RLB) Verify sign/verify on:
 // * KeyPackage
 // * GroupInfo

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -264,6 +264,32 @@ TEST_CASE_METHOD(TreeKEMTest, "TreeKEM encap/decap")
       REQUIRE(privs[j].consistent(pubs[j]));
     }
   }
+
+  // XXX(RLB) The below test probably doesn't belong here, but we have a nice
+  // properly-created tree here, so it's convenient to use it for testing tree
+  // slices.
+
+  // Verify that all slices of the tree have the correct tree hash
+  auto original = pubs[0];
+  original.set_hash_all();
+  const auto tree_hash = original.root_hash();
+  auto slices = std::vector<TreeSlice>{};
+  for (uint32_t i = 0; i < original.size.val; i++) {
+    auto slice = original.extract_slice(LeafIndex{ i });
+    REQUIRE(slice.tree_hash(suite) == tree_hash);
+
+    slices.push_back(slice);
+  }
+
+  // Verify that the tree can be reassembled from the slices
+  auto reconstructed = TreeKEMPublicKey(suite, slices[0]);
+  for (uint32_t i = 1; i < slices.size(); i++) {
+    reconstructed.implant_slice(slices[i]);
+  }
+
+  reconstructed.set_hash_all();
+  REQUIRE(reconstructed.root_hash() == tree_hash);
+  REQUIRE(reconstructed.parent_hash_valid());
 }
 
 TEST_CASE("TreeKEM Interop")

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -68,7 +68,7 @@ TEST_CASE_METHOD(TreeKEMTest, "TreeKEM Private Key")
   const auto priv2 = HPKEPrivateKey::generate(suite);
   const auto hash_size = suite.digest().hash_size;
 
-  // Create a tree with N blank leaves
+  // Create a tree with N leaves, blank otherwise
   auto pub = TreeKEMPublicKey(suite);
   for (auto i = uint32_t(0); i < size.val; i++) {
     auto [_leaf_priv, _sig_priv, leaf_node] = new_leaf_node();


### PR DESCRIPTION
WIP https://datatracker.ietf.org/doc/draft-kiefer-mls-light/

* [X] Convert TreeKEMPublicKey storage from array to map, so we can store partial trees
* [ ] Allow creation / validation of tree slices
* [ ] Allow client to join with light Welcome
* [ ] Allow client to process light Commit
* [ ] Allow client to upgrade to full client (by providing full ratchet tree
* [ ] Implement logic to map `Commit -> list of LightCommit` based on tree and list of light clients
* [ ] Add tests for light client scenarios