### PR TITLE
Refactor Commit Creation and Handling

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,8 +3,10 @@ Checks:            '*,
                     -altera-*,
                     -fuchsia-*,
                     -abseil-string-find-startswith,
+                    -boost-use-ranges,
                     -bugprone-easily-swappable-parameters,
                     -bugprone-exception-escape,
+                    -bugprone-chained-comparison,
                     -cert-err58-cpp,
                     -cppcoreguidelines-avoid-const-or-ref-data-members,
                     -cppcoreguidelines-avoid-magic-numbers,
@@ -32,6 +34,9 @@ Checks:            '*,
                     -readability-function-cognitive-complexity,
                     -readability-identifier-length,
                     -readability-magic-numbers,
+                    -readability-math-missing-parentheses,
+                    -readability-redundant-casting,
                     '
 WarningsAsErrors:  '*'
 HeaderFilterRegex: '*'
+ExcludeHeaderFilterRegex: 'catch_test_macros.hpp'

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 BUILD_DIR=build
 TEST_DIR=build/test
 CLANG_FORMAT=clang-format -i
+CLANG_FORMAT_EXCLUDE="test_vectors.cpp"
 CLANG_TIDY=OFF
 OPENSSL11_MANIFEST=alternatives/openssl_1.1
 OPENSSL3_MANIFEST=alternatives/openssl_3
@@ -96,8 +97,6 @@ clean:
 
 cclean:
 	rm -rf ${BUILD_DIR}
-
-CLANG_FORMAT_EXCLUDE="test_vectors.cpp"
 
 format:
 	for dir in include src test lib; \

--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,11 @@ clean:
 cclean:
 	rm -rf ${BUILD_DIR}
 
+CLANG_FORMAT_EXCLUDE="test_vectors.cpp"
+
 format:
-	find include -iname "*.h" -or -iname "*.cpp" | xargs ${CLANG_FORMAT}
-	find src -iname "*.h" -or -iname "*.cpp" | xargs ${CLANG_FORMAT}
-	find test -iname "*.h" -or -iname "*.cpp" | xargs ${CLANG_FORMAT}
-	find cmd -iname "*.h" -or -iname "*.cpp" | xargs ${CLANG_FORMAT}
-	find lib -iname "*.h" -or -iname "*.cpp" | grep -v "test_vectors.cpp" |  xargs ${CLANG_FORMAT}
+	for dir in include src test lib; \
+	do \
+		find $${dir} -iname "*.h" -or -iname "*.cpp" | grep -v ${CLANG_FORMAT_EXCLUDE} \
+		| xargs ${CLANG_FORMAT}; \
+	done

--- a/include/mls/common.h
+++ b/include/mls/common.h
@@ -249,6 +249,13 @@ contains(const Container& c, const Value& val)
   return std::find(c.begin(), c.end(), val) != c.end();
 }
 
+template<typename Container, typename Value>
+auto
+find(const Container& c, const Value& val)
+{
+  return std::find(c.begin(), c.end(), val);
+}
+
 template<typename Container, typename UnaryPredicate>
 auto
 find_if(Container& c, const UnaryPredicate& pred)

--- a/include/mls/key_schedule.h
+++ b/include/mls/key_schedule.h
@@ -199,8 +199,9 @@ struct TranscriptHash
                  bytes confirmed_in,
                  const bytes& confirmation_tag);
 
-  void update(const AuthenticatedContent& content_auth);
-  void update_confirmed(const AuthenticatedContent& content_auth);
+  // Updating hashes
+  bytes new_confirmed(const AuthenticatedContent& content_auth) const;
+  void set_confirmed(bytes confirmed_transcript_hash);
   void update_interim(const bytes& confirmation_tag);
   void update_interim(const AuthenticatedContent& content_auth);
 };

--- a/include/mls/key_schedule.h
+++ b/include/mls/key_schedule.h
@@ -200,10 +200,9 @@ struct TranscriptHash
                  const bytes& confirmation_tag);
 
   // Updating hashes
-  bytes new_confirmed(const AuthenticatedContent& content_auth) const;
+  bytes new_confirmed(const bytes& transcript_hash_input) const;
   void set_confirmed(bytes confirmed_transcript_hash);
   void update_interim(const bytes& confirmation_tag);
-  void update_interim(const AuthenticatedContent& content_auth);
 };
 
 bool

--- a/include/mls/key_schedule.h
+++ b/include/mls/key_schedule.h
@@ -106,6 +106,7 @@ public:
   bytes epoch_authenticator;
   bytes external_secret;
   bytes confirmation_key;
+  bytes confirmation_tag;
   bytes membership_key;
   bytes resumption_psk;
   bytes init_secret;
