### PR TITLE
Add go as action dependency

### DIFF
--- a/.github/actions/prepare-build/action.yml
+++ b/.github/actions/prepare-build/action.yml
@@ -31,7 +31,7 @@ runs:
       if: ${{ runner.os == 'macOS' }}
       shell: bash
       run: |
-        brew install llvm pkg-config nasm
+        brew install llvm pkg-config nasm go
         ln -s "/usr/local/opt/llvm/bin/clang-format" "/usr/local/bin/clang-format"
         ln -s "/usr/local/opt/llvm/bin/clang-tidy" "/usr/local/bin/clang-tidy"
 


### PR DESCRIPTION
`go` is a required dependency for BoringSSL builds