### PR TITLE
Addition of mls::State serialization using the existing serialization options

### DIFF
--- a/include/mls/crypto.h
+++ b/include/mls/crypto.h
@@ -31,6 +31,8 @@ struct KeyAndNonce
 {
   bytes key;
   bytes nonce;
+
+  TLS_SERIALIZABLE(key, nonce)
 };
 
 // opaque HashReference<V>;
@@ -272,7 +274,7 @@ struct SignaturePrivateKey
   void set_public_key(CipherSuite suite);
   std::string to_jwk(CipherSuite suite) const;
 
-  TLS_SERIALIZABLE(data)
+  TLS_SERIALIZABLE(data, public_key)
 
 private:
   SignaturePrivateKey(bytes priv_data, bytes pub_data);

--- a/include/mls/state.h
+++ b/include/mls/state.h
@@ -46,6 +46,9 @@ public:
   /// Constructors
   ///
 
+  // For deserialization purposes only
+  State() = default;
+
   // Initialize an empty group
   State(bytes group_id,
         CipherSuite suite,
@@ -267,6 +270,8 @@ protected:
   using EpochRef = std::tuple<bytes, epoch_t>;
   std::map<EpochRef, bytes> _resumption_psks;
 
+  TLS_SERIALIZABLE(_suite, _group_id, _epoch, _tree, _tree_priv, _transcript_hash, _extensions, _key_schedule, _keys, _index, _identity_priv, _external_psks, _resumption_psks);
+
   // Cache of Proposals and update secrets
   struct CachedProposal
   {
@@ -467,6 +472,15 @@ protected:
                   bool has_path,
                   const std::vector<PSKWithSecret>& psks,
                   const std::optional<bytes>& force_init_secret) const;
+
+  // Friend operators for serialization
+  friend tls::ostream& operator<<(tls::ostream& str, const State& obj);
+  friend tls::istream& operator>>(tls::istream& str, State& obj);
 };
+
+tls::ostream&
+operator<<(tls::ostream& str, const State& obj);
+tls::istream&
+operator>>(tls::istream& str, State& obj);
 
 } // namespace MLS_NAMESPACE

--- a/include/mls/treekem.h
+++ b/include/mls/treekem.h
@@ -81,6 +81,8 @@ struct TreeKEMPrivateKey
   std::map<NodeIndex, bytes> path_secrets;
   std::map<NodeIndex, HPKEPrivateKey> private_key_cache;
 
+  TLS_SERIALIZABLE(suite, index, update_secret, path_secrets, private_key_cache);
+
   static TreeKEMPrivateKey solo(CipherSuite suite,
                                 LeafIndex index,
                                 HPKEPrivateKey leaf_priv);
@@ -250,7 +252,7 @@ struct TreeKEMPublicKey
   OptionalNode& node_at(LeafIndex n);
   const OptionalNode& node_at(LeafIndex n) const;
 
-  TLS_SERIALIZABLE(nodes)
+  TLS_SERIALIZABLE(suite, size, nodes, hashes)
 
 #if ENABLE_TREE_DUMP
   void dump() const;
@@ -291,6 +293,8 @@ private:
   OptionalNode blank_node;
 
   friend struct TreeKEMPrivateKey;
+  friend tls::ostream& operator<<(tls::ostream& str, const TreeKEMPublicKey& obj);
+  friend tls::istream& operator>>(tls::istream& str, TreeKEMPublicKey& obj);
 };
 
 tls::ostream&

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -184,7 +184,7 @@ CipherSuite::get() const
       return ciphers_X448_CHACHA20POLY1305_SHA512_Ed448;
 #endif
 
-#if !defined(P256_SHA256)
+#if !defined(P256_SHA256) && defined(WITH_PQ)
     case ID::MLKEM768X25519_AES256GCM_SHA384_Ed25519:
       return ciphers_MLKEM768X25519_AES256GCM_SHA384_Ed25519;
 