@@ -118,6 +119,7 @@ public:
   static KeyScheduleEpoch joiner(CipherSuite suite_in,
                                  const bytes& joiner_secret,
                                  const std::vector<PSKWithSecret>& psks,
+                                 const bytes& confirmed_transcript_hash,
                                  const bytes& context);
 
   // Ciphersuite-only initializer, used by external joiner
@@ -136,10 +138,10 @@ public:
   KeyScheduleEpoch next(const bytes& commit_secret,
                         const std::vector<PSKWithSecret>& psks,
                         const std::optional<bytes>& force_init_secret,
+                        const bytes& confirmed_transcript_hash,
                         const bytes& context) const;
 
   GroupKeySource encryption_keys(LeafCount size) const;
-  bytes confirmation_tag(const bytes& confirmed_transcript_hash) const;
   bytes do_export(const std::string& label,
                   const bytes& context,
                   size_t size) const;
@@ -161,10 +163,12 @@ public:
                    const bytes& init_secret,
                    const bytes& commit_secret,
                    const bytes& psk_secret,
+                   const bytes& confirmed_transcript_hash,
                    const bytes& context);
   KeyScheduleEpoch next_raw(const bytes& commit_secret,
                             const bytes& psk_secret,
                             const std::optional<bytes>& force_init_secret,
+                            const bytes& confirmed_transcript_hash,
                             const bytes& context) const;
   static bytes welcome_secret_raw(CipherSuite suite,
                                   const bytes& joiner_secret,
@@ -174,6 +178,7 @@ private:
   KeyScheduleEpoch(CipherSuite suite_in,
                    const bytes& joiner_secret,
                    const bytes& psk_secret,
+                   const bytes& confirmed_transcript_hash,
                    const bytes& context);
 };
 

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -370,9 +370,9 @@ protected:
                     LeafIndex target,
                     const Update& update);
   static LeafIndex apply(TreeKEMPublicKey& tree, const Remove& remove);
-  std::vector<LeafIndex> apply(TreeKEMPublicKey& tree,
+  static std::vector<LeafIndex> apply(TreeKEMPublicKey& tree,
                                const std::vector<CachedProposal>& proposals,
-                               Proposal::Type required_type) const;
+                               Proposal::Type required_type);
   std::tuple<TreeKEMPublicKey,
              std::vector<LeafIndex>,
              std::vector<PSKWithSecret>,

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -332,6 +332,16 @@ protected:
     std::optional<State> cached_state,
     const std::optional<CommitParams>& expected_params);
 
+  State ratchet(TreeKEMPublicKey new_tree,
+                LeafIndex committer,
+                const std::optional<NodeIndex>& path_secret_decrypt_node,
+                const std::optional<HPKECiphertext>& encrypted_path_secret,
+                const ExtensionList& extensions,
+                const std::vector<PSKWithSecret>& psks,
+                const std::optional<bytes>& force_init_secret,
+                const bytes& confirmed_transcript_hash,
+                const bytes& confirmation_tag);
+
   // Create an MLSMessage encapsulating some content
   template<typename Inner>
   AuthenticatedContent sign(const Sender& sender,

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -370,9 +370,10 @@ protected:
                     LeafIndex target,
                     const Update& update);
   static LeafIndex apply(TreeKEMPublicKey& tree, const Remove& remove);
-  static std::vector<LeafIndex> apply(TreeKEMPublicKey& tree,
-                               const std::vector<CachedProposal>& proposals,
-                               Proposal::Type required_type);
+  static std::vector<LeafIndex> apply(
+    TreeKEMPublicKey& tree,
+    const std::vector<CachedProposal>& proposals,
+    Proposal::Type required_type);
   std::tuple<TreeKEMPublicKey,
              std::vector<LeafIndex>,
              std::vector<PSKWithSecret>,

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -321,12 +321,12 @@ protected:
     const bytes& leaf_secret,
     const std::optional<CommitOpts>& opts,
     const MessageOpts& msg_opts,
