### PR TITLE
Fix invalid parent hash with empty root left subtree

### DIFF
--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -903,7 +903,7 @@ TreeKEMPublicKey::parent_hashes(
   }
 
   // The list of nodes for whom parent hashes are computed, namely: Direct path
-  // excluding root, including leaf
+  // excluding the last entry, including leaf
   auto from_node = NodeIndex(from);
   auto dp = fdp;
   auto [last, _res_last] = dp.back();

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -906,6 +906,7 @@ TreeKEMPublicKey::parent_hashes(
   // excluding root, including leaf
   auto from_node = NodeIndex(from);
   auto dp = fdp;
+  auto [last, _res_last] = dp.back();
   dp.pop_back();
   dp.insert(dp.begin(), { from_node, {} });
 
@@ -914,7 +915,6 @@ TreeKEMPublicKey::parent_hashes(
   }
 
   // Parent hash for all the parents, starting from the root
-  auto last = NodeIndex::root(size);
   auto last_hash = bytes{};
   auto ph = std::vector<bytes>(dp.size());
   for (int i = static_cast<int>(dp.size()) - 1; i >= 0; i--) {

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -914,7 +914,8 @@ TreeKEMPublicKey::parent_hashes(
     throw ProtocolError("Malformed UpdatePath");
   }
 
-  // Parent hash for all the parents, starting from the root
+  // Parent hash for all the parents, starting from the last entry of the
+  // filtered direct path
   auto last_hash = bytes{};
   auto ph = std::vector<bytes>(dp.size());
   for (int i = static_cast<int>(dp.size()) - 1; i >= 0; i--) {

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -1107,11 +1107,10 @@ TEST_CASE_METHOD(StateTest, "Parent Hash with Empty Left Subtree")
     states[0].remove_proposal(LeafIndex{ 1 }),
   };
 
-    auto [commit2, welcome2, new_state_2] =
-      states[2].commit(fresh_secret(), CommitOpts{ { removes }, true, false, {} }, {});
-    silence_unused(commit2);
-    states[2] = new_state_2;
-
+  auto [commit2, welcome2, new_state_2] = states[2].commit(
+    fresh_secret(), CommitOpts{ { removes }, true, false, {} }, {});
+  silence_unused(commit2);
+  states[2] = new_state_2;
 
   // Member @2 should have a valid tree, even though its filtered direct path no
   // longer goes to the root.

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -1118,6 +1118,8 @@ TEST_CASE_METHOD(StateTest, "Invalid Tree2")
                        std::nullopt,
                        {} });
 
+  REQUIRE(states[2].tree().parent_hash_valid());
+
   // Member @2 removes member @1
   auto remove_proposal_1 = states[2].remove_proposal(LeafIndex { 1 });
 
@@ -1125,6 +1127,8 @@ TEST_CASE_METHOD(StateTest, "Invalid Tree2")
     fresh_secret(), CommitOpts{ { remove_proposal_1 }, true, false, {} }, {});
   silence_unused(welcome_remove_1);
   states[2] = new_state_remove_1;
+
+  REQUIRE(states[2].tree().parent_hash_valid());
 
   // Have member at leaf index 2 remove member at leaf index 0
   auto remove_proposal_0 = states[2].remove_proposal(LeafIndex { 0 });
@@ -1134,6 +1138,8 @@ TEST_CASE_METHOD(StateTest, "Invalid Tree2")
   silence_unused(welcome_remove_0);
   states[2] = new_state_remove_0;
 
+  REQUIRE(states[2].tree().parent_hash_valid());
+
   // ACT III: Member @2 adds another member
 
   // Add a new member
@@ -1142,6 +1148,8 @@ TEST_CASE_METHOD(StateTest, "Invalid Tree2")
     states[2].commit(fresh_secret(), CommitOpts{ { add_proposal_4 }, true, false, {} }, {});
   silence_unused(commit_add_4);
   states[2] = new_state_add_4;
