### PR TITLE
Use MLS_NAMESPACE everywhere needed

### DIFF
--- a/lib/hpke/test/userinfo_vc.cpp
+++ b/lib/hpke/test/userinfo_vc.cpp
@@ -8,7 +8,7 @@ namespace opt = MLS_NAMESPACE::tls::opt;
 using namespace MLS_NAMESPACE::hpke;
 using namespace std::string_literals;
 
-namespace mls::hpke {
+namespace MLS_NAMESPACE::hpke {
 
 static bool
 operator==(const Signature::PublicJWK& lhs, const Signature::PublicJWK& rhs)

--- a/lib/mls_ds/src/tree_follower.cpp
+++ b/lib/mls_ds/src/tree_follower.cpp
@@ -136,17 +136,17 @@ TreeFollower::TreeFollower(TreeKEMPublicKey tree)
 }
 
 void
-TreeFollower::update(const mls::MLSMessage& commit_message,
-                     const std::vector<mls::MLSMessage>& extra_proposals)
+TreeFollower::update(const MLSMessage& commit_message,
+                     const std::vector<MLSMessage>& extra_proposals)
 {
   // Unwrap the Commit
   const auto& commit_public_message =
-    var::get<mls::PublicMessage>(commit_message.message);
+    var::get<PublicMessage>(commit_message.message);
   const auto commit_auth_content =
     commit_public_message.authenticated_content();
   const auto group_content = commit_auth_content.content;
   const auto& commit =
-    var::get<mls::Commit>(commit_auth_content.content.content);
+    var::get<Commit>(commit_auth_content.content.content);
 
   // Apply proposals
   apply(_tree, _suite, group_content.sender, commit.proposals, extra_proposals);
@@ -156,7 +156,7 @@ TreeFollower::update(const mls::MLSMessage& commit_message,
   // Merge the update path
   if (commit.path) {
     const auto sender =
-      var::get<mls::MemberSender>(group_content.sender.sender);
+      var::get<MemberSender>(group_content.sender.sender);
     const auto from = LeafIndex(sender.sender);
     const auto& path = opt::get(commit.path);
     _tree.merge(from, path);

--- a/test/grease.cpp
+++ b/test/grease.cpp
@@ -3,7 +3,7 @@
 #include <mls/core_types.h>
 #include <mls/messages.h>
 
-using namespace mls;
+using namespace MLS_NAMESPACE;
 
 TEST_CASE("GREASE capabilities")
 {


### PR DESCRIPTION
When `MLS_NAMESPACE` is set to a non-default value, some code currently breaks.  This PR fixes those files so that they properly use `MLS_NAMESPACE`.