### PR TITLE
Minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,9 @@ set(VCPKG_BUILD_TYPE release)
 # Internal libraries
 add_subdirectory(lib)
 
+# External libraries
+find_package(nlohmann_json REQUIRED)
+
 # Third-Party libraries in tree
 add_subdirectory(third_party)
 
@@ -118,7 +121,11 @@ file(GLOB_RECURSE LIB_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src
 
 add_library(${LIB_NAME} ${LIB_HEADERS} ${LIB_SOURCES})
 add_dependencies(${LIB_NAME} bytes tls_syntax hpke)
-target_link_libraries(${LIB_NAME} bytes tls_syntax hpke)
+target_link_libraries(${LIB_NAME} 
+  PRIVATE
+    nlohmann_json::nlohmann_json
+  PUBLIC
+    bytes tls_syntax hpke)
 target_include_directories(${LIB_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/lib/hpke/test/build.cpp
+++ b/lib/hpke/test/build.cpp
@@ -3,16 +3,16 @@
 TEST_CASE("BoringSSL Define")
 {
 #if defined(__has_include)
-    #if __has_include(<openssl/is_boringssl.h>)
-        #if defined(WITH_BORINGSSL)
-            REQUIRE(WITH_BORINGSSL);
-        #else
-            FAIL("Expect #WITH_BORINGSSL set when compiling with BoringSSL");
-        #endif
-    #else
-        SKIP("Only applicable to BoringSSL");
-    #endif
+#if __has_include(<openssl/is_boringssl.h>)
+#if defined(WITH_BORINGSSL)
+  REQUIRE(WITH_BORINGSSL);
 #else
-    SKIP("Cannot ensure BoringSSL without __has_include()");
+  FAIL("Expect #WITH_BORINGSSL set when compiling with BoringSSL");
+#endif
+#else
+  SKIP("Only applicable to BoringSSL");
+#endif
+#else
+  SKIP("Cannot ensure BoringSSL without __has_include()");
 #endif
 }

--- a/lib/tls_syntax/include/tls/tls_syntax.h
+++ b/lib/tls_syntax/include/tls/tls_syntax.h
@@ -9,10 +9,19 @@
 #include <optional>
 #include <stdexcept>
 #include <vector>
+#include <cstdint>
+#include <cstddef>
 
 #include <tls/compat.h>
 
 namespace MLS_NAMESPACE::tls {
+
+using std::size_t;
+using std::uint8_t;
+using std::uint16_t;
+using std::uint32_t;
+using std::uint64_t;
+using std::ptrdiff_t;
 
 // For indicating no min or max in vector definitions
 const size_t none = std::numeric_limits<size_t>::max();
@@ -288,8 +297,9 @@ operator>>(istream& str, std::vector<T>& vec)
   // NB: Remember that we store the vector in reverse order
   // NB: This requires that T be default-constructible
   istream r;
+  const auto size_diff = static_cast<ptrdiff_t>(size);
   r._buffer =
-    std::vector<uint8_t>{ str._buffer.end() - size, str._buffer.end() };
+    std::vector<uint8_t>{ str._buffer.end() - size_diff, str._buffer.end() };
 
   vec.clear();
   while (r._buffer.size() > 0) {
@@ -298,7 +308,7 @@ operator>>(istream& str, std::vector<T>& vec)
   }
 
   // Truncate the primary buffer
-  str._buffer.erase(str._buffer.end() - size, str._buffer.end());
+  str._buffer.erase(str._buffer.end() - size_diff, str._buffer.end());
 
   return str;
 }

--- a/lib/tls_syntax/include/tls/tls_syntax.h
+++ b/lib/tls_syntax/include/tls/tls_syntax.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <map>
@@ -9,19 +10,17 @@
 #include <optional>
 #include <stdexcept>
 #include <vector>
-#include <cstdint>
-#include <cstddef>
 
 #include <tls/compat.h>
 
 namespace MLS_NAMESPACE::tls {
 
+using std::ptrdiff_t;
 using std::size_t;
-using std::uint8_t;
 using std::uint16_t;
 using std::uint32_t;
 using std::uint64_t;
-using std::ptrdiff_t;
+using std::uint8_t;
 
 // For indicating no min or max in vector definitions
 const size_t none = std::numeric_limits<size_t>::max();


### PR DESCRIPTION
* Link nlohmann_json at the top level to prevent build errors with some toolchains
* Use `<cstdint>` for integer types in the TLS syntax library
* Cast to `ptrdiff_t` in one casewhere it is needed 