### PR TITLE
Add checkout action to CI workflow

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -34,6 +34,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+    - uses: actions/checkout@v6
     - uses: dorny/paths-filter@v3
       id: filter_version
       with:


### PR DESCRIPTION
Fixes the currently broken workflow.

The checkout is not necessary on pull requests or feature branches, since the filter action uses the github api in those cases. However, on main it uses git instead, which requires the checkout before.

See [my main branch job ✅](https://github.com/MinnDevelopment/mlspp/actions/runs/20575086281/job/59090180749) working properly compared to the current [main branch job ❌](https://github.com/cisco/mlspp/actions/runs/19650014198/job/56274530357).