-    CommitParams params);
+    const CommitParams& params);
 
   struct CommitMaterials;
   CommitMaterials prepare_commit(const bytes& leaf_secret,
                                  const std::optional<CommitOpts>& opts,
-                                 CommitParams params) const;
+                                 const CommitParams& params) const;
   Welcome welcome(bool inline_tree,
                   const std::vector<PSKWithSecret>& psks,
                   const std::vector<KeyPackage>& joiners,
@@ -346,7 +346,7 @@ protected:
                 LeafIndex committer,
                 const std::optional<NodeIndex>& path_secret_decrypt_node,
                 const std::optional<HPKECiphertext>& encrypted_path_secret,
-                const ExtensionList& extensions,
+                ExtensionList extensions,
                 const std::vector<PSKWithSecret>& psks,
                 const std::optional<bytes>& force_init_secret,
                 const bytes& confirmed_transcript_hash,
@@ -448,8 +448,8 @@ protected:
                   ExtensionList extensions,
                   const bytes& confirmed_transcript_hash,
                   bool has_path,
-                  const std::vector<PSKWithSecret> psks,
-                  const std::optional<bytes> force_init_secret) const;
+                  const std::vector<PSKWithSecret>& psks,
+                  const std::optional<bytes>& force_init_secret) const;
 };
 
 } // namespace MLS_NAMESPACE

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -430,11 +430,6 @@ protected:
   friend bool operator==(const State& lhs, const State& rhs);
   friend bool operator!=(const State& lhs, const State& rhs);
 
-  // Derive and set the secrets for an epoch, given some new entropy
-  void update_epoch_secrets(const bytes& commit_secret,
-                            const std::vector<PSKWithSecret>& psks,
-                            const std::optional<bytes>& force_init_secret);
-
   // Signature verification over a handshake message
   bool verify_internal(const AuthenticatedContent& content_auth) const;
   bool verify_external(const AuthenticatedContent& content_auth) const;
@@ -452,7 +447,7 @@ protected:
                   TreeKEMPrivateKey tree_priv,
                   ExtensionList extensions,
                   const bytes& confirmed_transcript_hash,
-                  const bytes& commit_secret,
+                  bool has_path,
                   const std::vector<PSKWithSecret> psks,
                   const std::optional<bytes> force_init_secret) const;
 };

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -345,17 +345,19 @@ protected:
   MLSMessage protect_full(Inner&& content, const MessageOpts& msg_opts);
 
   // Apply the changes requested by various messages
-  LeafIndex apply(const Add& add);
-  void apply(LeafIndex target, const Update& update);
-  void apply(LeafIndex target,
-             const Update& update,
-             const HPKEPrivateKey& leaf_priv);
-  LeafIndex apply(const Remove& remove);
-  void apply(const GroupContextExtensions& gce);
-  std::vector<LeafIndex> apply(const std::vector<CachedProposal>& proposals,
-                               Proposal::Type required_type);
-  std::tuple<std::vector<LeafIndex>, std::vector<PSKWithSecret>> apply(
-    const std::vector<CachedProposal>& proposals);
+  static LeafIndex apply(TreeKEMPublicKey& tree, const Add& add);
+  static void apply(TreeKEMPublicKey& tree,
+                    LeafIndex target,
+                    const Update& update);
+  static LeafIndex apply(TreeKEMPublicKey& tree, const Remove& remove);
+  std::vector<LeafIndex> apply(TreeKEMPublicKey& tree,
+                               const std::vector<CachedProposal>& proposals,
+                               Proposal::Type required_type) const;
+  std::tuple<TreeKEMPublicKey,
+             std::vector<LeafIndex>,
+             std::vector<PSKWithSecret>,
+             ExtensionList>
+  apply(const std::vector<CachedProposal>& proposals) const;
 
   // Verify that a specific key package or all members support a given set of
   // extensions

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -323,6 +323,15 @@ protected:
     const MessageOpts& msg_opts,
     CommitParams params);
 
+  struct CommitMaterials;
+  CommitMaterials prepare_commit(const bytes& leaf_secret,
+                                 const std::optional<CommitOpts>& opts,
+                                 CommitParams params) const;
+  Welcome welcome(bool inline_tree,
+                  const std::vector<PSKWithSecret>& psks,
+                  const std::vector<KeyPackage>& joiners,
+                  const std::vector<std::optional<bytes>>& path_secrets) const;
+
   std::optional<State> handle(
     const ValidatedContent& val_content,
     std::optional<State> cached_state,
@@ -437,8 +446,15 @@ protected:
   // Convert a Roster entry into LeafIndex
   LeafIndex leaf_for_roster_entry(RosterIndex index) const;
 
-  // Create a draft successor state
-  State successor() const;
+  // Create a successor state
+  State successor(LeafIndex index,
+                  TreeKEMPublicKey tree,
+                  TreeKEMPrivateKey tree_priv,
+                  ExtensionList extensions,
+                  const bytes& confirmed_transcript_hash,
+                  const bytes& commit_secret,
+                  const std::vector<PSKWithSecret> psks,
+                  const std::optional<bytes> force_init_secret) const;
 };
 
 } // namespace MLS_NAMESPACE

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -324,13 +324,14 @@ protected:
     CommitParams params);
 
   std::optional<State> handle(
-    const MLSMessage& msg,
-    std::optional<State> cached_state,
-    const std::optional<CommitParams>& expected_params);
-  std::optional<State> handle(
     const ValidatedContent& val_content,
     std::optional<State> cached_state,
     const std::optional<CommitParams>& expected_params);