+
+  REQUIRE(states[2].tree().parent_hash_valid());
 
   CHECK_NOTHROW(State{ init_privs[4],
                        leaf_privs[4],

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -1107,6 +1107,7 @@ TEST_CASE_METHOD(StateTest, "Parent Hash with Empty Left Subtree")
   auto [commit2, welcome2, new_state_2] =
     state_2.commit(fresh_secret(), CommitOpts{ removes, true, false, {} }, {});
   silence_unused(commit2);
+  silence_unused(welcome2);
   state_2 = new_state_2;
 
   // Member @2 should have a valid tree, even though its filtered direct path no

--- a/test/state.cpp
+++ b/test/state.cpp
@@ -1073,46 +1073,43 @@ TEST_CASE_METHOD(RelatedGroupTest, "Reinitialize the group")
 TEST_CASE_METHOD(StateTest, "Parent Hash with Empty Left Subtree")
 {
   // Create a group with 4 members
-  states.emplace_back(group_id,
-                      suite,
-                      leaf_privs[0],
-                      identity_privs[0],
-                      key_packages[0].leaf_node,
-                      ExtensionList{});
+  auto state_0 = State(group_id,
+                       suite,
+                       leaf_privs[0],
+                       identity_privs[0],
+                       key_packages[0].leaf_node,
+                       ExtensionList{});
 
   const auto adds = std::vector{
-    states[0].add_proposal(key_packages[1]),
-    states[0].add_proposal(key_packages[2]),
-    states[0].add_proposal(key_packages[3]),
+    state_0.add_proposal(key_packages[1]),
+    state_0.add_proposal(key_packages[2]),
+    state_0.add_proposal(key_packages[3]),
   };
 
   auto [_commit0, welcome0, new_state_0] =
-    states[0].commit(fresh_secret(), CommitOpts{ adds, true, false, {} }, {});
+    state_0.commit(fresh_secret(), CommitOpts{ adds, true, false, {} }, {});
   silence_unused(_commit0);
-  states[0] = new_state_0;
+  state_0 = new_state_0;
 
-  for (size_t i = 1; i < 4; i++) {
-    states.push_back({ init_privs[i],
-                       leaf_privs[i],
-                       identity_privs[i],
-                       key_packages[i],
+  auto state_2 = State(init_privs[2],
+                       leaf_privs[2],
+                       identity_privs[2],
+                       key_packages[2],
                        welcome0,
                        std::nullopt,
-                       {} });
-  }
-
+                       {});
   // Member @2 removes the members on the left side of the tree
   const auto removes = std::vector{
-    states[0].remove_proposal(LeafIndex{ 0 }),
-    states[0].remove_proposal(LeafIndex{ 1 }),
+    state_2.remove_proposal(LeafIndex{ 0 }),
+    state_2.remove_proposal(LeafIndex{ 1 }),
   };
 
-  auto [commit2, welcome2, new_state_2] = states[2].commit(
-    fresh_secret(), CommitOpts{ { removes }, true, false, {} }, {});
+  auto [commit2, welcome2, new_state_2] =
+    state_2.commit(fresh_secret(), CommitOpts{ removes, true, false, {} }, {});
   silence_unused(commit2);
-  states[2] = new_state_2;
+  state_2 = new_state_2;
 
   // Member @2 should have a valid tree, even though its filtered direct path no
   // longer goes to the root.
-  REQUIRE(states[2].tree().parent_hash_valid());
+  REQUIRE(state_2.tree().parent_hash_valid());
 }


### PR DESCRIPTION
Fixes a bug with parent hash generation when the left subtree of the root node is empty.

If left subtree of the root node becomes empty (for example, when first two members are removed by a third group member) the parent hash computed during `TreeKEMPublicKey::update` will be invalid. A subsequent welcome will also have an invalid tree, and the welcome is unprocessable.

This occurred because `parent_hashes` assumed that the root node was always present in the filtered direct path, and therefore used the root node as the initial parent when doing a top-down generation of parent hashes.