--- a/src/key_schedule.cpp
+++ b/src/key_schedule.cpp
@@ -576,4 +576,44 @@ operator==(const TranscriptHash& lhs, const TranscriptHash& rhs)
   return confirmed && interim;
 }
 
+tls::ostream&
+operator<<(tls::ostream& str, const SecretTree& obj)
+{
+  str << obj.suite
+    << obj.group_size
+    << obj.root
+    << obj.secrets
+    << obj.secret_size;
+  return str;
+}
+
+tls::istream&
+operator>>(tls::istream& str, SecretTree& obj)
+{
+  str >> obj.suite
+    >> obj.group_size
+    >> obj.root
+    >> obj.secrets
+    >> obj.secret_size;
+  return str;
+}
+
+tls::ostream&
+operator<<(tls::ostream& str, const GroupKeySource& obj)
+{
+  str << obj.suite
+    << obj.secret_tree
+    << obj.chains;
+  return str;
+}
+
+tls::istream&
+operator>>(tls::istream& str, GroupKeySource& obj)
+{
+  str >> obj.suite
+    >> obj.secret_tree
+    >> obj.chains;
+  return str;
+}
+
 } // namespace MLS_NAMESPACE

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -2469,4 +2469,42 @@ State::successor(LeafIndex index,
   return next;
 }
 
+tls::ostream&
+operator<<(tls::ostream& str, const State& obj)
+{
+  str << obj._suite
+    << obj._group_id
+    << obj._epoch
+    << obj._tree
+    << obj._tree_priv
+    << obj._transcript_hash
+    << obj._extensions
+    << obj._key_schedule
+    << obj._keys
+    << obj._index
+    << obj._identity_priv
+    << obj._external_psks
+    << obj._resumption_psks;
+  return str;
+}
+
+tls::istream&
+operator>>(tls::istream& str, State& obj)
+{
+  str >> obj._suite
+    >> obj._group_id
+    >> obj._epoch
+    >> obj._tree
+    >> obj._tree_priv
+    >> obj._transcript_hash
+    >> obj._extensions
+    >> obj._key_schedule
+    >> obj._keys
+    >> obj._index
+    >> obj._identity_priv
+    >> obj._external_psks
+    >> obj._resumption_psks;
+  return str;
+}
+
 } // namespace MLS_NAMESPACE

--- a/src/treekem.cpp
+++ b/src/treekem.cpp
@@ -1327,9 +1327,12 @@ TreeKEMPublicKey::exists_in_tree(const SignaturePublicKey& key,
 tls::ostream&
 operator<<(tls::ostream& str, const TreeKEMPublicKey& obj)
 {
-  // Empty tree
+  str << obj.suite;
+  
   if (obj.size.val == 0) {
-    return str << std::vector<OptionalNode>{};
+    str << std::vector<OptionalNode>{};
+    str << obj.hashes;
+    return str;
   }
 
   LeafIndex cut = LeafIndex{ obj.size.val - 1 };
@@ -1345,15 +1348,24 @@ operator<<(tls::ostream& str, const TreeKEMPublicKey& obj)
     view.at(i.val) = obj.nodes.at(i);
   }
 
-  return str << view;
+  str << view;
+  str << obj.hashes;
+  return str;
 }
 
 tls::istream&
 operator>>(tls::istream& str, TreeKEMPublicKey& obj)
 {
+  // Deserialize the cipher suite first
+  str >> obj.suite;
+  
   // Read the node list
   std::vector<OptionalNode> nodes;
   str >> nodes;
+  
+  // Read the hashes map
+  str >> obj.hashes;
+  
   if (nodes.empty()) {
     return str;
   }


### PR DESCRIPTION
Adds TLS_SERIALIZABLE recursively to all required nested structures while keeping member accessibility untouched by adding specific overloaded stream operators.
Known issue: Since serialization requires an empty/existing object, mls::State and its nested structures must be default constructible. As long as serialization is implemented outside of structures, default constructors are mandatory.
Added missing #ifdef(WITH_PQ)

The project builds locally (Linux, Clang 18), and all unit tests are passing.