### PR TITLE
Openssl dependency cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,42 +100,6 @@ endif()
 # Configure vcpkg to only build release libraries
 set(VCPKG_BUILD_TYPE release)
 
-# External libraries
-find_package(OpenSSL REQUIRED)
-if ( OPENSSL_FOUND )
-    find_path(BORINGSSL_INCLUDE_DIR openssl/is_boringssl.h HINTS ${OPENSSL_INCLUDE_DIR} NO_DEFAULT_PATH)
-
-    if (BORINGSSL_INCLUDE_DIR)
-      message(STATUS "Found OpenSSL includes are for BoringSSL")
-      
-      add_compile_definitions(WITH_BORINGSSL)
-
-      if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-        add_compile_options(-Wno-gnu-anonymous-struct -Wno-nested-anon-types)
-      endif ()
-
-      file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/crypto.h" boringssl_version_str
-           REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_TEXT[\t ]+\"OpenSSL ([0-9])+\\.([0-9])+\\.([0-9])+ .+")
-      
-      string(REGEX REPLACE "^.*OPENSSL_VERSION_TEXT[\t ]+\"OpenSSL ([0-9]+\\.[0-9]+\\.[0-9])+ .+$"
-             "\\1" OPENSSL_VERSION "${boringssl_version_str}")
-
-    elseif (REQUIRE_BORINGSSL)
-      message(FATAL_ERROR "BoringSSL required but not found")
-    endif ()
-
-    if (${OPENSSL_VERSION} VERSION_GREATER_EQUAL 3)
-      add_compile_definitions(WITH_OPENSSL3)
-    elseif(${OPENSSL_VERSION} VERSION_LESS 1.1.1)
-      message(FATAL_ERROR "OpenSSL 1.1.1 or greater is required")
-    endif()
-    message(STATUS "OpenSSL Found: ${OPENSSL_VERSION}")
-    message(STATUS "OpenSSL Include: ${OPENSSL_INCLUDE_DIR}")
-    message(STATUS "OpenSSL Libraries: ${OPENSSL_LIBRARIES}")
-else()
-  message(FATAL_ERROR "No OpenSSL library found")
-endif()
-
 # Internal libraries
 add_subdirectory(lib)
 