+
+  void handle_proposal(const AuthenticatedContent& content_auth);
+  State handle_commit(const AuthenticatedContent& content_auth,
+                      std::optional<State> cached_state,
+                      const std::optional<CommitParams>& expected_params) const;
 
   State ratchet(TreeKEMPublicKey new_tree,
                 LeafIndex committer,
@@ -340,7 +341,7 @@ protected:
                 const std::vector<PSKWithSecret>& psks,
                 const std::optional<bytes>& force_init_secret,
                 const bytes& confirmed_transcript_hash,
-                const bytes& confirmation_tag);
+                const bytes& confirmation_tag) const;
 
   // Create an MLSMessage encapsulating some content
   template<typename Inner>
@@ -374,7 +375,6 @@ protected:
   bool extensions_supported(const ExtensionList& exts) const;
 
   // Extract proposals and PSKs from cache
-  void cache_proposal(AuthenticatedContent content_auth);
   std::optional<CachedProposal> resolve(
     const ProposalOrRef& id,
     std::optional<LeafIndex> sender_index) const;

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -94,6 +94,12 @@ struct TreeKEMPrivateKey
              const UpdatePath& path,
              const std::vector<LeafIndex>& except);
 
+  void decap(LeafIndex from,
+             const TreeKEMPublicKey& pub,
+             const bytes& context,
+             const NodeIndex& decrypt_node,
+             const HPKECiphertext& encrypted_path_secret);
+
   void truncate(LeafCount size);
 
   bool consistent(const TreeKEMPrivateKey& other) const;
@@ -149,6 +155,17 @@ struct TreeKEMPublicKey
   std::optional<LeafIndex> find(const LeafNode& leaf) const;
   std::optional<LeafNode> leaf_node(LeafIndex index) const;
   std::vector<NodeIndex> resolve(NodeIndex index) const;
+
+  struct DecapCoords
+  {
+    size_t ancestor_node_index;
+    size_t resolution_node_index;
+    NodeIndex resolution_node;
+  };
+  DecapCoords decap_coords(
+    LeafIndex to,
+    LeafIndex from,
+    const std::vector<LeafIndex>& joiner_locations) const;
 
   template<typename UnaryPredicate>
   bool all_leaves(const UnaryPredicate& pred) const

