### PR TITLE
Fix build error in tree_follower.cpp

### DIFF
--- a/lib/mls_ds/src/tree_follower.cpp
+++ b/lib/mls_ds/src/tree_follower.cpp
@@ -97,7 +97,7 @@ apply(TreeKEMPublicKey& tree,
       continue;
     }
 
-    std::visit([&](const auto& pr) { apply(tree, sender, pr); },
+    var::visit([&](const auto& pr) { apply(tree, sender, pr); },
                proposal.content);
   }
 }


### PR DESCRIPTION
Fix build error on Mac:
```
04:35:27:html_generator.py:log_to_file:100: ❌ spark-client-framework/thirdparty/mlspp_v4/lib/mls_ds/src/tree_follower.cpp:100:5: [31mno matching function for call to 'visit'[0m
04:35:27:html_generator.py:log_to_file:100: 100 | std::visit([&](const auto& pr) { apply(tree, sender, pr); },
```