@@ -159,8 +123,6 @@ target_include_directories(${LIB_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
-  PRIVATE
-    ${OPENSSL_INCLUDE_DIR}
 )
 
 install(TARGETS ${LIB_NAME} EXPORT mlspp-targets)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A convenience Makefile is included to avoid the need to remember a bunch of CMak
 > make        # Configures and builds the library 
 > make dev    # Configure a "developer" build with tests and checks using OpenSSL 1.1
 > make dev3   # Configure a "developer" build with tests and checks using OpenSSL 3.0
-> make devB   # Configure a "developer" build with tests and checks using OpenSSL 3.0
+> make devB   # Configure a "developer" build with tests and checks using BoringSSL
 > make test   # Builds and runs tests
 > make format # Runs clang-format over the source
 ```

--- a/lib/hpke/CMakeLists.txt
+++ b/lib/hpke/CMakeLists.txt
@@ -1,26 +1,59 @@
 set(CURRENT_LIB_NAME hpke)
 
 ###
-### Dependencies
-###
-find_package(nlohmann_json REQUIRED)
-
-###
 ### Library Config
 ###
 
 file(GLOB_RECURSE LIB_HEADERS CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h")
 file(GLOB_RECURSE LIB_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")
+add_library(${CURRENT_LIB_NAME} ${LIB_HEADERS} ${LIB_SOURCES})
+add_dependencies(${CURRENT_LIB_NAME} bytes tls_syntax)
 
+###
+### Dependencies
+###
+
+# JSON.
+find_package(nlohmann_json REQUIRED)
 # https://gitlab.kitware.com/cmake/cmake/-/issues/15415#note_334852
 # Warning: this will fail once nlohman_json stops being header-only!
 get_target_property(JSON_INCLUDE_INTERFACE nlohmann_json::nlohmann_json INTERFACE_INCLUDE_DIRECTORIES)
+target_include_directories(${CURRENT_LIB_NAME} PRIVATE "${JSON_INCLUDE_INTERFACE}")
 
-add_library(${CURRENT_LIB_NAME} ${LIB_HEADERS} ${LIB_SOURCES})
-add_dependencies(${CURRENT_LIB_NAME} bytes tls_syntax)
-target_include_directories(${CURRENT_LIB_NAME}
-  PRIVATE
-    "${JSON_INCLUDE_INTERFACE}")
+# OpenSSL.
+find_package(OpenSSL REQUIRED)
+if ( OPENSSL_FOUND )
+    find_path(BORINGSSL_INCLUDE_DIR openssl/is_boringssl.h HINTS ${OPENSSL_INCLUDE_DIR} NO_DEFAULT_PATH)
+
+    if (BORINGSSL_INCLUDE_DIR)
+      message(STATUS "Found OpenSSL includes are for BoringSSL")
+      target_compile_definitions(${CURRENT_LIB_NAME} PUBLIC WITH_BORINGSSL)
+
+      if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        add_compile_options(-Wno-gnu-anonymous-struct -Wno-nested-anon-types)
+      endif ()
+
+      file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/crypto.h" boringssl_version_str
+           REGEX "^#[\t ]*define[\t ]+OPENSSL_VERSION_TEXT[\t ]+\"OpenSSL ([0-9])+\\.([0-9])+\\.([0-9])+ .+")
+
+      string(REGEX REPLACE "^.*OPENSSL_VERSION_TEXT[\t ]+\"OpenSSL ([0-9]+\\.[0-9]+\\.[0-9])+ .+$"
+             "\\1" OPENSSL_VERSION "${boringssl_version_str}")
+
+    elseif (REQUIRE_BORINGSSL)
+      message(FATAL_ERROR "BoringSSL required but not found")
+    endif ()
+
+    if (${OPENSSL_VERSION} VERSION_GREATER_EQUAL 3)
+      target_compile_definitions(${CURRENT_LIB_NAME} PUBLIC WITH_OPENSSL3)
+    elseif(${OPENSSL_VERSION} VERSION_LESS 1.1.1)
+      message(FATAL_ERROR "OpenSSL 1.1.1 or greater is required")
+    endif()
+    message(STATUS "OpenSSL Found: ${OPENSSL_VERSION}")
+    message(STATUS "OpenSSL Include: ${OPENSSL_INCLUDE_DIR}")
+    message(STATUS "OpenSSL Libraries: ${OPENSSL_LIBRARIES}")
+else()
+  message(FATAL_ERROR "No OpenSSL library found")
+endif()
 
 target_link_libraries(${CURRENT_LIB_NAME} 
   PUBLIC

--- a/lib/hpke/test/CMakeLists.txt
+++ b/lib/hpke/test/CMakeLists.txt
@@ -10,4 +10,4 @@ target_link_libraries(${TEST_APP_NAME} PRIVATE ${CURRENT_LIB_NAME}
   Catch2::Catch2WithMain OpenSSL::Crypto)
 
 # Enable CTest
-catch_discover_tests(${TEST_APP_NAME})
+catch_discover_tests(${TEST_APP_NAME} PROPERTIES SKIP_RETURN_CODE 4)

--- a/lib/hpke/test/build.cpp
+++ b/lib/hpke/test/build.cpp
@@ -1,0 +1,18 @@
+#include <catch2/catch_all.hpp>
+
+TEST_CASE("BoringSSL Define")
+{
+#if defined(__has_include)
+    #if __has_include(<openssl/is_boringssl.h>)
+        #if defined(WITH_BORINGSSL)
+            REQUIRE(WITH_BORINGSSL);
+        #else
+            FAIL("Expect #WITH_BORINGSSL set when compiling with BoringSSL");
+        #endif
+    #else
+        SKIP("Only applicable to BoringSSL");
+    #endif
+#else
+    SKIP("Cannot ensure BoringSSL without __has_include()");
+#endif
+}


### PR DESCRIPTION
- Move OpenSSL dependency directly to `libhpke` definition. 
- Replace `add_compile_definitions` with `target_compile_definitions` to ensure proper propagation of defines.
- Added a test to ensure the custom `WITH_BORINGSSL` define gets set when compiling with BoringSSL - maybe overkill but helped me validate this change so might be useful. I had to set a property on test discovery to make ctest not see skips as failures. Ref: https://github.com/catchorg/Catch2/issues/2873

Although this is a standalone change the motivation here was to do some pre-work for looking into #425 