--- a/lib/hpke/src/base64.cpp
+++ b/lib/hpke/src/base64.cpp
@@ -57,7 +57,7 @@ to_base64url(const bytes& data)
 bytes
 from_base64(const std::string& enc)
 {
-  if (enc.length() == 0) {
+  if (enc.empty()) {
     return {};
   }
 

--- a/lib/hpke/src/group.cpp
+++ b/lib/hpke/src/group.cpp
@@ -728,7 +728,7 @@ private:
   }
 #endif
 
-  static inline int group_to_nid(Group::ID group_id)
+  static int group_to_nid(Group::ID group_id)
   {
     switch (group_id) {
       case Group::ID::P256:
@@ -862,7 +862,7 @@ struct RawKeyGroup : public EVPGroup
 private:
   const int evp_type;
 
-  static inline int group_to_evp(Group::ID group_id)
+  static int group_to_evp(Group::ID group_id)
   {
     switch (group_id) {
       case Group::ID::X25519:

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -989,7 +989,8 @@ TranscriptTestVector::TranscriptTestVector(CipherSuite suite)
     sig_priv,
     group_context);
 
-  const auto new_confirmed = transcript.new_confirmed(authenticated_content.confirmed_transcript_hash_input());
+  const auto new_confirmed = transcript.new_confirmed(
+    authenticated_content.confirmed_transcript_hash_input());
   transcript.set_confirmed(new_confirmed);
 
   group_context.confirmed_transcript_hash = transcript.confirmed;
@@ -1014,10 +1015,12 @@ TranscriptTestVector::verify() const
   auto transcript = TranscriptHash(cipher_suite);
   transcript.interim = interim_transcript_hash_before;
 
-  const auto new_confirmed = transcript.new_confirmed(authenticated_content.confirmed_transcript_hash_input());
+  const auto new_confirmed = transcript.new_confirmed(
+    authenticated_content.confirmed_transcript_hash_input());
   transcript.set_confirmed(new_confirmed);
 
-  const auto input_confirmation_tag = opt::get(authenticated_content.auth.confirmation_tag);
+  const auto input_confirmation_tag =
+    opt::get(authenticated_content.auth.confirmation_tag);
   transcript.update_interim(input_confirmation_tag);
 
   VERIFY_EQUAL(

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -989,7 +989,8 @@ TranscriptTestVector::TranscriptTestVector(CipherSuite suite)
     sig_priv,
     group_context);
 
-  transcript.update_confirmed(authenticated_content);
+  const auto new_confirmed = transcript.new_confirmed(authenticated_content);
+  transcript.set_confirmed(new_confirmed);
 
   group_context.confirmed_transcript_hash = transcript.confirmed;
   auto key_schedule_after =
@@ -1015,7 +1016,10 @@ TranscriptTestVector::verify() const
   auto transcript = TranscriptHash(cipher_suite);
   transcript.interim = interim_transcript_hash_before;
 
-  transcript.update(authenticated_content);
+  const auto new_confirmed = transcript.new_confirmed(authenticated_content);
+  transcript.set_confirmed(new_confirmed);
+  transcript.update_interim(authenticated_content);
+
   VERIFY_EQUAL(
     "confirmed", transcript.confirmed, confirmed_transcript_hash_after);
   VERIFY_EQUAL("interim", transcript.interim, interim_transcript_hash_after);

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -992,6 +992,7 @@ TranscriptTestVector::TranscriptTestVector(CipherSuite suite)
   const auto new_confirmed = transcript.new_confirmed(
     authenticated_content.confirmed_transcript_hash_input());
   transcript.set_confirmed(new_confirmed);
+  ;
 
   group_context.confirmed_transcript_hash = transcript.confirmed;
   auto key_schedule_after =
@@ -1001,6 +1002,8 @@ TranscriptTestVector::TranscriptTestVector(CipherSuite suite)
                              transcript.confirmed,
                              tls::marshal(group_context));
 
+  authenticated_content.set_confirmation_tag(
+    key_schedule_after.confirmation_tag);
   transcript.update_interim(key_schedule_after.confirmation_tag);
 
   // Store the required data

--- a/lib/mls_vectors/src/mls_vectors.cpp
+++ b/lib/mls_vectors/src/mls_vectors.cpp
@@ -13,8 +13,10 @@ using namespace MLS_NAMESPACE;
 /// Assertions for verifying test vectors
 ///
 
+// For some reason, clang-tidy lints about C arrays are firing on this line.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 template<typename T, std::enable_if_t<std::is_enum_v<T>, int> = 0>
-std::ostream&
+static std::ostream&
 operator<<(std::ostream& str, const T& obj)
 {
   auto u = static_cast<std::underlying_type_t<T>>(obj);
@@ -75,7 +77,7 @@ operator<<(std::ostream& str, const GroupContent::RawContent& obj)
 }
 
 template<typename T>
-inline std::enable_if_t<T::_tls_serializable, std::ostream&>
+static inline std::enable_if_t<T::_tls_serializable, std::ostream&>
 operator<<(std::ostream& str, const T& obj)
 {
   return str << to_hex(tls::marshal(obj));

--- a/lib/mls_vectors/test/mls_vectors.cpp
+++ b/lib/mls_vectors/test/mls_vectors.cpp
@@ -78,7 +78,7 @@ TEST_CASE("Welcome")
   }
 }
 
-TEST_CASE("Tree Hashes")
+TEST_CASE("Tree Hashes", "[.][all]")
 {
   for (auto suite : supported_suites) {
     for (auto structure : all_tree_structures) {
@@ -97,7 +97,7 @@ TEST_CASE("Tree Operations")
   }
 }
 
-TEST_CASE("TreeKEM")
+TEST_CASE("TreeKEM", "[.][all]")
 {
   for (auto suite : supported_suites) {
     for (auto structure : treekem_test_tree_structures) {

--- a/lib/tls_syntax/test/tls_syntax.cpp
+++ b/lib/tls_syntax/test/tls_syntax.cpp
@@ -97,8 +97,8 @@ protected:
 };
 
 template<typename T>
-void
-ostream_test(T val, const std::vector<uint8_t>& enc)
+static void
+ostream_test(const T& val, const std::vector<uint8_t>& enc)
 {
   MLS_NAMESPACE::tls::ostream w; // NOLINT(misc-const-correctness)
   w << val;
@@ -127,8 +127,8 @@ TEST_CASE_METHOD(TLSSyntaxTest, "TLS ostream")
 }
 
 template<typename T>
-void
-istream_test(T val, T& data, const std::vector<uint8_t>& enc)
+static void
+istream_test(const T& val, T& data, const std::vector<uint8_t>& enc)
 {
   MLS_NAMESPACE::tls::istream r(enc); // NOLINT(misc-const-correctness)
   r >> data;

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -551,11 +551,9 @@ TranscriptHash::TranscriptHash(CipherSuite suite_in,
 }
 
 bytes
-TranscriptHash::new_confirmed(const AuthenticatedContent& content_auth) const
+TranscriptHash::new_confirmed(const bytes& transcript_hash_input) const
 {
-  const auto transcript =
-    interim + content_auth.confirmed_transcript_hash_input();
-  return suite.digest().hash(transcript);
+  return suite.digest().hash(interim + transcript_hash_input);
 }
 
 void
@@ -567,16 +565,7 @@ TranscriptHash::set_confirmed(bytes confirmed_transcript_hash)
 void
 TranscriptHash::update_interim(const bytes& confirmation_tag)
 {
-  const auto transcript = confirmed + tls::marshal(confirmation_tag);
-  interim = suite.digest().hash(transcript);
-}
-
-void
-TranscriptHash::update_interim(const AuthenticatedContent& content_auth)
-{
-  const auto transcript =
-    confirmed + content_auth.interim_transcript_hash_input();
-  interim = suite.digest().hash(transcript);
+  interim = suite.digest().hash(confirmed + tls::marshal(confirmation_tag));
 }
 
 bool

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -243,7 +243,7 @@ GroupKeySource::get(ContentType type,
 void
 GroupKeySource::erase(ContentType type, LeafIndex sender, uint32_t generation)
 {
-  return chain(type, sender).erase(generation);
+  chain(type, sender).erase(generation);
 }
 
 // struct {

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -301,14 +301,20 @@ KeyScheduleEpoch
 KeyScheduleEpoch::joiner(CipherSuite suite_in,
                          const bytes& joiner_secret,
                          const std::vector<PSKWithSecret>& psks,
+                         const bytes& confirmed_transcript_hash,
                          const bytes& context)
 {
-  return { suite_in, joiner_secret, make_psk_secret(suite_in, psks), context };
+  return { suite_in,
+           joiner_secret,
+           make_psk_secret(suite_in, psks),
+           confirmed_transcript_hash,
+           context };
 }
 
 KeyScheduleEpoch::KeyScheduleEpoch(CipherSuite suite_in,
                                    const bytes& joiner_secret,
                                    const bytes& psk_secret,
+                                   const bytes& confirmed_transcript_hash,
                                    const bytes& context)
   : suite(suite_in)
   , joiner_secret(joiner_secret)
@@ -325,6 +331,8 @@ KeyScheduleEpoch::KeyScheduleEpoch(CipherSuite suite_in,
   , init_secret(suite.derive_secret(epoch_secret, "init"))
   , external_priv(HPKEPrivateKey::derive(suite, external_secret))
 {
+  confirmation_tag =
+    suite.digest().hmac(confirmation_key, confirmed_transcript_hash);
 }
 
 KeyScheduleEpoch::KeyScheduleEpoch(CipherSuite suite_in)
@@ -339,6 +347,7 @@ KeyScheduleEpoch::KeyScheduleEpoch(CipherSuite suite_in,
       suite_in,
       make_joiner_secret(suite_in, context, init_secret, suite_in.zero()),
       { /* no PSKs */ },
+      { /* confirmed transcript hash is the zero-length octet string */ },
       context)
 {
 }
@@ -347,11 +356,13 @@ KeyScheduleEpoch::KeyScheduleEpoch(CipherSuite suite_in,
                                    const bytes& init_secret,
                                    const bytes& commit_secret,
                                    const bytes& psk_secret,
+                                   const bytes& confirmed_transcript_hash,
                                    const bytes& context)
   : KeyScheduleEpoch(
       suite_in,
       make_joiner_secret(suite_in, context, init_secret, commit_secret),
       psk_secret,
+      confirmed_transcript_hash,
       context)
 {
 }
@@ -377,16 +388,21 @@ KeyScheduleEpoch
 KeyScheduleEpoch::next(const bytes& commit_secret,
                        const std::vector<PSKWithSecret>& psks,
                        const std::optional<bytes>& force_init_secret,
+                       const bytes& confirmed_transcript_hash,
                        const bytes& context) const
 {
-  return next_raw(
-    commit_secret, make_psk_secret(suite, psks), force_init_secret, context);
+  return next_raw(commit_secret,
+                  make_psk_secret(suite, psks),
+                  force_init_secret,
+                  confirmed_transcript_hash,
+                  context);
 }
 
 KeyScheduleEpoch
 KeyScheduleEpoch::next_raw(const bytes& commit_secret,
                            const bytes& psk_secret,
                            const std::optional<bytes>& force_init_secret,
+                           const bytes& confirmed_transcript_hash,
                            const bytes& context) const
 {
   auto actual_init_secret = init_secret;
@@ -394,19 +410,14 @@ KeyScheduleEpoch::next_raw(const bytes& commit_secret,
     actual_init_secret = opt::get(force_init_secret);
   }
 
-  return { suite, actual_init_secret, commit_secret, psk_secret, context };
+  return { suite,      actual_init_secret,        commit_secret,
+           psk_secret, confirmed_transcript_hash, context };
 }
 
 GroupKeySource
 KeyScheduleEpoch::encryption_keys(LeafCount size) const
 {
   return { suite, size, encryption_secret };
-}
-
-bytes
-KeyScheduleEpoch::confirmation_tag(const bytes& confirmed_transcript_hash) const
-{
-  return suite.digest().hmac(confirmation_key, confirmed_transcript_hash);
 }
 
 bytes

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -550,19 +550,18 @@ TranscriptHash::TranscriptHash(CipherSuite suite_in,
   update_interim(confirmation_tag);
 }
 
-void
-TranscriptHash::update(const AuthenticatedContent& content_auth)
-{
-  update_confirmed(content_auth);
-  update_interim(content_auth);
-}
-
-void
-TranscriptHash::update_confirmed(const AuthenticatedContent& content_auth)
+bytes
+TranscriptHash::new_confirmed(const AuthenticatedContent& content_auth) const
 {
   const auto transcript =
     interim + content_auth.confirmed_transcript_hash_input();
-  confirmed = suite.digest().hash(transcript);
+  return suite.digest().hash(transcript);
+}
+
+void
+TranscriptHash::set_confirmed(bytes confirmed_transcript_hash)
+{
+  confirmed = std::move(confirmed_transcript_hash);
 }
 
 void

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -1337,7 +1337,7 @@ State::apply(TreeKEMPublicKey& tree, const Remove& remove)
 std::vector<LeafIndex>
 State::apply(TreeKEMPublicKey& tree,
              const std::vector<CachedProposal>& proposals,
-             Proposal::Type required_type) const
+             Proposal::Type required_type)
 {
   auto locations = std::vector<LeafIndex>{};
   for (const auto& cached : proposals) {
@@ -2224,7 +2224,7 @@ State::roster() const
   auto leaves = std::vector<LeafNode>{};
   leaves.reserve(_tree.size.val);
 
-  _tree.all_leaves([&](auto /* i */, auto leaf) {
+  _tree.all_leaves([&](auto /* i */, const auto& leaf) {
     leaves.push_back(leaf);
     return true;
   });

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -874,7 +874,8 @@ State::handle(const ValidatedContent& val_content,
 
     // Commits are handled in the remainder of this method
     case ContentType::commit:
-      return handle_commit(content_auth, std::move(cached_state), expected_params);
+      return handle_commit(
+        content_auth, std::move(cached_state), expected_params);
 
     // Any other content type in this method is an error
     default:

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -247,6 +247,27 @@ void
 TreeKEMPrivateKey::decap(LeafIndex from,
                          const TreeKEMPublicKey& pub,
                          const bytes& context,
+                         const NodeIndex& decrypt_node,
+                         const HPKECiphertext& encrypted_path_secret)
+{
+  const auto overlap_node = from.ancestor(index);
+  const auto priv = opt::get(private_key(decrypt_node));
+  const auto path_secret = priv.decrypt(suite,
+                                        encrypt_label::update_path_node,
+                                        context,
+                                        encrypted_path_secret);
+  implant(pub, overlap_node, path_secret);
+
+  // Check that the resulting state is consistent with the public key
+  if (!consistent(pub)) {
+    throw ProtocolError("TreeKEMPublicKey inconsistent with TreeKEMPrivateKey");
+  }
+}
+
+void
+TreeKEMPrivateKey::decap(LeafIndex from,
+                         const TreeKEMPublicKey& pub,
+                         const bytes& context,
                          const UpdatePath& path,
                          const std::vector<LeafIndex>& except)
 {
@@ -584,6 +605,48 @@ TreeKEMPublicKey::resolve(NodeIndex index) const
   auto r = resolve(index.right());
   l.insert(l.end(), r.begin(), r.end());
   return l;
+}
+
+TreeKEMPublicKey::DecapCoords
+TreeKEMPublicKey::decap_coords(
+  LeafIndex to,
+  LeafIndex from,
+  const std::vector<LeafIndex>& joiner_locations) const
+{
+  const auto to_node = NodeIndex(to);
+  const auto from_node = NodeIndex(from);
+
+  // Find the index of the common ancestor in the filtered direct path
+  const auto ancestor = to.ancestor(from);
+  const auto from_fdp = filtered_direct_path(from_node);
+  const auto ancestor_node_it = stdx::find_if(from_fdp, [&](const auto& pair) {
+    const auto& [node, _resolution] = pair;
+    return node == ancestor;
+  });
+  const auto ancestor_node_index =
+    static_cast<size_t>(ancestor_node_it - from_fdp.begin());
+
+  // Find the appropriate node in the copath resolution
+  auto copath_child = ancestor.left();
+  if (!from_node.is_below(copath_child)) {
+    copath_child = ancestor.right();
+  }
+
+  auto resolution = std::get<1>(*ancestor_node_it);
+  for (const auto& j : joiner_locations) {
+    const auto it = stdx::find(resolution, NodeIndex(j));
+    if (it != resolution.end()) {
+      resolution.erase(it);
+    }
+  }
+
+  const auto resolution_node_it = stdx::find_if(
+    resolution, [&](const auto i) { return to_node.is_below(i); });
+  const auto resolution_node_index =
+    static_cast<size_t>(resolution_node_it - resolution.begin());
+  const auto resolution_node = *resolution_node_it;
+
+  return { ancestor_node_index, resolution_node_index, resolution_node };
 }
 
 TreeKEMPublicKey::FilteredDirectPath

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -252,10 +252,8 @@ TreeKEMPrivateKey::decap(LeafIndex from,
 {
   const auto overlap_node = from.ancestor(index);
   const auto priv = opt::get(private_key(decrypt_node));
-  const auto path_secret = priv.decrypt(suite,
-                                        encrypt_label::update_path_node,
-                                        context,
-                                        encrypted_path_secret);
+  const auto path_secret = priv.decrypt(
+    suite, encrypt_label::update_path_node, context, encrypted_path_secret);
   implant(pub, overlap_node, path_secret);
 
   // Check that the resulting state is consistent with the public key

--- a/test/treekem.cpp
+++ b/test/treekem.cpp
@@ -266,7 +266,7 @@ TEST_CASE_METHOD(TreeKEMTest, "TreeKEM encap/decap")
   }
 }
 
-TEST_CASE("TreeKEM Interop")
+TEST_CASE("TreeKEM Interop", "[.][all]")
 {
   for (auto suite : all_supported_suites) {
     for (auto structure : treekem_test_tree_structures) {


### PR DESCRIPTION
This PR is a restructuring PR to prepare MLSpp for some variations on Commit structure, as discussed in the [light MLS I-D] and [this issue]. 

`State::handle` is split out into a few parts:

* `State::handle_proposal`, just a renamed `State::cache_proposal`
* `State::handle_commit`, which handles all the parts of Commit processing
  that depend on the structure of the Commit
* `State::ratchet`, which updates the state of the tree based on the
  information gleaned from a Commit

Similarly, `State::commit` is broken in a few pieces as well, though there's a little more back-and-forth due to the transcript hash interactions: 

1. Call `State::prepare_commit` to do the actual computations to create the new trees, etc., that need to be done irrespective of the commit format.
2. Back in `State::commit`, prepare the AuthenticatedContent and the updated confirmed transcript hash.
3. Call `State::successor` to create the next state from the commit data and updated confirmed transcript hash.
4. Use the resulting confirmation tag to complete the AuthenticatedContent, and encapsulate as an MLSMessage.
5. Call `State::welcome` to create the Welcome message.

Overall, the idea is that to support a new format for commits, you should just have to touch the format-specific code.  On creation, a method parallel to `State::commit` can call through to `State::prepare_commit` and `State::successor` for the non-format-specific details.  On handle, a method parallel to `State::handle_commit` can ingest the format and then call `State::ratchet`.

In the process of this refactoring `State::successor` got a lot more beefy, and took over the functions of `State::update_epoch_secrets`, which was then removed.  I also updated the API to the transcript to reflect that the confirmed transcript hash is never update all at once, but instead computed and stored on two sides of an API call.

There are a couple of drive-by fixes in here as well:

* Fixed a bug where `State::resolve` was not properly checking group IDs in a short-circuit branch.

* Refactored `make format` so that it actually excludes test vectors and thus goes much faster.

* Disabled long-running interop tests by default in `make dtest`.  They will still run with `make ctest` or when manually enabled. 

[light MLS I-D]: https://www.ietf.org/archive/id/draft-kiefer-mls-light-00.html
[this issue]: https://github.com/cryspen/scalable-mls-id/issues/6
