### PR TITLE
Fix CI

### DIFF
--- a/.github/actions/prepare-build/action.yml
+++ b/.github/actions/prepare-build/action.yml
@@ -31,7 +31,7 @@ runs:
       if: ${{ runner.os == 'macOS' }}
       shell: bash
       run: |
-        brew install llvm pkg-config nasm
+        brew install llvm pkg-config nasm go
         ln -s "/usr/local/opt/llvm/bin/clang-format" "/usr/local/bin/clang-format"
         ln -s "/usr/local/opt/llvm/bin/clang-tidy" "/usr/local/bin/clang-tidy"
 

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -38,7 +38,6 @@ jobs:
         crypto: [openssl_1.1, openssl_3, boringssl]
 
     env:
-      BUILD_DIR: "${RUNNER_TEMP}/build_${{ matrix.crypto }}"
       CRYPTO_DIR: "./alternatives/${{ matrix.crypto }}"
 
     steps:
@@ -55,12 +54,12 @@ jobs:
 
     - name: Build
       run: |
-        cmake -B "${{ env.BUILD_DIR }}" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}" -DTESTING=ON
-        cmake --build "${{ env.BUILD_DIR }}"
+        cmake -B "${{ runner.temp }}/build_${{ matrix.crypto }}" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}" -DTESTING=ON
+        cmake --build "${{ runner.temp }}/build_${{ matrix.crypto }}"
 
     - name: Unit Test
       run: |
-        ctest --test-dir "${{ env.BUILD_DIR }}"
+        ctest --test-dir "${{ runner.temp }}/build_${{ matrix.crypto }}"
 
   interop-test:
     if: github.event.pull_request.draft == false
@@ -69,7 +68,6 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      BUILD_DIR: "${RUNNER_TEMP}/build_openssl_1.1"
       CRYPTO_DIR: "./alternatives/openssl_1.1"
 
     steps:
@@ -86,8 +84,8 @@ jobs:
 
     - name: Build
       run: |
-        cmake -B "${{ env.BUILD_DIR }}" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}"
-        cmake --build "${{ env.BUILD_DIR }}"
+        cmake -B "${{ runner.temp }}/build_openssl_1.1" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}"
+        cmake --build "${{ runner.temp }}/build_openssl_1.1"
 
     - name: Build (Interop Harness)
       run: |
@@ -118,7 +116,6 @@ jobs:
         crypto: [openssl_1.1, openssl_3, boringssl]
 
     env:
-      BUILD_DIR: "${RUNNER_TEMP}/build_${{ matrix.crypto }}"
       CRYPTO_DIR: "./alternatives/${{ matrix.crypto }}"
 
     steps:
@@ -135,6 +132,6 @@ jobs:
 
     - name: Build with clang-tidy
       run: |
-        cmake -B "${{ env.BUILD_DIR }}" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}" \
-                                        -DTESTING=ON -DCLANG_TIDY=ON -DSANITIZERS=ON
-        cmake --build "${{ env.BUILD_DIR }}"
+        cmake -B "${{ runner.temp }}/build_${{ matrix.crypto }}" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}" \
+                                                                 -DTESTING=ON -DCLANG_TIDY=ON -DSANITIZERS=ON
+        cmake --build "${{ runner.temp }}/build_${{ matrix.crypto }}"

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -58,15 +58,9 @@ jobs:
         cmake -B "${{ env.BUILD_DIR }}" -DVCPKG_MANIFEST_DIR="${{ env.CRYPTO_DIR }}" -DTESTING=ON
         cmake --build "${{ env.BUILD_DIR }}"
 
-    - name: Unit Test (non-Windows)
-      if: matrix.os != 'windows-latest'
+    - name: Unit Test
       run: |
-        cmake --build "${{ env.BUILD_DIR }}" --target test
-
-    - name: Unit Test (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        cmake --build "${{ env.BUILD_DIR }}" --target RUN_TESTS
+        ctest --test-dir "${{ env.BUILD_DIR }}"
 
   interop-test:
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
CI seemed to be broken on main for a couple of reasons (I'm assuming the root causes here are GH runner changes). 

1. Missing `go` dependency on MacOS for `boringssl`.
2. Bad build directory causing test runs to fail on Windows due to `$RUNNER_TEMP` environment variable not being present. Using the context variable directly is a bit more verbose but works and also won't silently expand to nothing (like the env variable was). 

I also altered the Unit Test stage to use `ctest` as I didn't see a need for 2 different workflow steps for Windows vs. the unix platforms. 